### PR TITLE
Up to date spectre-meltdown-checker

### DIFF
--- a/apparmor.d/profiles-s-z/spectre-meltdown-checker
+++ b/apparmor.d/profiles-s-z/spectre-meltdown-checker
@@ -25,7 +25,7 @@ profile spectre-meltdown-checker @{exec_path} {
   /{usr/,}bin/cut        rix,
   /{usr/,}bin/{,e}grep   rix,
   /{usr/,}bin/head       rix,
-  /{usr/,}bin/gawk       rix,
+  /{usr/,}bin/{,g,m}awk  rix,
   /{usr/,}bin/sed        rix,
   /{usr/,}bin/od         rix,
   /{usr/,}bin/dd         rix,
@@ -54,7 +54,9 @@ profile spectre-meltdown-checker @{exec_path} {
   /{usr/,}{s,}bin/iucode_tool         rix,
   /{usr/,}bin/dmesg                   rix,
   /{usr/,}bin/mount      rix,
-
+  /{usr/,}bin/find       rix,
+  /{usr/,}bin/xargs      rix,
+  
   /{usr/,}bin/pgrep      rCx -> pgrep,
   /{usr/,}bin/ccache     rCx -> ccache,
   /{usr/,}bin/kmod       rCx -> kmod,
@@ -90,6 +92,7 @@ profile spectre-meltdown-checker @{exec_path} {
   @{PROC}/cmdline r,
   @{PROC}/kallsyms r,
   @{PROC}/modules r,
+  @{PROC}/@{pid}/status r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,


### PR DESCRIPTION
```
$ readlink -m $(which awk)
/usr/bin/mawk

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye
```

https://github.com/speed47/spectre-meltdown-checker/blob/master/spectre-meltdown-checker.sh#L4481