### PR TITLE
Up to date spectre-meltdown-checker fixes

### DIFF
--- a/apparmor.d/profiles-s-z/spectre-meltdown-checker
+++ b/apparmor.d/profiles-s-z/spectre-meltdown-checker
@@ -6,7 +6,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /{usr/,}bin/spectre-meltdown-checker
+@{exec_path} = /{,usr/}{,local/}bin/spectre-meltdown-checker{,.sh}
 profile spectre-meltdown-checker @{exec_path} {
   include <abstractions/base>
 
@@ -77,7 +77,7 @@ profile spectre-meltdown-checker @{exec_path} {
   owner /tmp/intelfw-*/Intel-Linux-Processor-Microcode-Data-Files-master/** rw,
 
   owner @{HOME}/.mcedb rw,
-  owner /{usr/,}bin/spectre-meltdown-checker w,
+  owner @{exec_path} w,
 
         /tmp/ r,
   owner /tmp/{config,kernel}-* rw,

--- a/apparmor.d/profiles-s-z/spectre-meltdown-checker
+++ b/apparmor.d/profiles-s-z/spectre-meltdown-checker
@@ -16,6 +16,10 @@ profile spectre-meltdown-checker @{exec_path} {
   # Needed to read system logs
   capability syslog,
 
+  # Used by readlink
+  capability sys_ptrace,
+  ptrace (read),
+
   @{exec_path} r,
   /{usr/,}bin/{,ba,da}sh rix,
 
@@ -56,6 +60,7 @@ profile spectre-meltdown-checker @{exec_path} {
   /{usr/,}bin/mount      rix,
   /{usr/,}bin/find       rix,
   /{usr/,}bin/xargs      rix,
+  /{usr/,}bin/readlink   rix,
   
   /{usr/,}bin/pgrep      rCx -> pgrep,
   /{usr/,}bin/ccache     rCx -> ccache,
@@ -92,7 +97,11 @@ profile spectre-meltdown-checker @{exec_path} {
   @{PROC}/cmdline r,
   @{PROC}/kallsyms r,
   @{PROC}/modules r,
-  @{PROC}/@{pid}/status r,
+
+  # find and denoise
+  @{PROC}/@{pid}/{status,exe} r,
+  @{PROC}/@{pid}/fd/ r,
+  @{PROC}/*/ r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,
@@ -153,6 +162,11 @@ profile spectre-meltdown-checker @{exec_path} {
 
   profile kmod {
     include <abstractions/base>
+
+    capability sys_module,
+
+    owner /sys/module/cpuid/** r,
+    owner /sys/module/msr/** r,
 
     /{usr/,}bin/kmod mr,
 

--- a/apparmor.d/profiles-s-z/spectre-meltdown-checker
+++ b/apparmor.d/profiles-s-z/spectre-meltdown-checker
@@ -165,8 +165,8 @@ profile spectre-meltdown-checker @{exec_path} {
 
     capability sys_module,
 
-    owner /sys/module/cpuid/** r,
-    owner /sys/module/msr/** r,
+    owner @{sys}/module/cpuid/** r,
+    owner @{sys}/module/msr/** r,
 
     /{usr/,}bin/kmod mr,
 


### PR DESCRIPTION
- Going further, since `find` is very noisy, I think some permissions on `/proc` need to be relaxed - nothing serious, just a directory traverse. Otherwise it can shadow other DENIALs like with me earlier. Why not `deny` directive? If some other functionality will be added to `spectre-meltdown-checker` debugging on our side will be rather painful.
- Without the modules section two mitigations were false negative.
- `ptrace` is used by readlink and does not affect mitigations detection, at least at first glance.
```
apparmor="DENIED" operation="capable" profile="spectre-meltdown-checker" pid=1356 comm="readlink" capability=19  capname="sys_ptrace"
apparmor="DENIED" operation="ptrace" profile="spectre-meltdown-checker" pid=1357 comm="readlink" requested_mask="read" denied_mask="read" peer="unconfined"
```
Remove of you don't like it.