### PR TITLE
QEMU guest virtual disks compatibility

### DIFF
--- a/apparmor.d/abstractions/disks-read
+++ b/apparmor.d/abstractions/disks-read
@@ -9,10 +9,10 @@
   /dev/ r,
 
   # Regular disk/partition devices
-  /dev/sd[a-z] rk,
-  /dev/sd[a-z][0-9]* rk,
-  @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/ r,
-  @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/** r,
+  /dev/{s,v}d[a-z] rk,
+  /dev/{s,v}d[a-z][0-9]* rk,
+  @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/ r,
+  @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/** r,
   @{sys}/devices/pci[0-9]*/**/{usb,ata}[0-9]/** r,
 
   # SSD Nvme devices

--- a/apparmor.d/abstractions/disks-write
+++ b/apparmor.d/abstractions/disks-write
@@ -9,10 +9,10 @@
   /dev/ r,
 
   # Regular disk/partition devices
-  /dev/sd[a-z] rwk,
-  /dev/sd[a-z][0-9]* rwk,
-  @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/ r,
-  @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/** r,
+  /dev/{s,v}d[a-z] rwk,
+  /dev/{s,v}d[a-z][0-9]* rwk,
+  @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/ r,
+  @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/** r,
   @{sys}/devices/pci[0-9]*/**/{usb,ata}[0-9]/** r,
 
   # SSD Nvme devices

--- a/apparmor.d/profiles-a-f/conky
+++ b/apparmor.d/profiles-a-f/conky
@@ -101,7 +101,7 @@ profile conky @{exec_path} {
 
   # Display the hard disk model name
   @{sys}/devices/pci[0-9]*/**/{usb,ata}[0-9]/**/model r,
-  @{sys}/block/sd[a-z]/device/model r,
+  @{sys}/block/{s,v}d[a-z]/device/model r,
   # Display the disk write/read speed
   @{PROC}/diskstats r,
   # Get the mount point names

--- a/apparmor.d/profiles-a-f/fatresize
+++ b/apparmor.d/profiles-a-f/fatresize
@@ -53,7 +53,7 @@ profile fatresize @{exec_path} {
     @{sys}/firmware/efi/efivars/SecureBoot-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]* r,
 
     # file_inherit
-    /dev/sd[a-z] rw,
+    /dev/{s,v}d[a-z] rw,
 
   }
 

--- a/apparmor.d/profiles-g-l/gpartedbin
+++ b/apparmor.d/profiles-g-l/gpartedbin
@@ -152,19 +152,19 @@ profile gpartedbin @{exec_path} {
 
     /{usr/,}bin/mount mr,
 
-    mount /dev/sd[a-z][0-9]* -> /tmp/gparted-*/,
+    mount /dev/{s,v}d[a-z][0-9]* -> /tmp/gparted-*/,
 
-    mount /dev/sd[a-z][0-9]* -> /boot/,
-    mount /dev/sd[a-z][0-9]* -> @{MOUNTS}/*/,
-    mount /dev/sd[a-z][0-9]* -> @{MOUNTS}/*/*/,
+    mount /dev/{s,v}d[a-z][0-9]* -> /boot/,
+    mount /dev/{s,v}d[a-z][0-9]* -> @{MOUNTS}/*/,
+    mount /dev/{s,v}d[a-z][0-9]* -> @{MOUNTS}/*/*/,
 
-    @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/ r,
-    @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/dev r,
-    @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/sd[a-z][0-9]*/ r,
-    @{sys}/devices/pci[0-9]*/**/block/sd[a-z]/sd[a-z][0-9]*/{start,size} r,
+    @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/ r,
+    @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/dev r,
+    @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/{s,v}d[a-z][0-9]*/ r,
+    @{sys}/devices/pci[0-9]*/**/block/{s,v}d[a-z]/{s,v}d[a-z][0-9]*/{start,size} r,
 
-    /dev/sd[a-z] r,
-    /dev/sd[a-z][0-9]* r,
+    /dev/{s,v}d[a-z] r,
+    /dev/{s,v}d[a-z][0-9]* r,
 
   }
 

--- a/apparmor.d/profiles-m-r/ntfs-3g
+++ b/apparmor.d/profiles-m-r/ntfs-3g
@@ -36,10 +36,10 @@ profile ntfs-3g @{exec_path} {
   @{MOUNTS}/*/*/ r,
 
   # Allow to mount ntfs disks only under the /media/, /run/media, and /mnt/ dirs
-  mount fstype=fuseblk /dev/sd[a-z][0-9]* -> @{MOUNTS}/*/,
-  mount fstype=fuseblk /dev/sd[a-z][0-9]* -> @{MOUNTS}/*/*/,
-  mount fstype=fuseblk /dev/sd[a-z][0-9]* -> /mnt/,
-  mount fstype=fuseblk /dev/sd[a-z][0-9]* -> /mnt/*/,
+  mount fstype=fuseblk /dev/{s,v}d[a-z][0-9]* -> @{MOUNTS}/*/,
+  mount fstype=fuseblk /dev/{s,v}d[a-z][0-9]* -> @{MOUNTS}/*/*/,
+  mount fstype=fuseblk /dev/{s,v}d[a-z][0-9]* -> /mnt/,
+  mount fstype=fuseblk /dev/{s,v}d[a-z][0-9]* -> /mnt/*/,
   mount fstype=fuseblk /dev/mmcblk[0-9]*p[0-9]* -> @{MOUNTS}/*/,
   mount fstype=fuseblk /dev/mmcblk[0-9]*p[0-9]* -> @{MOUNTS}/*/*/,
 

--- a/apparmor.d/profiles-s-z/udisksd
+++ b/apparmor.d/profiles-s-z/udisksd
@@ -47,8 +47,8 @@ profile udisksd @{exec_path} flags=(attach_disconnected) {
   /{usr/,}bin/systemd-escape  rPx,
 
   # Allow mounting of removable devices
-  mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/sd[a-z]       -> @{MOUNTS}/*/*/,
-  mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/sd[a-z][0-9]* -> @{MOUNTS}/*/*/,
+  mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/{s,v}d[a-z]       -> @{MOUNTS}/*/*/,
+  mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/{s,v}d[a-z][0-9]* -> @{MOUNTS}/*/*/,
   mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/dm-[0-9]*     -> @{MOUNTS}/*/*/,
   # Allow mounting of loop devices (ISO files)
   mount fstype={btrfs,ext*,vfat,iso9660,udf} /dev/loop[0-9]*        -> @{MOUNTS}/*/*/,


### PR DESCRIPTION
Not all paths need to be changed since QEMU is using the drives through it's own driver, so hardware-specific commands will not work anyway.