### PR TITLE
Debian 10 and Ubuntu 20.04 compatibility

### DIFF
--- a/apparmor.d/tunables/run
+++ b/apparmor.d/tunables/run
@@ -1,0 +1,1 @@
+@{run}=/run/ /var/run/


### PR DESCRIPTION
Fixes #7 
`tunables/global` in this repo includes `run`, but the file itself is absent. There may be collisions in Arch, please check.