### PR TITLE
nameservice-strict: Ubuntu compatibility

### DIFF
--- a/apparmor.d/abstractions/nameservice-strict
+++ b/apparmor.d/abstractions/nameservice-strict
@@ -7,6 +7,7 @@
   /etc/hosts r,
   /etc/host.conf r,
   /etc/resolv.conf r,
+  @{run}/systemd/resolve/stub-resolv.conf r,
   /etc/nsswitch.conf r,
   /etc/passwd r,
   /etc/gai.conf r,

--- a/apparmor.d/abstractions/nameservice-strict
+++ b/apparmor.d/abstractions/nameservice-strict
@@ -17,8 +17,8 @@
   /etc/services r,
 
   # NSS records from systemd-userdbd.service
-  /{var,}run/systemd/userdb/ r,
-  /{var,}run/systemd/userdb/io.systemd.{NameServiceSwitch,Multiplexer,DynamicUser,Home} r,
+  @{run}/systemd/userdb/ r,
+  @{run}/systemd/userdb/io.systemd.{NameServiceSwitch,Multiplexer,DynamicUser,Home} r,
   @{PROC}/sys/kernel/random/boot_id r,
 
   include if exists <abstractions/nameservice-strict.d>


### PR DESCRIPTION
```
$ readlink -f /etc/resolv.conf 
/run/systemd/resolve/stub-resolv.conf
```
```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.3 LTS
Release:	20.04
Codename:	focal
```

Newline is Github's automation, I guess it's ok.