### PR TITLE
More `consoles` requirement after `sshd` introduction

### DIFF
--- a/apparmor.d/profiles-g-l/groups
+++ b/apparmor.d/profiles-g-l/groups
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/groups
 profile groups @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
 
   @{exec_path} mr,

--- a/apparmor.d/profiles-g-l/last
+++ b/apparmor.d/profiles-g-l/last
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/last{,b}
 profile last @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
   include <abstractions/wutmp>
 
@@ -20,6 +21,9 @@ profile last @{exec_path} {
   @{exec_path} mr,
 
   @{PROC}/@{pids}/loginuid r,
+
+  /var/log/wtmp r,
+  /var/log/btmp{,.[0-9]*} r,
 
   include if exists <local/last>
 }

--- a/apparmor.d/profiles-g-l/lastlog
+++ b/apparmor.d/profiles-g-l/lastlog
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/lastlog
 profile lastlog @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
 
   network netlink raw,
@@ -17,6 +18,8 @@ profile lastlog @{exec_path} {
 
   /var/log/lastlog r,
   /etc/login.defs r,
+
+  @{run}/systemd/userdb/io.systemd.DynamicUser w,
 
   include if exists <local/lastlog>
 }

--- a/apparmor.d/profiles-g-l/lscpu
+++ b/apparmor.d/profiles-g-l/lscpu
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/lscpu
 profile lscpu @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
 
   @{exec_path} mr,
 

--- a/apparmor.d/profiles-m-r/passwd
+++ b/apparmor.d/profiles-m-r/passwd
@@ -10,6 +10,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/passwd
 profile passwd @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/authentication>
   include <abstractions/nameservice-strict>
   include <abstractions/wutmp>

--- a/apparmor.d/profiles-s-z/top
+++ b/apparmor.d/profiles-s-z/top
@@ -11,6 +11,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/top
 profile top @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/wutmp>
   include <abstractions/nameservice-strict>
 

--- a/apparmor.d/profiles-s-z/uptime
+++ b/apparmor.d/profiles-s-z/uptime
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/uptime
 profile uptime @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/wutmp>
 
   @{exec_path} mr,

--- a/apparmor.d/profiles-s-z/w
+++ b/apparmor.d/profiles-s-z/w
@@ -10,6 +10,7 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/w
 profile w @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
   include <abstractions/wutmp>
 


### PR DESCRIPTION
```
apparmor="DENIED" operation="file_inherit" profile="w" name="/dev/pts/0" pid=1079 comm="w" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="getattr" info="Failed name lookup - disconnected path" error=-13 profile="w" name="apparmor/.null" pid=1079 comm="w" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
apparmor="DENIED" operation="file_inherit" profile="uptime" name="/dev/pts/0" pid=1080 comm="uptime" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="getattr" info="Failed name lookup - disconnected path" error=-13 profile="uptime" name="apparmor/.null" pid=1080 comm="uptime" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
apparmor="DENIED" operation="file_inherit" profile="lscpu" name="/dev/pts/0" pid=1162 comm="lscpu" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="getattr" info="Failed name lookup - disconnected path" error=-13 profile="lscpu" name="apparmor/.null" pid=1162 comm="lscpu" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
apparmor="DENIED" operation="file_inherit" profile="top" name="/dev/pts/0" pid=1166 comm="top" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="file_inherit" profile="last" name="/dev/pts/0" pid=1168 comm="last" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="open" profile="last" name="/var/log/wtmp" pid=1168 comm="last" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
apparmor="DENIED" operation="file_inherit" profile="lastlog" name="/dev/pts/0" pid=1169 comm="lastlog" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0
apparmor="DENIED" operation="getattr" info="Failed name lookup - disconnected path" error=-13 profile="lastlog" name="apparmor/.null" pid=1169 comm="lastlog" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```
It's not happening without `sshd`.