### PR TITLE
Various containerd fixes

### DIFF
--- a/apparmor.d/abstractions/disks-read
+++ b/apparmor.d/abstractions/disks-read
@@ -8,7 +8,7 @@
 
   /dev/ r,
   /dev/block/ r,
-  /dev/disk/*/ r,
+  /dev/disk/{,*/} r,
 
   # Regular disk/partition devices
   /dev/{s,v}d[a-z]* rk,
@@ -37,14 +37,14 @@
 
   # LUKS/LVM (device-mapper) devices
   /dev/dm-[0-9]* rk,
-  /dev/mapper/* r,
+  /dev/mapper/{,*} r,
   @{sys}/devices/virtual/block/dm-[0-9]*/ r,
   @{sys}/devices/virtual/block/dm-[0-9]*/** r,
 
   # ZFS devices
   /dev/zd[0-9]* rk,
-  /dev/zvol/ r,
-  /dev/zvol/*/ r,
+  /dev/zvol/{,*/} r,
+  /dev/*pool/ r,
   @{sys}/devices/virtual/block/zd[0-9]*/ r,
   @{sys}/devices/virtual/block/zd[0-9]*/** r,
 

--- a/apparmor.d/groups/virt/cni-calico
+++ b/apparmor.d/groups/virt/cni-calico
@@ -24,6 +24,7 @@ profile cni-calico @{exec_path} {
   /var/log/calico/cni/ r,
   /var/log/calico/cni/cni.log rw,
   
+  @{run}/calico/ rw,
   @{run}/calico/ipam.lock rwk,
 
   @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,

--- a/apparmor.d/groups/virt/cni-loopback
+++ b/apparmor.d/groups/virt/cni-loopback
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = /{usr/,}lib/cni/loopback /opt/cni/bin/loopback
-profile cni-loopback @{exec_path} {
+profile cni-loopback @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
 
   @{exec_path} mr,

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -16,6 +16,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
 
   capability chown,
   capability dac_read_search,
+  capability dac_override,
   capability net_admin,
   capability sys_admin,
 
@@ -23,11 +24,13 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   network inet6 dgram,
   network inet stream,
   network inet6 stream,
+  network netlink raw,
 
   mount fstype=tmpfs options in (rw, nosuid, nodev, noexec) -> @{run}/containerd/io.containerd.grpc.v1.cri/sandboxes/[0-9a-f]*/shm/,
   mount fstype=zfs -> /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/,
   mount options in (rw, bind, nosuid, nodev, noexec) -> @{run}/netns/cni-@{uuid},
 
+  umount @{run}/containerd/io.containerd.grpc.v1.cri/sandboxes/[0-9a-f]*/shm/,
   umount /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/,
   umount @{run}/netns/cni-@{uuid},
 
@@ -72,28 +75,27 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   @{sys}/module/apparmor/parameters/enabled r,
 
         @{PROC}/@{pid}/task/@{tid}/ns/net rw,
+  owner @{PROC}/@{pids}/attr/current      r,
   owner @{PROC}/@{pids}/uid_map           r,
   owner @{PROC}/@{pids}/mountinfo         r,
         @{PROC}/sys/net/core/somaxconn    r,
 
-  deny /dev/bsg/            rwkl,
-  deny /dev/bus/            rwkl,
-  deny /dev/bus/usb/        rwkl,
-  deny /dev/bus/usb/[0-9]*/ rwkl,
-  deny /dev/char/           rwkl,
-  deny /dev/cpu/            rwkl,
-  deny /dev/cpu/[0-9]*/     rwkl,
-  deny /dev/dma_heap/       rwkl,
-  deny /dev/dri/            rwkl,
-  deny /dev/dri/by-path/    rwkl,
-  deny /dev/hugepages/      rwkl,
-  deny /dev/input/          rwkl,
-  deny /dev/input/by-id/    rwkl,
-  deny /dev/input/by-path/  rwkl,
-  deny /dev/net/            rwkl,
-  deny /dev/snd/            rwkl,
-  deny /dev/snd/by-path/    rwkl,
-  deny /dev/vfio/           rwkl,
+  /dev/bsg/            r,
+  /dev/bus/            r,
+  /dev/char/           r,
+  /dev/cpu/            r,
+  /dev/cpu/[0-9]*/     r,
+  /dev/dma_heap/       r,
+  /dev/dri/            r,
+  /dev/dri/by-path/    r,
+  /dev/hugepages/      r,
+  /dev/input/          r,
+  /dev/input/by-id/    r,
+  /dev/input/by-path/  r,
+  /dev/net/            r,
+  /dev/snd/            r,
+  /dev/snd/by-path/    r,
+  /dev/vfio/           r,
 
   include if exists <local/containerd>
 }

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -98,7 +98,5 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   /dev/snd/by-path/    r,
   /dev/vfio/           r,
 
-  deny / r,
-
   include if exists <local/containerd>
 }

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -17,6 +17,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   capability chown,
   capability dac_read_search,
   capability dac_override,
+  capability fsetid,
   capability net_admin,
   capability sys_admin,
 
@@ -57,7 +58,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
 
   /var/lib/cni/results/cni-loopback-@{uuid}-lo l,
   /var/lib/containerd/{,**} rwk,
-  /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/lib{64,}/** l,
+  /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/** l,
   /var/lib/docker/containerd/{,**} rwk,
   /var/log/pods/**/[0-9]*.log w,
 

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -98,5 +98,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   /dev/snd/by-path/    r,
   /dev/vfio/           r,
 
+  deny / r,
+
   include if exists <local/containerd>
 }

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -56,7 +56,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
 
   /opt/containerd/{,**} rw,
 
-  /var/lib/cni/results/cni-loopback-@{uuid}-lo l,
+  /var/lib/cni/results/cni-loopback-@{uuid}-lo wl,
   /var/lib/containerd/{,**} rwk,
   /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/** l,
   /var/lib/docker/containerd/{,**} rwk,


### PR DESCRIPTION
Various fixes for containerd. When running Calico, it requires access to a lot of stuff under devices but it seems to only want an index.