### PR TITLE
Support for containerd-shim

### DIFF
--- a/apparmor.d/groups/ubuntu/packagekitd
+++ b/apparmor.d/groups/ubuntu/packagekitd
@@ -38,7 +38,7 @@ profile packagekitd @{exec_path} {
 
   dbus receive bus=system path=/org/freedesktop/NetworkManager
        interface=org.freedesktop.NetworkManager
-       member={CheckPermissions,StateChanged},
+       member={CheckPermissions,DeviceAdded,DeviceRemoved,StateChanged},
 
   dbus receive bus=system path=/org/freedesktop/NetworkManager
        interface=org.freedesktop.DBus.Properties

--- a/apparmor.d/groups/ubuntu/packagekitd
+++ b/apparmor.d/groups/ubuntu/packagekitd
@@ -46,7 +46,7 @@ profile packagekitd @{exec_path} {
 
   dbus receive bus=system path=/org/freedesktop/login[0-9]
        interface=org.freedesktop.login[0-9].Manager
-       member={SessionNew,PrepareForShutdown,SessionRemoved},
+       member={SessionNew,PrepareForShutdown,SessionRemoved,UserNew,UserRemoved},
 
   dbus bind bus=system 
        name=org.freedesktop.PackageKit,

--- a/apparmor.d/groups/virt/containerd
+++ b/apparmor.d/groups/virt/containerd
@@ -1,5 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -25,7 +26,7 @@ profile containerd @{exec_path} flags=(attach_disconnected) {
   network inet6 stream,
 
   mount fstype=tmpfs options in (rw, nosuid, nodev, noexec) -> @{run}/containerd/io.containerd.grpc.v1.cri/sandboxes/[0-9a-f]*/shm/,
-  mount fstype=zfs -> /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/,
+  mount -> /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/,
   mount options in (rw, bind, nosuid, nodev, noexec) -> @{run}/netns/cni-@{uuid},
 
   umount /var/lib/containerd/tmpmounts/containerd-mount[0-9]*/,

--- a/apparmor.d/groups/virt/containerd-shim-runc-v2
+++ b/apparmor.d/groups/virt/containerd-shim-runc-v2
@@ -1,0 +1,43 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2022 Jeroen Rijken
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = /{usr/,}bin/containerd-shim-runc-v2
+profile containerd-shim-runc-v2 @{exec_path} flags=(complain,attach_disconnected) {
+  include <abstractions/base>
+
+  capability dac_read_search,
+  capability dac_override,
+  capability net_admin,
+  capability sys_admin,
+  capability sys_resource,
+
+  mount -> /run/containerd/io.containerd.runtime.v2.task/k8s.io/[0-9a-z]*/rootfs/,
+  umount /run/containerd/io.containerd.runtime.v2.task/k8s.io/[0-9a-z]*/rootfs/,
+
+  @{exec_path} mrix,
+  /{usr/,}{s,}bin/runc rPUx,
+
+  /tmp/runc-process[0-9]* rw,
+
+  @{run}/containerd/containerd.sock.ttrpc rw,
+  @{run}/containerd/io.containerd.grpc.v1.cri/containers/[0-9a-z]*/io/[0-9]*/[0-9a-z]*-stderr rw,
+  @{run}/containerd/io.containerd.grpc.v1.cri/containers/[0-9a-z]*/io/[0-9]*/[0-9a-z]*-stdout rw,
+  @{run}/containerd/io.containerd.runtime.v2.task/k8s.io/[0-9a-z]*/{,*} rw,
+  @{run}/containerd/s/[0-9a-z]* rw,
+  @{run}/secrets/kubernetes.io/serviceaccount/*/token w,
+
+  @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+  @{sys}/fs/cgroup/kubepods/{,**} rw,
+  @{sys}/fs/cgroup/{,**} rw,
+
+  @{PROC}/@{pids}/cgroup r,
+  @{PROC}/@{pids}/oom_score_adj rw,
+  @{PROC}/sys/net/core/somaxconn r,
+
+  include if exists <local/containerd-shim-runc-v2>
+}


### PR DESCRIPTION
This PR adds preliminary support for containerd-shim-runc-v2. A little more security for Linux containers via containerd.

I've also attempted to write a profile for runc, but this proved to be more difficult because it needs so many permission and a pivotroot. And after the pivotroot, it basically needs `/** wrkl`. Not to mention it would probably conflict with AppArmor profiles loaded via Docker / Kubernetes.

Also, I don't know how to do a pivotroot in AppArmor.