### PR TITLE
Initial support for zsys

### DIFF
--- a/apparmor.d/groups/apt/apt
+++ b/apparmor.d/groups/apt/apt
@@ -88,6 +88,7 @@ profile apt @{exec_path} flags=(attach_disconnected) {
   /{usr/,}bin/snap                           rPUx,
   /{usr/,}lib/cnf-update-db                   rPx,
   /{usr/,}lib/needrestart/apt-pinvoke         rPx,
+  @{libexec}/zsys-system-autosnapshot         rPx,
 
   # For building the source after the download process is finished (apt-get source --compile)
   /{usr/,}bin/dpkg-buildpackage               rPUx,

--- a/apparmor.d/groups/apt/apt-listbugs-aptcleanup
+++ b/apparmor.d/groups/apt/apt-listbugs-aptcleanup
@@ -6,7 +6,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /usr/libexec/apt-listbugs/aptcleanup
+@{exec_path} = @{libexec}/apt-listbugs/aptcleanup
 profile apt-listbugs-aptcleanup @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>

--- a/apparmor.d/groups/apt/apt-listbugs-migratepins
+++ b/apparmor.d/groups/apt/apt-listbugs-migratepins
@@ -6,7 +6,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /usr/libexec/apt-listbugs/migratepins
+@{exec_path} = @{libexec}/apt-listbugs/migratepins
 profile apt-listbugs-migratepins @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>

--- a/apparmor.d/groups/apt/unattended-upgrade
+++ b/apparmor.d/groups/apt/unattended-upgrade
@@ -49,7 +49,7 @@ profile unattended-upgrade @{exec_path} flags=(attach_disconnected) {
 
   dbus receive bus=system path=/org/freedesktop/NetworkManager
        interface=org.freedesktop.NetworkManager
-       member=StateChanged,
+       member={CheckPermissions,StateChanged},
 
   @{exec_path} mr,
 
@@ -74,11 +74,14 @@ profile unattended-upgrade @{exec_path} flags=(attach_disconnected) {
   /{usr/,}lib/apt/methods/http{,s}     rPx,
   /{usr/,}lib/needrestart/apt-pinvoke  rPx,
   /{usr/,}lib/update-notifier/update-motd-updates-available rPx,
+  @{libexec}/zsys-system-autosnapshot  rPx,
 
   /usr/share/distro-info/* r,
 
   /etc/apt/*.list r,
   /etc/apt/apt.conf.d/{,**} r,
+  /etc/update-manager/{,**} r,
+  /etc/update-motd.d/{91-release-upgrade,92-unattended-upgrades} r,
 
   /etc/machine-id r,
 

--- a/apparmor.d/groups/ubuntu/do-release-upgrade
+++ b/apparmor.d/groups/ubuntu/do-release-upgrade
@@ -35,6 +35,7 @@ profile do-release-upgrade @{exec_path} {
   /etc/machine-id r,
   /etc/update-manager/{,**} r,
 
+  /var/lib/ubuntu-release-upgrader/release-upgrade-available rw,
   /var/lib/update-manager/* rw,
   /var/cache/apt/pkgcache.bin{,.*} rw,
 

--- a/apparmor.d/groups/ubuntu/release-upgrade-motd
+++ b/apparmor.d/groups/ubuntu/release-upgrade-motd
@@ -21,7 +21,5 @@ profile release-upgrade-motd @{exec_path} {
 
   /var/lib/ubuntu-release-upgrader/release-upgrade-available rw,
 
-  @{PROC}/filesystems r,
-
   include if exists <local/release-upgrade-motd>
 }

--- a/apparmor.d/groups/ubuntu/release-upgrade-motd
+++ b/apparmor.d/groups/ubuntu/release-upgrade-motd
@@ -15,11 +15,13 @@ profile release-upgrade-motd @{exec_path} {
   /{usr/,}bin/{,ba,da}sh          rix,
   /{usr/,}bin/date                rix,
   /{usr/,}bin/expr                rix,
+  /{usr/,}bin/id                  rix,
   /{usr/,}bin/stat                rix,
   /{usr/,}bin/do-release-upgrade  rPx,
 
   /var/lib/ubuntu-release-upgrader/release-upgrade-available rw,
 
+  @{PROC}/filesystems r,
 
   include if exists <local/release-upgrade-motd>
 }

--- a/apparmor.d/groups/ubuntu/release-upgrade-motd
+++ b/apparmor.d/groups/ubuntu/release-upgrade-motd
@@ -15,7 +15,7 @@ profile release-upgrade-motd @{exec_path} {
   /{usr/,}bin/{,ba,da}sh          rix,
   /{usr/,}bin/date                rix,
   /{usr/,}bin/expr                rix,
-  /{usr/,}bin/id                  rix,
+  /{usr/,}bin/id                  rPx,
   /{usr/,}bin/stat                rix,
   /{usr/,}bin/do-release-upgrade  rPx,
 

--- a/apparmor.d/profiles-m-r/mount-zfs
+++ b/apparmor.d/profiles-m-r/mount-zfs
@@ -25,7 +25,7 @@ profile mount-zfs @{exec_path} flags=(complain) {
   mount fstype=zfs -> @{MOUNTS}/,
   mount fstype=zfs -> @{MOUNTS}/*/,
   mount fstype=zfs -> /,
-  mount fstype=zfs -> /*/,
+  mount fstype=zfs -> /**/,
   mount fstype=zfs -> /tmp/zfsmnt.*/,
   mount fstype=zfs -> /tmp/zfsmnt.*/*/,
 

--- a/apparmor.d/profiles-s-z/sudo
+++ b/apparmor.d/profiles-s-z/sudo
@@ -37,6 +37,7 @@ profile sudo @{exec_path} {
 
   signal (send) peer=unconfined,
   signal (send) set=(cont,hup) peer=su,
+  signal (send) set=winch peer=apt,
 
   dbus send bus=system path=/org/freedesktop/login[0-9]
        interface=org.freedesktop.login[0-9].Manager

--- a/apparmor.d/profiles-s-z/zpool
+++ b/apparmor.d/profiles-s-z/zpool
@@ -22,7 +22,7 @@ profile zpool @{exec_path} {
   /etc/zfs/*.cache rwk,
 
   @{run}/blkid/blkid.tab rw,
-  @{run}/blkid/blkid.tab.old l,
+  @{run}/blkid/blkid.tab.old rwl,
   @{run}/blkid/blkid.tab-* rwl,
 
   @{sys}/bus/pci/slots/ r,
@@ -34,5 +34,5 @@ profile zpool @{exec_path} {
   /dev/pts/[0-9]* rw,
   /dev/zfs rw,
 
-  include if exists <local/zfs>
+  include if exists <local/zpool>
 }

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -1,0 +1,34 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2022 Jeroen Rijken
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = /{usr/,}{s,}bin/zsys-system-autosnapshot
+profile zsys-system-autosnapshot flags=(complain) @{exec_path} {
+  include <abstractions/base>
+
+  @{exec_path}           rm,
+  /{usr/,}bin/{,ba,da}sh rix,
+  /{usr/,}bin/cat        rix,
+  /{usr/,}bin/cp         rix,
+  /{usr/,}bin/rm         rix,
+  /{usr/,}bin/zsysctl    rix,
+  /{usr/,}bin/zsysd      rix,
+
+  /{usr/,}lib/locale/locale-archive r,
+  
+  /var/log/unattended-upgrades/unattended-upgrades-dpkg.log rw,
+
+  @{run}/zsys-bootmenu.unattended-upgrades rw,
+  @{run}/zsys-snapshot.unattended-upgrades rw,
+  @{run}/unattended-upgrades.pid r,
+
+  @{PROC}/filesystems r,
+
+  /dev/pts/[0-9]* rw,
+
+  include if exists <local/zsys-system-autosnapshot>
+}

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -15,8 +15,8 @@ profile zsys-system-autosnapshot @{exec_path} flags=(complain) {
   /{usr/,}bin/cat        rix,
   /{usr/,}bin/cp         rix,
   /{usr/,}bin/rm         rix,
-  /{usr/,}bin/zsysctl    rix,
-  /{usr/,}bin/zsysd      rix,
+  /{usr/,}bin/zsysctl    rPx,
+  /{usr/,}bin/zsysd      rPx,
   
   /var/log/unattended-upgrades/unattended-upgrades-dpkg.log rw,
 

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = /{usr/,}{s,}bin/zsys-system-autosnapshot
-profile zsys-system-autosnapshot flags=(complain) @{exec_path} {
+profile zsys-system-autosnapshot @{exec_path} flags=(complain) {
   include <abstractions/base>
 
   @{exec_path}           rm,

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -6,7 +6,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /{usr/,}{s,}bin/zsys-system-autosnapshot
+@{exec_path} = @{libexec}/zsys-system-autosnapshot
 profile zsys-system-autosnapshot @{exec_path} flags=(complain) {
   include <abstractions/base>
 

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -17,16 +17,12 @@ profile zsys-system-autosnapshot @{exec_path} flags=(complain) {
   /{usr/,}bin/rm         rix,
   /{usr/,}bin/zsysctl    rix,
   /{usr/,}bin/zsysd      rix,
-
-  /{usr/,}lib/locale/locale-archive r,
   
   /var/log/unattended-upgrades/unattended-upgrades-dpkg.log rw,
 
   @{run}/zsys-bootmenu.unattended-upgrades rw,
   @{run}/zsys-snapshot.unattended-upgrades rw,
   @{run}/unattended-upgrades.pid r,
-
-  @{PROC}/filesystems r,
 
   /dev/pts/[0-9]* rw,
 

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -34,9 +34,9 @@ profile zsysctl @{exec_path} flags=(complain) {
   @{run}/zsys-snapshot.unattended-upgrades rw,
   @{run}/zsysd.sock rw,
 
+  owner @{PROC}/@{pids}/stats r,
         @{PROC}/@{pids}/mounts r,
         @{PROC}/cmdline r,
-  owner @{PROC}/@{pids}/stats r,
         @{PROC}/filesystems r,
         @{PROC}/sys/kernel/spl/hostid r,
 
@@ -45,5 +45,5 @@ profile zsysctl @{exec_path} flags=(complain) {
   /dev/pts/[0-9]* rw,
   /dev/zfs rw,
 
-  include if exists <local/zsysctl>
+  include if exists <local/zsysd>
 }

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -10,6 +10,7 @@ include <tunables/global>
 profile zsysctl @{exec_path} flags=(complain) {
   include <abstractions/base>
   include <abstractions/dbus-strict>
+  include <abstractions/nameservice-strict>
 
   capability sys_ptrace,
   capability sys_admin,
@@ -18,13 +19,9 @@ profile zsysctl @{exec_path} flags=(complain) {
        interface=org.freedesktop.PolicyKit1.Authority
        member=CheckAuthorization,
 
-  @{exec_path}          rm,
-  /{usr/,}bin/zsysctl   rix,
-  /{usr/,}bin/zsysd     rix,
+  @{exec_path} rmix,
 
   /etc/hostid r,
-  /etc/passwd r,
-  /etc/nsswitch.conf r,
   /etc/zsys.conf r,
   
   /var/log/unattended-upgrades/unattended-upgrades-dpkg.log rw,

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -11,6 +11,13 @@ profile zsysctl @{exec_path} flags=(complain) {
   include <abstractions/base>
   include <abstractions/dbus-strict>
 
+  capability sys_ptrace,
+  capability sys_admin,
+
+  dbus send bus=system path=/org/freedesktop/PolicyKit1/Authority
+       interface=org.freedesktop.PolicyKit1.Authority
+       member=CheckAuthorization,
+
   @{exec_path}          rm,
   /{usr/,}bin/zsysctl   rix,
   /{usr/,}bin/zsysd     rix,
@@ -27,9 +34,11 @@ profile zsysctl @{exec_path} flags=(complain) {
   @{run}/zsys-snapshot.unattended-upgrades rw,
   @{run}/zsysd.sock rw,
 
-  @{PROC}/@{pids}/mounts r,
-  @{PROC}/filesystems r,
-  @{PROC}/sys/kernel/spl/hostid r,
+        @{PROC}/@{pids}/mounts r,
+        @{PROC}/cmdline r,
+  owner @{PROC}/@{pids}/stats r,
+        @{PROC}/filesystems r,
+        @{PROC}/sys/kernel/spl/hostid r,
 
   @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
 

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -34,7 +34,6 @@ profile zsysctl @{exec_path} flags=(complain) {
   owner @{PROC}/@{pids}/stat r,
         @{PROC}/@{pids}/mounts r,
         @{PROC}/cmdline r,
-        @{PROC}/filesystems r,
         @{PROC}/sys/kernel/spl/hostid r,
 
   @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = /{usr/,}{s,}bin/zsysd /{usr/,}{s,}bin/zsysctl
-profile zsysctl @{exec_path} flags=(complain) {
+profile zsysd @{exec_path} flags=(complain) {
   include <abstractions/base>
   include <abstractions/dbus-strict>
   include <abstractions/nameservice-strict>

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -34,7 +34,7 @@ profile zsysctl @{exec_path} flags=(complain) {
   @{run}/zsys-snapshot.unattended-upgrades rw,
   @{run}/zsysd.sock rw,
 
-  owner @{PROC}/@{pids}/stats r,
+  owner @{PROC}/@{pids}/stat r,
         @{PROC}/@{pids}/mounts r,
         @{PROC}/cmdline r,
         @{PROC}/filesystems r,

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -19,7 +19,10 @@ profile zsysd @{exec_path} flags=(complain) {
        interface=org.freedesktop.PolicyKit1.Authority
        member=CheckAuthorization,
 
-  @{exec_path} rmix,
+  @{exec_path}                   rmix,
+  /{usr/,}{local/,}{s,}bin/zfs   rPx,
+  /{usr/,}{local/,}{s,}bin/zpool rPx,
+  /{usr/,}{s,}bin/update-grub    rPUx,
 
   /etc/hostid r,
   /etc/zsys.conf r,

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -1,0 +1,40 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2022 Jeroen Rijken
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = /{usr/,}{s,}bin/zsysd /{usr/,}{s,}bin/zsysctl
+profile zsysctl @{exec_path} flags=(complain) {
+  include <abstractions/base>
+  include <abstractions/dbus-strict>
+
+  @{exec_path}          rm,
+  /{usr/,}bin/zsysctl   rix,
+  /{usr/,}bin/zsysd     rix,
+
+  /etc/hostid r,
+  /etc/passwd r,
+  /etc/nsswitch.conf r,
+  /etc/zsys.conf r,
+  
+  /var/log/unattended-upgrades/unattended-upgrades-dpkg.log rw,
+
+  @{run}/systemd/notify rw,
+  @{run}/unattended-upgrades.pid r,
+  @{run}/zsys-snapshot.unattended-upgrades rw,
+  @{run}/zsysd.sock rw,
+
+  @{PROC}/@{pids}/mounts r,
+  @{PROC}/filesystems r,
+  @{PROC}/sys/kernel/spl/hostid r,
+
+  @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+
+  /dev/pts/[0-9]* rw,
+  /dev/zfs rw,
+
+  include if exists <local/zsysctl>
+}


### PR DESCRIPTION
Changes:
* Replace hardcoded libexec with variable
* Small updates for unattended-update
* Small ZFS fixes
* Initial support for zsysd and automated snapshots before apt upgrade using zsysd.

Questions:
I'm getting the following error:
```
ALLOWED mount exec /sbin/mount.zfs info="no new privs" comm=mount requested_mask=x denied_mask=x error=-1
```
This causes the `mount.zfs` command to be run within the regular mount profile, with all the usual AVC errors. The `mount` profile does explicitly say the following:
```
/{usr/,}{s,}bin/mount.*    rPx,
```

So why is it not transitioning?