### PR TITLE
General update

### DIFF
--- a/apparmor.d/groups/grub/grub-mkconfig
+++ b/apparmor.d/groups/grub/grub-mkconfig
@@ -66,7 +66,9 @@ profile grub-mkconfig @{exec_path} {
 
   /usr/share/grub/{**,} r,
 
+  /.zfs/snapshot/*/boot/ r,
   /.zfs/snapshot/*/etc/{machine-id,} r,
+  /.zfs/snapshot/*/etc/fstab r,
   /.zfs/snapshot/*/{usr/,}lib/os-release r,
 
   / r,

--- a/apparmor.d/profiles-a-f/dkms
+++ b/apparmor.d/profiles-a-f/dkms
@@ -65,6 +65,8 @@ profile dkms @{exec_path} flags=(attach_disconnected) {
   /var/lib/dkms/**/configure rix,
   /var/lib/dkms/**/dkms.postbuild rix,
 
+  /var/lib/shim-signed/mok/** r,
+
   / r,
   /{usr/,}lib/modules/*/updates/ rw,
   /{usr/,}lib/modules/*/updates/dkms/{,*,*/,**.ko.xz,**.ko.zst} rw,

--- a/apparmor.d/profiles-s-z/update-secureboot-policy
+++ b/apparmor.d/profiles-s-z/update-secureboot-policy
@@ -14,9 +14,21 @@ profile update-secureboot-policy @{exec_path} {
 
   @{exec_path} rm,
 
-  /{usr/,}bin/{,ba,da}sh       rix,
-  /{usr/,}bin/dpkg-trigger     rPx,
-  /usr/share/debconf/frontend  rPx,
+  /{usr/,}bin/{,ba,da}sh      rix,
+  /{usr/,}bin/{,m,g}awk       rix,
+  /{usr/,}bin/dpkg-trigger    rPx,
+  /{usr/,}bin/find            rix,
+  /{usr/,}bin/id              rix,
+  /{usr/,}bin/od              rix,
+  /{usr/,}bin/sort            rix,
+  /{usr/,}bin/touch           rix,
+  /{usr/,}bin/wc              rix,
+  /usr/share/debconf/frontend rPx,
+
+  /usr/share/debconf/confmodule r,
+
+  /var/lib/dkms/ r,
+  /var/lib/shim-signed/dkms-list r,
 
   include if exists <local/update-secureboot-policy>
 }

--- a/apparmor.d/profiles-s-z/whereis
+++ b/apparmor.d/profiles-s-z/whereis
@@ -27,6 +27,8 @@ profile whereis @{exec_path} flags=(complain) {
   /usr/share/man/{**,} r,
   /usr/src/{**,} r,
 
+  /etc/ r,
+
   /opt/ r,
   /opt/cni/bin/ r,
   /opt/containerd/bin/ r,


### PR DESCRIPTION
Several updates discovered after a system update.

`/usr/share/debconf/frontend` executes `update-secureboot-policy`, but `frontend` has no policy so there are still some AVC messages left.