### PR TITLE
pacman: allow dir read in or below @{user_pkg_dirs}

### DIFF
--- a/apparmor.d/groups/pacman/pacman
+++ b/apparmor.d/groups/pacman/pacman
@@ -123,6 +123,7 @@ profile pacman @{exec_path} {
   /mnt r,
 
   # Read packages files
+  @{user_pkg_dirs}/**/ r,
   @{user_pkg_dirs}/**.pkg.tar.zst{,.sig} r,
 
   owner /var/lib/pacman/{,**} rwl,


### PR DESCRIPTION
use case:
```
ALLOWED pacman open /home/vbauer/.cache/paru/clone/apparmor.d-git/ comm=pacman requested_mask=r denied_mask=r
```

content of `tunables/xdg-user-dirs.d/site.local`:
```
@{user_pkg_dirs}+=@{user_cache_dirs}/paru/
```