### PR TITLE
Adding capability net_admin

### DIFF
--- a/apparmor.d/profiles-s-z/sddm
+++ b/apparmor.d/profiles-s-z/sddm
@@ -52,11 +52,13 @@ profile sddm @{exec_path} {
 
   # To read the /var/lib/sddm/state.conf file
   capability dac_read_search,
+  
+  # To prevent breaking the boot process
+  capability net_admin,
 
   # Needed?
   #capability sys_tty_config,
-  deny capability net_admin,
-
+  
   ptrace (trace) peer=@{profile_name},
 
   signal (send) set=(kill, term) peer=xorg,
@@ -144,6 +146,7 @@ profile sddm @{exec_path} {
   owner @{HOME}/.Xauthority rw,
 
   /etc/default/locale r,
+  /etc/locale.conf
   @{etc_ro}/environment r,
 
   owner @{PROC}/@{pid}/loginuid rw,


### PR DESCRIPTION
capability net_admin is needed to prevent breaking the boot process on Arch Linux with KDE.