### PR TITLE
run-parts:  0anacron rPUx -> rix, and some other additions

### DIFF
--- a/apparmor.d/groups/kde/ksmserver
+++ b/apparmor.d/groups/kde/ksmserver
@@ -11,6 +11,7 @@ profile ksmserver @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/app-launcher-user>
   include <abstractions/dri-common>
+  include <abstractions/fonts>
   include <abstractions/freedesktop.org>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
@@ -44,6 +45,7 @@ profile ksmserver @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{HOME}/.Xauthority rw,
 
   owner @{user_cache_dirs}/icon-cache.kcache rw,
+  owner @{user_cache_dirs}/fontconfig/*-le64.cache-* r,
   owner @{user_cache_dirs}/ksycoca5_* r,
 
   owner @{user_config_dirs}/kdedefaults/* r,

--- a/apparmor.d/profiles-m-r/run-parts
+++ b/apparmor.d/profiles-m-r/run-parts
@@ -16,7 +16,10 @@ profile run-parts @{exec_path} {
 
   @{exec_path} mr,
 
+  /{usr/,}bin/anacron rix,
   /{usr/,}bin/{,ba,da}sh rix,
+  /{usr/,}bin/cat rix,
+  /{usr/,}bin/date rix,
   /{usr/,}bin/nice rix,
   /{usr/,}bin/snapper rix,
   
@@ -25,12 +28,14 @@ profile run-parts @{exec_path} {
   /usr/share/update-notifier/notify-updates-outdated  rPx,
 
   /etc/ r,
+  /etc/anacrontab                                      r,
   /etc/conf.d/snapper{,**}                             r,
+  /etc/snapper/configs/root                            r,
     
 
   # Crontab
   /etc/cron.{hourly,daily,weekly,monthly}/                     r,
-  /etc/cron.{hourly,daily,weekly,monthly}/0anacron            rPUx,
+  /etc/cron.{hourly,daily,weekly,monthly}/0anacron             rix,
   /etc/cron.{hourly,daily,weekly,monthly}/apport               rPx,
   /etc/cron.{hourly,daily,weekly,monthly}/apt-compat           rPx,
   /etc/cron.{hourly,daily,weekly,monthly}/apt-listbugs         rPx,
@@ -126,6 +131,8 @@ profile run-parts @{exec_path} {
 
   owner /tmp/#[0-9]*[0-9] rw,
   owner /tmp/$anacron* rw,
+  
+  owner @{sys}/class/power_supply/            r,
 
   /dev/tty[0-9]* rw,
 


### PR DESCRIPTION
The rule
`/etc/cron.{hourly,daily,weekly,monthly}/0anacron            rPUx, `

causes the error:
`ALLOWED run-parts exec /etc/cron.hourly/0anacron info="no new privs" comm=run-parts requested_mask=x denied_mask=x class=file error=-1`