### PR TITLE
allow k for user_publicshare_dirs

### DIFF
--- a/apparmor.d/groups/virt/libvirtd
+++ b/apparmor.d/groups/virt/libvirtd
@@ -148,7 +148,7 @@ profile libvirtd @{exec_path} flags=(attach_disconnected) {
   @{user_share_dirs}/ r,
   @{user_share_dirs}/libvirt/{,**} rwk,
   @{user_vm_dirs}/{,**} rwk,
-  @{user_publicshare_dirs}/{,**} rw,
+  @{user_publicshare_dirs}/{,**} rwk,
 
   @{run}/libvirt/ rw,
   @{run}/libvirt/** rwk,


### PR DESCRIPTION
```
ALLOWED libvirtd file_lock /home/vbauer/Public/archlinux/archlinux-2023.05.03-x86_64.iso comm=qemu-event requested_mask=k denied_mask=k class=file
ALLOWED libvirtd file_lock /home/vbauer/Public/archlinux/archlinux-2023.05.03-x86_64.iso comm=rpc-libvirtd requested_mask=k denied_mask=k class=file
```