### PR TITLE
Brave: adjust @{exec_path}

### DIFF
--- a/apparmor.d/groups/browsers/brave
+++ b/apparmor.d/groups/browsers/brave
@@ -13,7 +13,7 @@ include <tunables/global>
 @{chromium_config_dirs} = @{user_config_dirs}/BraveSoftware/Brave-Browser{,-Beta,-Dev}
 @{chromium_cache_dirs} = @{user_cache_dirs}/BraveSoftware/Brave-Browser{,-Beta,-Dev}
 
-@{exec_path} = @{chromium_lib_dirs}/@{chromium_name}
+@{exec_path} = @{chromium_lib_dirs}{,/@{chromium_name}}
 profile brave @{exec_path} {
   include <abstractions/base>
   include <abstractions/chromium>


### PR DESCRIPTION
The path in Ubuntu is:
/opt/brave.com/brave/brave

The path in Arch is:
/opt/brave-bin/brave

That's why Brave was not confined on Arch.