### PR TITLE
Fix xdg user dirs

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
@@ -162,7 +162,7 @@ profile xdg-desktop-portal-gtk @{exec_path} {
   owner @{HOME}/ r,
   owner @{HOME}/.* r,
   owner @{HOME}/.icons/{,**} r,
-  owner @{HOME}/@{XDG_DATA_HOME}/ r,
+  owner @{HOME}/@{XDG_DATA_DIR}/ r,
 
   owner /tmp/runtime-*/xauth_?????? r,
 

--- a/apparmor.d/groups/freedesktop/xdg-permission-store
+++ b/apparmor.d/groups/freedesktop/xdg-permission-store
@@ -46,7 +46,7 @@ profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
-  @{HOME}/@{XDG_DATA_HOME}/flatpak/db/gnome rw,
+  @{HOME}/@{XDG_DATA_DIR}/flatpak/db/gnome rw,
 
   owner @{user_share_dirs}/flatpak/ w,
   owner @{user_share_dirs}/flatpak/db/ rw,

--- a/apparmor.d/profiles-m-r/man
+++ b/apparmor.d/profiles-m-r/man
@@ -104,10 +104,10 @@ profile man_filter {
   # there's no harm in allowing wide read access here since the worst it can
   # do is feed data to the invoking man process.
         /usr/** r,
-  owner @{HOME}/@{XDG_DATA_HOME}/** r,
+  owner @{HOME}/@{XDG_DATA_DIR}/** r,
   owner @{user_projects_dirs}/** r,
   owner @{user_cache_dirs}/** r,
-  owner @{MOUNTS}/*/@{XDG_DATA_HOME}/** r,
+  owner @{MOUNTS}/*/@{XDG_DATA_DIR}/** r,
 
   /var/cache/man/** w,
 

--- a/apparmor.d/profiles-s-z/syncthing
+++ b/apparmor.d/profiles-s-z/syncthing
@@ -30,7 +30,7 @@ profile syncthing @{exec_path} {
   /usr/share/mime/globs2 r,
 
   owner @{HOME}/ r,
-  owner @{HOME}/@{XDG_DATA_HOME}/syncthing/{,**} rwk,
+  owner @{HOME}/@{XDG_DATA_DIR}/syncthing/{,**} rwk,
   owner @{user_config_dirs}/syncthing/{,**} rwk,
 
   /home/ r,

--- a/apparmor.d/tunables/home.d/apparmor.d
+++ b/apparmor.d/tunables/home.d/apparmor.d
@@ -31,19 +31,19 @@
 @{XDG_PASSWORD_STORE_DIR}=".password-store"
 
 # Definition of local user configuration directories
-@{XDG_CACHE_HOME}=".cache"
-@{XDG_CONFIG_HOME}=".config"
-@{XDG_DATA_HOME}=".local/share"
-@{XDG_STATE_HOME}=".local/state"
-@{XDG_BIN_HOME}=".local/bin"
-@{XDG_LIB_HOME}=".local/lib"
+@{XDG_CACHE_DIR}=".cache"
+@{XDG_CONFIG_DIR}=".config"
+@{XDG_DATA_DIR}=".local/share"
+@{XDG_STATE_DIR}=".local/state"
+@{XDG_BIN_DIR}=".local/bin"
+@{XDG_LIB_DIR}=".local/lib"
 
 # Full path of the user configuration directories
-@{user_cache_dirs}=@{HOME}/@{XDG_CACHE_HOME}
-@{user_config_dirs}=@{HOME}/@{XDG_CONFIG_HOME}
-@{user_state_dirs}=@{HOME}/@{XDG_STATE_HOME}
-@{user_bin_dirs}=@{HOME}/@{XDG_BIN_HOME}
-@{user_lib_dirs}=@{HOME}/@{XDG_LIB_HOME}
+@{user_cache_dirs}=@{HOME}/@{XDG_CACHE_DIR}
+@{user_config_dirs}=@{HOME}/@{XDG_CONFIG_DIR}
+@{user_state_dirs}=@{HOME}/@{XDG_STATE_DIR}
+@{user_bin_dirs}=@{HOME}/@{XDG_BIN_DIR}
+@{user_lib_dirs}=@{HOME}/@{XDG_LIB_DIR}
 
 # User build directories and output
 @{user_build_dirs}="/tmp/"

--- a/apparmor.d/tunables/xdg-user-dirs.d/apparmor.d
+++ b/apparmor.d/tunables/xdg-user-dirs.d/apparmor.d
@@ -20,3 +20,5 @@
 @{user_templates_dirs}=@{HOME}/@{XDG_TEMPLATES_DIR} @{MOUNTS}/@{XDG_TEMPLATES_DIR}
 @{user_videos_dirs}=@{HOME}/@{XDG_VIDEOS_DIR} @{MOUNTS}/@{XDG_VIDEOS_DIR}
 @{user_vm_shares}=@{HOME}/@{XDG_VM_SHARES_DIR} @{MOUNTS}/@{XDG_VM_SHARES_DIR}
+
+include if exists <tunnables/xdg-user-dirs.d/apparmor.d.d>

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -32,23 +32,23 @@ title: Variables References
 | SSH | `@{XDG_SSH_DIR}` | `.ssh` |
 | GPG | `@{XDG_GPG_DIR}` | `.gnupg` |
 | Passwords | `@{XDG_PASSWORD_STORE_DIR}` | `.password-store` |
-| Cache | ` @{XDG_CACHE_HOME}` | `.cache` |
-| Config | `@{XDG_CONFIG_HOME}` | `.config` |
-| Data | `@{XDG_DATA_HOME}` | `.local/share` |
-| State | `@{XDG_STATE_HOME}` | `.local/state` |
-| Bin | `@{XDG_BIN_HOME}` | `.local/bin` |
-| Lib | `@{XDG_LIB_HOME}` | `.local/lib` |
+| Cache | ` @{XDG_CACHE_DIR}` | `.cache` |
+| Config | `@{XDG_CONFIG_DIR}` | `.config` |
+| Data | `@{XDG_DATA_DIR}` | `.local/share` |
+| State | `@{XDG_STATE_DIR}` | `.local/state` |
+| Bin | `@{XDG_BIN_DIR}` | `.local/bin` |
+| Lib | `@{XDG_LIB_DIR}` | `.local/lib` |
 
 ### Full configuration path
 
 | Description | Name | Value |
 |-------------|:----:|---------|
-| Cache | `@{user_cache_dirs}` | `@{HOME}/@{XDG_CACHE_HOME}` |
-| Config | `@{user_config_dirs}` | `@{HOME}/@{XDG_CONFIG_HOME}` |
-| Share | `@{user_share_dirs}` | ` @{HOME}/@{XDG_DATA_HOME}` |
-| State | `@{user_state_dirs}` | ` @{HOME}/@{XDG_STATE_HOME}` |
-| Bin | `@{user_bin_dirs}` | `@{HOME}/@{XDG_BIN_HOME}` |
-| Lib | `@{user_lib_dirs}` | `@{HOME}/@{XDG_LIB_HOME}` |
+| Cache | `@{user_cache_dirs}` | `@{HOME}/@{XDG_CACHE_DIR}` |
+| Config | `@{user_config_dirs}` | `@{HOME}/@{XDG_CONFIG_DIR}` |
+| Share | `@{user_share_dirs}` | ` @{HOME}/@{XDG_DATA_DIR}` |
+| State | `@{user_state_dirs}` | ` @{HOME}/@{XDG_STATE_DIR}` |
+| Bin | `@{user_bin_dirs}` | `@{HOME}/@{XDG_BIN_DIR}` |
+| Lib | `@{user_lib_dirs}` | `@{HOME}/@{XDG_LIB_DIR}` |
 | Build | `@{user_build_dirs}` | `/tmp/` |
 | Tmp | `@{user_tmp_dirs}` | `@{run}/user/@{uid} /tmp/` |
 | Packages | `@{user_pkg_dirs}` | `/tmp/pkg/` |


### PR DESCRIPTION
This PR aims to allow users to reuse existing variables in their custom config. I also believe that `xdg-user-dirs.d` is more suited than `home.d` for such a config file.

Currently in my `/etc/apparmor.d/tunables/xdg-user-dirs.d/local` I'm unable to do:

```
@{user_config_dirs}+=@{HOME}/.dotfiles/@{XDG_CONFIG_HOME}
```

Because `XDG_CONFIG_HOME` does not exist in that scope.

As stated in #131, the idea would be to create a subfolder `/etc/apparmor.d/tunables/xdg-user-dirs.d/apparmor.d.extend` to prevent upstream from sourcing the user config and source your `apparmor.d` first. Then all your `apparmor.d` has to do is to source the user folder:

```
include if exists <tunnables/xdg-user-dirs.d/apparmor.d.extend>
```

I also renamed all the `*_HOME` to `*_DIR` for consistence, upstream seems to use that convention:

```
# ------------------------------------------------------------------
#
#    Copyright (C) 2014 Canonical Ltd.
#
#    This program is free software; you can redistribute it and/or
#    modify it under the terms of version 2 of the GNU General Public
#    License published by the Free Software Foundation.
#
# ------------------------------------------------------------------

# Define the common set of XDG user directories (usually defined in
# /etc/xdg/user-dirs.defaults)
@{XDG_DESKTOP_DIR}="Desktop"
@{XDG_DOWNLOAD_DIR}="Downloads"
@{XDG_TEMPLATES_DIR}="Templates"
@{XDG_PUBLICSHARE_DIR}="Public"
@{XDG_DOCUMENTS_DIR}="Documents"
@{XDG_MUSIC_DIR}="Music"
@{XDG_PICTURES_DIR}="Pictures"
@{XDG_VIDEOS_DIR}="Videos"

# Also, include files in tunables/xdg-user-dirs.d for site-specific adjustments
# to the various XDG directories
include <tunables/xdg-user-dirs.d>
```

Also, I was wondering about all the :

```
@{user_documents_dirs}=@{HOME}/@{XDG_DOCUMENTS_DIR} @{MOUNTS}/@{XDG_DOCUMENTS_DIR}
@{user_download_dirs}=@{HOME}/@{XDG_DOWNLOAD_DIR} @{MOUNTS}/@{XDG_DOWNLOAD_DIR}
@{user_music_dirs}=@{HOME}/@{XDG_MUSIC_DIR} @{MOUNTS}/@{XDG_MUSIC_DIR}

[...]
```

Don't you think it would be easier to just append to the existing `XDG_*` ? The above could become:

```
@{XDG_DOCUMENTS_DIR}+=@{MOUNTS}/@{XDG_DOCUMENTS_DIR}
@{XDG_DOWNLOAD_DIR}+=@{MOUNTS}/@{XDG_DOWNLOAD_DIR}
@{XDG_MUSIC_DIR}+=@{MOUNTS}/@{XDG_MUSIC_DIR}

[...]
```

And the user could also add its own:

```
@{XDG_CONFIG_DIR}+=.dotfiles/@{XDG_CONFIG_DIR}
@{XDG_DATA_DIR}+=.dotfiles/@{XDG_DATA_DIR}

[...]
```

I think it would be much easier and it would not require creating new variables.

In the profiles you would then have to use `@{HOME}` everywhere :

```
@{HOME}/@{XDG_DOCUMENTS_DIR}/salut rw,
```

And as a bonus, it would allow you to use some upstream abstractions that already depend on `XDG_*` variables such as [this one](https://gitlab.com/apparmor/apparmor/-/blob/17a521ff5051d4e36c38d2cb760d0d97773f5a8d/profiles/apparmor.d/abstractions/user-write).