### PR TITLE
Update pipewire

### DIFF
--- a/apparmor.d/groups/freedesktop/pipewire
+++ b/apparmor.d/groups/freedesktop/pipewire
@@ -62,10 +62,11 @@ profile pipewire @{exec_path} flags=(attach_disconnected) {
   
   owner @{user_config_dirs}/pipewire/pipewire-pulse.conf r,
   owner @{user_config_dirs}/pipewire/pipewire.conf r,
-
+  
   owner /tmp/librnnoise-[0-9]*.so rm,
   owner @{run}/user/@{uid}/pipewire-@{int} rw,
   owner @{run}/user/@{uid}/pipewire-@{int}.lock rwk,
+  owner @{run}/user/@{uid}/pipewire-@{int}-manager.lock rwk,
 
   @{run}/udev/data/c81:@{int}  r,         # For video4linux
   @{run}/udev/data/c23[4-9]:@{int} r,     # For dynamic assignment range 234 to 254


### PR DESCRIPTION
Necessary after the recent pipewire update, otherwise audio devices are no longer available.