### PR TITLE
fix gnome slow start up

### DIFF
--- a/apparmor.d/groups/bus/dbus-daemon
+++ b/apparmor.d/groups/bus/dbus-daemon
@@ -44,7 +44,7 @@ profile dbus-daemon @{exec_path} flags=(attach_disconnected) {
   @{lib}/{,at-spi2{,-core}/}at-spi2-registryd                             rPx,
   @{lib}/@{multiarch}/tumbler-1/tumblerd                                 rPUx,
   @{lib}/@{multiarch}/xfce[0-9]/xfconf/xfconfd                            rPx,
-  @{lib}/*                                                               rPUx,
+  @{lib}/*                                                                rix,
   @{lib}/atril/atrild                                                     rPx,
   @{lib}/dbus-1*/dbus-daemon-launch-helper                                rPx,
   @{lib}/gnome-shell/gnome-shell-calendar-server                          rPx,


### PR DESCRIPTION
Gentlemen, it is with great pleasure to inform you that I have been able to locate the source of the notorious slow start up problem. This unironically fixes the slow start up on gnome. Almost everything under @{lib} is directories. If we inherit our profile instead of looking for seperate profiles for each and every one of them, it fixes the issue. Maybe this solution can be improved further. But yes, this is the problem, and there is the solution.