### PR TITLE
Allow more login shells

### DIFF
--- a/apparmor.d/profiles-g-l/login
+++ b/apparmor.d/profiles-g-l/login
@@ -37,7 +37,7 @@ profile login @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
-  @{bin}/{,z,ba,da}sh  rUx,
+  @{bin}/{,c,k,o,y,z,ba,da,fi,tc,xon,elvi}sh  rUx,
 
   @{etc_ro}/environment r,
   @{etc_ro}/security/limits.d/{,*} r,


### PR DESCRIPTION
Add [ksh](http://www.kornshell.com/), [oil shell](https://www.oilshell.org/), [C shell](https://www.tcsh.org/), [Elvish](https://elv.sh/), [fish](https://fishshell.com/) and [xonsh](https://xon.sh/) to login shell profile.

Names of these binaries are taken from [Arch Linux's Package Content](https://wiki.archlinux.org/title/Command-line_shell#List_of_shells).

Only shells with binary name ending with `sh` is added (so no [nushell](https://www.nushell.sh/)). Shells that are not present in the Arch Linux's Official Repository are ignored (because I'm not sure where to find their binary names)

Closes #269