### PR TITLE
Tighten `firefox`

### DIFF
--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -148,6 +148,8 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   owner @{user_share_dirs}/applications/userapp-Firefox-@{rand6}.desktop{,.@{rand6}} rw,
   owner @{user_share_dirs}/mime/packages/user-extension-{htm,html,xht,xhtml,shtml}.xml rw,
   owner @{user_share_dirs}/mime/packages/user-extension-{htm,html,xht,xhtml,shtml}.xml.* rw,
+  owner @{user_share_dirs}/sounds/__custom/index.theme r,
+  owner @{user_share_dirs}/sounds/__custom/*.ogg r,
 
   owner @{config_dirs}/ rw,
   owner @{config_dirs}/{extensions,systemextensionsdev}/ rw,
@@ -172,15 +174,22 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   owner /tmp/user/@{uid}/@{name}/* rwk,
   owner /tmp/@{name}/ rw,
   owner /tmp/@{name}/* rwk,
-  owner /tmp/* rw,
   owner /tmp/firefox_*/ rw,
   owner /tmp/firefox_*/* rwk,
   owner /tmp/mozilla_*/ rw,
   owner /tmp/mozilla_*/* rw,
-  owner /tmp/MozillaBackgroundTask-*-removeDirectory/ rw,
-  owner /tmp/MozillaBackgroundTask-*-removeDirectory/** rwk,
-  owner /tmp/Mozillato-be-removed-cachePurge-* k,
-  owner /tmp/Temp-@{uuid}/ rw,
+  owner /tmp/MozillaBackgroundTask-???????????????-removeDirectory/{**,} rw,
+  owner /tmp/MozillaBackgroundTask-???????????????-removeDirectory/.parentlock k,
+  owner /tmp/Mozillato-be-removed-cachePurge-??????????????? rwk,
+  owner /tmp/Mozilla@{uuid}-cachePurge-??????????????? rwk,
+  owner /tmp/Mozilla\{@{uuid}\}-cachePurge-??????????????? rwk,
+  owner /tmp/Temp-@{uuid}/{**,} rw,
+  owner /tmp/mozilla-temp-@{int} rw,
+  owner /tmp/@{rand8}.txt w,
+  owner /tmp/tmp-???.xpi rw,
+  owner /tmp/.xfsm-ICE-@{rand6} rw,
+  owner /tmp/tmpaddon r,
+  owner /tmp/* w,  # file downloads (to anywhere)
 
   @{run}/mount/utab r,
 
@@ -231,6 +240,7 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   owner /dev/tty@{int} rw, # File Inherit
 
   # Silencer
+  deny capability sys_ptrace,
   deny @{lib_dirs}/** w,
   deny @{run}/user/@{uid}/gnome-shell-disable-extensions w,
   deny /tmp/MozillaUpdateLock-* w,


### PR DESCRIPTION
Versions tested:
- 121.0.1 (official tar on Ubuntu 22.04)
- 102.15.0esr (from stock repository on Debian 12)

Behavior tested:
- Regular browsing
- File downloads
- Extension adding/removal
- Themes adding/removal