### PR TITLE
Updating polkit, sddm, unix chkpwd, btrfs, needrestart

### DIFF
--- a/apparmor.d/groups/freedesktop/polkitd
+++ b/apparmor.d/groups/freedesktop/polkitd
@@ -58,6 +58,7 @@ profile polkitd @{exec_path} flags=(attach_disconnected) {
 
   @{PROC}/@{pids}/cgroup r,
   @{PROC}/@{pids}/cmdline r,
+  @{PROC}/@{pid}/fdinfo/@{int} r,
   @{PROC}/@{pids}/stat r,
   @{PROC}/@{pids}/task/@{tid}/stat r,
   @{PROC}/1/environ r,

--- a/apparmor.d/groups/kde/sddm
+++ b/apparmor.d/groups/kde/sddm
@@ -63,6 +63,7 @@ profile sddm @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   @{bin}/tty           rix,
   @{bin}/xdm            r,
   @{bin}/xmodmap       rix,
+  @{bin}/unix_chkpwd   rPx,
 
   @{bin}/kwin_wayland rPUx,
   @{bin}/sddm-greeter rPx,

--- a/apparmor.d/profiles-a-f/btrfs
+++ b/apparmor.d/profiles-a-f/btrfs
@@ -41,13 +41,18 @@ profile btrfs @{exec_path} flags=(attach_disconnected) {
 
   @{run}/blkid/blkid.tab{,-@{rand6}} rw,
   @{run}/blkid/blkid.tab.old rwl -> @{run}/blkid/blkid.tab,
-
+  @{run}/snapper-tools-*/ r,
+  @{run}/snapper-tools-@{rand6}/@/.snapshots/@{int}/snapshot r,
+  
+  @{sys}/fs/btrfs/@{uuid}/exclusive_operation r,
   @{sys}/fs/btrfs/@{uuid}/devinfo/@{int}/fsid r,
+  @{sys}/fs/btrfs/@{uuid}/devinfo/@{int}/scrub_speed_max r,
 
         @{PROC}/partitions r,
   owner @{PROC}/@{pid}/mounts r,
 
   /dev/btrfs-control rw,
+  /dev/pts/@{int} rw,
   /dev/tty@{int} rw,
   
 

--- a/apparmor.d/profiles-g-l/login
+++ b/apparmor.d/profiles-g-l/login
@@ -38,6 +38,7 @@ profile login @{exec_path} flags=(attach_disconnected) {
   @{exec_path} mr,
 
   @{bin}/{,z,ba,da}sh  rUx,
+  @{bin}/unix_chkpwd rPx,
 
   @{etc_ro}/environment r,
   @{etc_ro}/security/limits.d/{,*} r,
@@ -55,7 +56,7 @@ profile login @{exec_path} flags=(attach_disconnected) {
 
   owner @{user_cache_dirs}/motd.legal-displayed rw,
 
-  @{run}/motd.d/ r,
+  @{run}/motd.d/{,*} r,
   @{run}/dbus/system_bus_socket rw,
   @{run}/faillock/* rwk,
   @{run}/motd.dynamic{,.new} rw,

--- a/apparmor.d/profiles-m-r/needrestart
+++ b/apparmor.d/profiles-m-r/needrestart
@@ -34,6 +34,7 @@ profile needrestart @{exec_path} flags=(attach_disconnected) {
   @{bin}/systemctl                         rPx -> child-systemctl,
   @{bin}/systemd-detect-virt               rPx,
   @{bin}/udevadm                           rPx,
+  @{bin}/unix_chkpwd                       rPx,
   @{bin}/whiptail                          rPx,
   @{bin}/who                               rix,
   @{lib}/needrestart/iucode-scan-versions  rPx,

--- a/apparmor.d/profiles-s-z/unix-chkpwd
+++ b/apparmor.d/profiles-s-z/unix-chkpwd
@@ -21,6 +21,7 @@ profile unix-chkpwd @{exec_path} {
   /etc/shadow r,
 
   # file_inherit
+        /dev/pts/@{int} rw,
   owner /dev/tty@{int} rw,
 
   include if exists <local/unix-chkpwd>


### PR DESCRIPTION
Today the boot process in Arch was broken for me. I'm not quite sure what exactly caused that but those modifications fixed it. 

I got those rules from aa-log after booting into a snapshot (I'm using btrfs with snapper).