### PR TITLE
Mutt and Abook profiles

### DIFF
--- a/apparmor.d/profiles-a-f/abook
+++ b/apparmor.d/profiles-a-f/abook
@@ -21,9 +21,9 @@ profile abook @{exec_path} {
   # Abook has built in support to launch mutt
   @{bin}/mutt       rPUx,
 
-  /etc/inputrc r,
-
   /usr/share/terminfo/** r,
+
+  /etc/inputrc r,
 
   owner @{HOME}/.abook/abookrc       r,
   owner @{HOME}/.abook/addressbook* rw,

--- a/apparmor.d/profiles-a-f/abook
+++ b/apparmor.d/profiles-a-f/abook
@@ -1,0 +1,32 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2024 Zane Zakraisek <zz@eng.utah.edu>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/abook
+profile abook @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/consoles>
+  include <abstractions/nameservice-strict>
+  include <abstractions/user-download-strict>
+
+  @{exec_path} mr,
+
+  # Used for printing
+  @{bin}/{,ba,da}sh rix,
+  @{bin}/lp{,r}     rPUx,
+  # Abook has built in support to launch mutt
+  @{bin}/mutt       rPUx,
+
+  /etc/inputrc r,
+
+  /usr/share/terminfo/** r,
+
+  owner @{HOME}/.abook/abookrc       r,
+  owner @{HOME}/.abook/addressbook* rw,
+
+  include if exists <local/abook>
+}

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -32,7 +32,6 @@ profile mutt @{exec_path} {
   @{bin}/sendmail                rPUx,
   @{lib}/sendmail/sendmail rPUx,
   @{bin}/ispell                  rPUx, 
-  # TODO: Add a profile for abook (Most distros don't ship this anymore though)
   @{bin}/abook                   rPUx,
   @{bin}/mutt_dotlock             rix,
   # Misc mutt scripts

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -33,8 +33,7 @@ profile mutt @{exec_path} {
   # Used when saving attachments. Mutt saves attachments in whatever directory
   # it's launched from, which is most likely @{HOME}.
   owner @{HOME}/*           lw,
-  owner @{HOME}/.mutt*/     w,
-  owner @{HOME}/.mutt*/*    w,
+  owner @{HOME}/.mutt*/{,*} w,
   owner @{HOME}/Downloads/* lw,
   # Used When viewing attachments
   owner /tmp/*              lrw,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -52,7 +52,9 @@ profile mutt @{exec_path} {
 
   /usr/share/terminfo/** r,
 
-  /etc/mime.types r,
+  # Mutt MIME types search path
+  /etc/mime.types           r,
+  owner @{HOME}/.mime.types r,
 
   # Mutt mailcap search path
   /etc/{mutt/,}mailcap   r,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -9,10 +9,10 @@ include <tunables/global>
 @{exec_path} = @{bin}/mutt
 profile mutt @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
   include <abstractions/openssl>
   include <abstractions/ssl_certs>
-  include <abstractions/consoles>
   include <abstractions/user-download-strict>
   include <abstractions/user-read>
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -150,8 +150,9 @@ profile mutt @{exec_path} {
     include <abstractions/base>
     include <abstractions/consoles>
   
-    /{usr/,}bin/less mrix,
-    /{usr/,}bin/more mrix,
+    /{usr/,}bin/less  mr,
+    /{usr/,}bin/more  mr,
+    /{usr/,}bin/pager mr,
     
     owner @{HOME}/.lesshsQ r,
     owner @{HOME}/.local/state/ r,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -69,14 +69,6 @@ profile mutt @{exec_path} {
 
   owner @{HOME}/.cache/mutt rwk,
 
-  # Used When viewing attachments
-  owner /tmp/*              lrw,
-
-  # Needed to compose a message
-  owner /{var/,}tmp/.mutt*/  rw,
-  owner /{var/,}tmp/.mutt*/* lrwk,
-  owner /{var/,}tmp/mutt*    lrwk,
-
   # Needed for the edit operation.
   owner @{HOME}/ r,
 
@@ -101,6 +93,14 @@ profile mutt @{exec_path} {
 
   # Common location for mail aliases
   owner @{HOME}/.mail_aliases r,
+
+  # Needed to compose a message
+  owner /{var/,}tmp/.mutt*/  rw,
+  owner /{var/,}tmp/.mutt*/* lrwk,
+  owner /{var/,}tmp/mutt*    lrwk,
+
+  # Used When viewing attachments
+  owner /tmp/* lrw,
   
   profile html-renderer {
     include <abstractions/base>

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -24,6 +24,42 @@ profile mutt @{exec_path} {
 
   @{exec_path} mr,
 
+  # Used to exec programs defined in the mailcap.
+  # There are countless programs that can be executed from the mailcap.
+  # This profile includes only the most basic.
+  @{bin}/{,ba,da}sh               rix,
+ 
+  @{bin}/sendmail                rPUx,
+  /usr/libexec/sendmail/sendmail rPUx,
+  @{bin}/ispell                  rPUx, 
+  # TODO: Add a profile for abook (Most distros don't ship this anymore though)
+  @{bin}/abook                   rPUx,
+  @{bin}/mutt_dotlock             rix,
+  # Misc mutt scripts
+  @{lib}/mutt/*                   rix,
+ 
+  @{bin}/w3m             rCx -> html-renderer,
+  @{bin}/lynx            rCx -> html-renderer,
+  @{bin}/vim             rCx -> editor,
+  @{bin}/vim.*           rCx -> editor,
+  @{bin}/sensible-editor rCx -> editor,
+  @{bin}/more            rCx -> pager,
+  @{bin}/less            rCx -> pager,
+  @{bin}/pager           rCx -> pager,
+  @{bin}/gpg{2,}         rCx -> gpg,
+  @{bin}/gpgconf         rCx -> gpg,
+  @{bin}/gpgsm           rCx -> gpg,
+  @{bin}/pgpewrap        rCx -> gpg,
+
+  /usr/share/terminfo/** r,
+
+  /etc/mime.types r,
+
+  # Mutt mailcap search path
+  /etc/{mutt/,}mailcap      r,
+  /usr/{local/,}etc/mailcap r,
+  owner @{HOME}/.mailcap    r,
+
   # Mutt config files
   /usr/share/mutt/**         r,
   /etc/{mutt/,}Muttrc        r,
@@ -42,7 +78,7 @@ profile mutt @{exec_path} {
   owner /{var/,}tmp/mutt*    lrwk,
 
   # Needed for the edit operation.
-  @{HOME}/ r,
+  owner @{HOME}/ r,
 
   # User mbox
   # Could be a file or dir depending on mbox_type variable
@@ -66,43 +102,6 @@ profile mutt @{exec_path} {
   # Common location for mail aliases
   owner @{HOME}/.mail_aliases r,
   
-  /usr/share/terminfo/** r,
-
-  /etc/mime.types r,
- 
-  # Mutt mailcap search path
-  owner @{HOME}/.mailcap    r,
-  /etc/{mutt/,}mailcap      r,
-  /usr/{local/,}etc/mailcap r,
-
-  # Used to exec programs defined in the mailcap.
-  # There are countless programs that can be executed from the mailcap.
-  # This profile includes only the most basic.
-  @{bin}/{,ba,da}sh  rix,
- 
-  @{bin}/sendmail                rPUx,
-  /usr/libexec/sendmail/sendmail rPUx,
-  @{bin}/ispell       rPUx, 
-  # TODO: Add a profile for abook (Most distros don't ship this anymore though)
-  @{bin}/abook        rPUx,
-  @{bin}/mutt_dotlock rix,
-  #Misc mutt scripts
-  @{lib}/mutt/*       rix,
- 
-  @{bin}/w3m             rCx -> html-renderer,
-  @{bin}/lynx            rCx -> html-renderer,
-  @{bin}/vim             rCx -> editor,
-  @{bin}/vim.*           rCx -> editor,
-  @{bin}/sensible-editor rCx -> editor,
-  @{bin}/more            rCx -> pager,
-  @{bin}/less            rCx -> pager,
-  @{bin}/pager           rCx -> pager,
-  @{bin}/gpg{2,}         rCx -> gpg,
-  @{bin}/gpgconf         rCx -> gpg,
-  @{bin}/gpgsm           rCx -> gpg,
-  @{bin}/pgpewrap        rCx -> gpg,
-  
-
   profile html-renderer {
     include <abstractions/base>
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -49,7 +49,7 @@ profile mutt @{exec_path} {
   owner /tmp/mutt* lrwk,
 
   # Needed for the edit operation.
-  @{HOME} r,
+  @{HOME}/ r,
 
   # User mbox
   owner /var/{spool/,}mail/* rwk,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -97,7 +97,9 @@ profile mutt @{exec_path} {
   @{bin}/more            rCx -> pager,
   @{bin}/less            rCx -> pager,
   @{bin}/pager           rCx -> pager,
-  @{bin}/gpg{2,}         rCx -> gpg, 
+  @{bin}/gpg{2,}         rCx -> gpg,
+  @{bin}/gpgconf         rCx -> gpg,
+  @{bin}/gpgsm           rCx -> gpg,
   @{bin}/pgpewrap        rCx -> gpg,
   
 
@@ -171,6 +173,8 @@ profile mutt @{exec_path} {
     include <abstractions/nameservice-strict>
 
     @{bin}/gpg{,2}  mrix,
+    @{bin}/gpgconf  mr,
+    @{bin}/gpgsm    mr,
     @{bin}/pgpewrap mr,
 
     owner @{HOME}/@{XDG_GPG_DIR}/ rw,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -30,7 +30,7 @@ profile mutt @{exec_path} {
   @{bin}/{,ba,da}sh               rix,
  
   @{bin}/sendmail                rPUx,
-  /usr/libexec/sendmail/sendmail rPUx,
+  @{lib}/sendmail/sendmail rPUx,
   @{bin}/ispell                  rPUx, 
   # TODO: Add a profile for abook (Most distros don't ship this anymore though)
   @{bin}/abook                   rPUx,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -6,7 +6,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /{usr/,}bin/mutt
+@{exec_path} = @{bin}/mutt
 profile mutt @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
@@ -77,29 +77,29 @@ profile mutt @{exec_path} {
   # Used to exec programs defined in the mailcap.
   # There are countless programs that can be executed from the mailcap.
   # This profile includes only the most basic.
-  /{usr/,}bin/{,ba,da}sh  rix,
+  @{bin}/{,ba,da}sh  rix,
  
   /{usr/,}{s,}bin/sendmail rPUx, 
-  /{usr/,}bin/ispell       rPUx, 
+  @{bin}/ispell       rPUx, 
   # TODO: Add a profile for abook (Most distros don't ship this anymore though)
-  /{usr/,}bin/abook        rPUx, 
+  @{bin}/abook        rPUx, 
  
-  /{usr/,}bin/w3m             rCx -> html-renderer,
-  /{usr/,}bin/lynx            rCx -> html-renderer,
-  /{usr/,}bin/vim             rCx -> editor,
-  /{usr/,}bin/sensible-editor rCx -> editor,
-  /{usr/,}bin/more            rCx -> pager,
-  /{usr/,}bin/less            rCx -> pager,
-  /{usr/,}bin/pager           rCx -> pager,
-  /{usr/,}bin/gpg{2,}         rCx -> gpg, 
-  /{usr/,}bin/pgpewrap        rCx -> gpg,
+  @{bin}/w3m             rCx -> html-renderer,
+  @{bin}/lynx            rCx -> html-renderer,
+  @{bin}/vim             rCx -> editor,
+  @{bin}/sensible-editor rCx -> editor,
+  @{bin}/more            rCx -> pager,
+  @{bin}/less            rCx -> pager,
+  @{bin}/pager           rCx -> pager,
+  @{bin}/gpg{2,}         rCx -> gpg, 
+  @{bin}/pgpewrap        rCx -> gpg,
   
 
   profile html-renderer {
     include <abstractions/base>
 
-    /{usr/,}bin/w3m     mrix,
-    /{usr/,}bin/lynx    mrix,
+    @{bin}/w3m     mrix,
+    @{bin}/lynx    mrix,
     
     owner @{HOME}/.w3m/* rw,
 
@@ -112,11 +112,11 @@ profile mutt @{exec_path} {
     include <abstractions/base>
     include <abstractions/nameservice-strict>
 
-    /{usr/,}bin/sensible-editor        mr,
-    /{usr/,}bin/vim                  mrix,
-    /{usr/,}bin/vim.*                mrix,
-    /{usr/,}bin/{,ba,da}sh            rix,
-    /{usr/,}bin/which{,.debianutils}  rix,
+    @{bin}/sensible-editor        mr,
+    @{bin}/vim                  mrix,
+    @{bin}/vim.*                mrix,
+    @{bin}/{,ba,da}sh            rix,
+    @{bin}/which{,.debianutils}  rix,
 
     /usr/share/vim/{,**} r,
     /usr/share/terminfo/** r,
@@ -143,9 +143,9 @@ profile mutt @{exec_path} {
     include <abstractions/base>
     include <abstractions/consoles>
   
-    /{usr/,}bin/less  mr,
-    /{usr/,}bin/more  mr,
-    /{usr/,}bin/pager mr,
+    @{bin}/less  mr,
+    @{bin}/more  mr,
+    @{bin}/pager mr,
     
     owner @{HOME}/.lesshsQ r,
     owner @{HOME}/.local/state/ r,
@@ -164,8 +164,8 @@ profile mutt @{exec_path} {
     include <abstractions/base>
     include <abstractions/nameservice-strict>
 
-    /{usr/,}bin/gpg{,2}  mrix,
-    /{usr/,}bin/pgpewrap mr,
+    @{bin}/gpg{,2}  mrix,
+    @{bin}/pgpewrap mr,
 
     owner @{HOME}/@{XDG_GPG_DIR}/ rw,
     owner @{HOME}/@{XDG_GPG_DIR}/** rwkl -> @{HOME}/@{XDG_GPG_DIR}/**,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -50,8 +50,8 @@ profile mutt @{exec_path} {
   owner @{HOME}/postponed    rwk,
   owner @{HOME}/sent         rwk,
   # User maildir
-  owner @{HOME}/{M,m}ail/    rw,
-  owner @{HOME}/{M,m}ail/**  rwk, 
+  owner @{user_mail_dirs}/ rw,
+  owner @{user_mail_dirs}/** rwlk -> @{user_mail_dirs}/**,
 
   # Trusted certificate store
   owner @{HOME}/.mutt_certificates rwk,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -23,10 +23,10 @@ profile mutt @{exec_path} {
   @{exec_path} mr,
 
   # Mutt config files
-  /usr/{local/,}share/mutt/Muttrc r,
-  /etc/{mutt/,}Muttrc             r,
-  owner @{HOME}/.mutt/**          r,
-  owner @{HOME}/.muttrc*          r,
+  /usr/share/mutt/**     r,
+  /etc/{mutt/,}Muttrc    r,
+  owner @{HOME}/.mutt/** r,
+  owner @{HOME}/.muttrc* r,
 
   owner @{HOME}/.cache/mutt rwk,
 
@@ -77,7 +77,6 @@ profile mutt @{exec_path} {
  
   # Mutt mailcap search path
   owner @{HOME}/.mailcap    r,
-  /usr/share/mutt/mailcap   r,
   /etc/{mutt/,}mailcap      r,
   /usr/{local/,}etc/mailcap r,
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -46,9 +46,11 @@ profile mutt @{exec_path} {
   @{HOME}/ r,
 
   # User mbox
-  owner /var/{spool/,}mail/* rwlk,
-  owner @{HOME}/postponed    rwk,
-  owner @{HOME}/sent         rwk,
+  # Could be a file or dir depending on mbox_type variable
+  owner /var/{spool/,}mail/*             rwlk,
+  owner @{HOME}/{mbox,postponed,sent}*   rwlk,
+  owner @{HOME}/{mbox,postponed,sent}/   rw,
+  owner @{HOME}/{mbox,postponed,sent}/** rwlk,
   # User maildir
   owner @{user_mail_dirs}/ rw,
   owner @{user_mail_dirs}/** rwlk -> @{user_mail_dirs}/**,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -100,7 +100,7 @@ profile mutt @{exec_path} {
   owner /{var/,}tmp/mutt*    lrwk,
 
   # Used When viewing attachments
-  owner /tmp/* lrw,
+  owner /{var/,}tmp/* lrw,
   
   profile html-renderer {
     include <abstractions/base>

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -25,22 +25,21 @@ profile mutt @{exec_path} {
   @{exec_path} mr,
 
   # Mutt config files
-  /usr/share/mutt/**     r,
-  /etc/{mutt/,}Muttrc    r,
-  owner @{HOME}/.mutt/** r,
-  owner @{HOME}/.muttrc* r,
+  /usr/share/mutt/**         r,
+  /etc/{mutt/,}Muttrc        r,
+  /etc/{mutt/,}Muttrc.d/{*,} r,
+  owner @{HOME}/.mutt/**     r,
+  owner @{HOME}/.muttrc*     r,
 
   owner @{HOME}/.cache/mutt rwk,
 
   # Used When viewing attachments
   owner /tmp/*              lrw,
 
-  #Needed to open a mailbox (at least an imap one)
-  owner /tmp/.mutt*/  rw,
-  owner /tmp/.mutt*/* lrwk,
-
-  # Might be able to get away without this
-  owner /tmp/mutt* lrwk,
+  # Needed to compose a message
+  owner /{var/,}tmp/.mutt*/  rw,
+  owner /{var/,}tmp/.mutt*/* lrwk,
+  owner /{var/,}tmp/mutt*    lrwk,
 
   # Needed for the edit operation.
   @{HOME}/ r,
@@ -89,6 +88,7 @@ profile mutt @{exec_path} {
   @{bin}/w3m             rCx -> html-renderer,
   @{bin}/lynx            rCx -> html-renderer,
   @{bin}/vim             rCx -> editor,
+  @{bin}/vim.*           rCx -> editor,
   @{bin}/sensible-editor rCx -> editor,
   @{bin}/more            rCx -> pager,
   @{bin}/less            rCx -> pager,
@@ -105,7 +105,7 @@ profile mutt @{exec_path} {
     
     owner @{HOME}/.w3m/* rw,
 
-    owner /tmp/mutt* rw,
+    owner /{var/,}tmp/mutt* rw,
 
     include if exists <local/mutt_html-renderer>
   }
@@ -136,7 +136,7 @@ profile mutt @{exec_path} {
     owner @{HOME}/.cache/vim/** wr,
    
     # This is the file that holds the message
-    owner /tmp/mutt* rw,
+    owner /{var/,}tmp/{.,}mutt* rw,
 
     include if exists <local/mutt_editor>
   }
@@ -157,7 +157,7 @@ profile mutt @{exec_path} {
     /usr/share/file/misc/magic.mgc r,
   
     # This is the file that holds the message
-    owner /tmp/mutt* rw,
+    owner /{var/,}tmp/mutt* rw,
 
     include if exists <local/mutt_pager>
   }
@@ -172,7 +172,7 @@ profile mutt @{exec_path} {
     owner @{HOME}/@{XDG_GPG_DIR}/ rw,
     owner @{HOME}/@{XDG_GPG_DIR}/** rwkl -> @{HOME}/@{XDG_GPG_DIR}/**,
   
-    owner /tmp/mutt* lrw,
+    owner /{var/,}tmp/mutt* lrw,
     
     include if exists <local/mutt_gpg>
   }

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -56,9 +56,9 @@ profile mutt @{exec_path} {
   /etc/mime.types r,
 
   # Mutt mailcap search path
-  /etc/{mutt/,}mailcap      r,
-  /usr/{local/,}etc/mailcap r,
-  owner @{HOME}/.mailcap    r,
+  /etc/{mutt/,}mailcap   r,
+  /usr/etc/mailcap       r,
+  owner @{HOME}/.mailcap r,
 
   # Mutt config files
   /usr/share/mutt/**         r,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -155,7 +155,7 @@ profile mutt @{exec_path} {
     @{bin}/more  mr,
     @{bin}/pager mr,
     
-    owner @{HOME}/.lesshsQ r,
+    owner @{HOME}/.lesshs* r,
     owner @{HOME}/.local/state/ r,
     owner @{HOME}/.local/state/less* rw,
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -80,7 +80,8 @@ profile mutt @{exec_path} {
   # This profile includes only the most basic.
   @{bin}/{,ba,da}sh  rix,
  
-  /{usr/,}{s,}bin/sendmail rPUx, 
+  @{bin}/sendmail                rPUx,
+  /usr/libexec/sendmail/sendmail rPUx,
   @{bin}/ispell       rPUx, 
   # TODO: Add a profile for abook (Most distros don't ship this anymore though)
   @{bin}/abook        rPUx, 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -9,9 +9,16 @@ include <tunables/global>
 @{exec_path} = /{usr/,}bin/mutt
 profile mutt @{exec_path} {
   include <abstractions/base>
-  include <abstractions/nameservice>
+  include <abstractions/nameservice-strict>
   include <abstractions/openssl>
+  include <abstractions/ssl_certs>
   include <abstractions/consoles>
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
 
   @{exec_path} mr,
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -149,7 +149,10 @@ profile mutt @{exec_path} {
   profile pager {
     include <abstractions/base>
     include <abstractions/consoles>
-  
+
+    /usr/share/terminfo/** r,
+    /usr/share/file/misc/magic.mgc r,
+
     @{bin}/less  mr,
     @{bin}/more  mr,
     @{bin}/pager mr,
@@ -157,9 +160,6 @@ profile mutt @{exec_path} {
     owner @{HOME}/.lesshs* r,
     owner @{HOME}/.local/state/ r,
     owner @{HOME}/.local/state/less* rw,
-
-    /usr/share/terminfo/** r,
-    /usr/share/file/misc/magic.mgc r,
   
     # This is the file that holds the message
     owner /{var/,}tmp/mutt* rw,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -156,7 +156,7 @@ profile mutt @{exec_path} {
     owner @{HOME}/.local/state/ r,
     owner @{HOME}/.local/state/less* rw,
 
-    /usr/share/terminfo/x/xterm-256color r,
+    /usr/share/terminfo/** r,
     /usr/share/file/misc/magic.mgc r,
   
     # This is the file that holds the message

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -13,6 +13,8 @@ profile mutt @{exec_path} {
   include <abstractions/openssl>
   include <abstractions/ssl_certs>
   include <abstractions/consoles>
+  include <abstractions/user-download-strict>
+  include <abstractions/user-read>
 
   network inet dgram,
   network inet6 dgram,
@@ -30,15 +32,8 @@ profile mutt @{exec_path} {
 
   owner @{HOME}/.cache/mutt rwk,
 
-  # Used when saving attachments. Mutt saves attachments in whatever directory
-  # it's launched from, which is most likely @{HOME}.
-  owner @{HOME}/*           lw,
-  owner @{HOME}/.mutt*/{,*} w,
-  owner @{HOME}/Downloads/* lw,
   # Used When viewing attachments
   owner /tmp/*              lrw,
-  # Allow uploading attachments from Public
-  owner @{HOME}/Public/*    r,
 
   #Needed to open a mailbox (at least an imap one)
   owner /tmp/.mutt*/  rw,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -46,7 +46,7 @@ profile mutt @{exec_path} {
   @{HOME}/ r,
 
   # User mbox
-  owner /var/{spool/,}mail/* rwk,
+  owner /var/{spool/,}mail/* rwlk,
   owner @{HOME}/postponed    rwk,
   owner @{HOME}/sent         rwk,
   # User maildir

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -1,0 +1,178 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2023 Zane Zakraisek <zz@eng.utah.edu>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = /{usr/,}bin/mutt
+profile mutt @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+  include <abstractions/consoles>
+
+  @{exec_path} mr,
+
+  # Mutt config files
+  /usr/{local/,}share/mutt/Muttrc r,
+  /etc/{mutt/,}Muttrc             r,
+  owner @{HOME}/.mutt/**          r,
+  owner @{HOME}/.muttrc*          r,
+
+  owner @{HOME}/.cache/mutt rwk,
+
+  # Used when saving attachments. Mutt saves attachments in whatever directory
+  # it's launched from, which is most likely @{HOME}.
+  owner @{HOME}/*           lw,
+  owner @{HOME}/.mutt*/     w,
+  owner @{HOME}/.mutt*/*    w,
+  owner @{HOME}/Downloads/* lw,
+  # Used When viewing attachments
+  owner /tmp/*              lrw,
+  # Allow uploading attachments from Public
+  owner @{HOME}/Public/*    r,
+
+  #Needed to open a mailbox (at least an imap one)
+  owner /tmp/.mutt*/  rw,
+  owner /tmp/.mutt*/* lrwk,
+
+  # Might be able to get away without this
+  owner /tmp/mutt* lrwk,
+
+  # Needed for the edit operation.
+  @{HOME} r,
+
+  # User mbox
+  owner /var/{spool/,}mail/* rwk,
+  owner @{HOME}/postponed    rwk,
+  owner @{HOME}/sent         rwk,
+  # User maildir
+  owner @{HOME}/{M,m}ail/    rw,
+  owner @{HOME}/{M,m}ail/**  rwk, 
+
+  # Trusted certificate store
+  owner @{HOME}/.mutt_certificates rwk,
+  
+  # Mutt history file
+  owner @{HOME}/.mutthistory rwk,
+  
+  # Mutt signature file
+  owner @{HOME}/.signature r,
+
+  # Common location for mail aliases
+  owner @{HOME}/.mail_aliases r,
+  
+  /usr/share/terminfo/** r,
+
+  /etc/mime.types r,
+ 
+  # Mutt mailcap search path
+  owner @{HOME}/.mailcap    r,
+  /usr/share/mutt/mailcap   r,
+  /etc/{mutt/,}mailcap      r,
+  /usr/{local/,}etc/mailcap r,
+
+  # Used to exec programs defined in the mailcap.
+  # There are countless programs that can be executed from the mailcap.
+  # This profile includes only the most basic.
+  /{usr/,}bin/{,ba,da}sh  rix,
+ 
+  /{usr/,}{s,}bin/sendmail rPUx, 
+  /{usr/,}bin/ispell       rPUx, 
+  # TODO: Add a profile for abook (Most distros don't ship this anymore though)
+  /{usr/,}bin/abook        rPUx, 
+ 
+  /{usr/,}bin/w3m             rCx -> html-renderer,
+  /{usr/,}bin/lynx            rCx -> html-renderer,
+  /{usr/,}bin/vim             rCx -> editor,
+  /{usr/,}bin/sensible-editor rCx -> editor,
+  /{usr/,}bin/more            rCx -> pager,
+  /{usr/,}bin/less            rCx -> pager,
+  /{usr/,}bin/pager           rCx -> pager,
+  /{usr/,}bin/gpg{2,}         rCx -> gpg, 
+  /{usr/,}bin/pgpewrap        rCx -> gpg,
+  
+
+  profile html-renderer {
+    include <abstractions/base>
+
+    /{usr/,}bin/w3m     mrix,
+    /{usr/,}bin/lynx    mrix,
+    
+    owner @{HOME}/.w3m/* rw,
+
+    owner /tmp/mutt* rw,
+
+    include if exists <local/mutt_html-renderer>
+  }
+
+  profile editor {
+    include <abstractions/base>
+    include <abstractions/nameservice-strict>
+
+    /{usr/,}bin/sensible-editor        mr,
+    /{usr/,}bin/vim                  mrix,
+    /{usr/,}bin/vim.*                mrix,
+    /{usr/,}bin/{,ba,da}sh            rix,
+    /{usr/,}bin/which{,.debianutils}  rix,
+
+    /usr/share/vim/{,**} r,
+    /usr/share/terminfo/** r,
+
+    /etc/vimrc r,
+    /etc/vim/{,**} r,
+
+    owner @{HOME}/.selected_editor r,
+    owner @{HOME}/.viminfo{,.tmp} rw,
+    owner @{HOME}/.vimrc r,
+  
+    # Vim swap file 
+    owner @{HOME}/ r,
+    owner @{HOME}/.cache/ r,
+    owner @{HOME}/.cache/vim/** wr,
+   
+    # This is the file that holds the message
+    owner /tmp/mutt* rw,
+
+    include if exists <local/mutt_editor>
+  }
+  
+  profile pager {
+    include <abstractions/base>
+    include <abstractions/consoles>
+  
+    /{usr/,}bin/less mrix,
+    /{usr/,}bin/more mrix,
+    
+    owner @{HOME}/.lesshsQ r,
+    owner @{HOME}/.local/state/ r,
+    owner @{HOME}/.local/state/less* rw,
+
+    /usr/share/terminfo/x/xterm-256color r,
+    /usr/share/file/misc/magic.mgc r,
+  
+    # This is the file that holds the message
+    owner /tmp/mutt* rw,
+
+    include if exists <local/mutt_pager>
+  }
+
+  profile gpg {
+    include <abstractions/base>
+    include <abstractions/nameservice-strict>
+
+    /{usr/,}bin/gpg{,2}  mrix,
+    /{usr/,}bin/pgpewrap mr,
+
+    owner @{HOME}/@{XDG_GPG_DIR}/ rw,
+    owner @{HOME}/@{XDG_GPG_DIR}/** rwkl -> @{HOME}/@{XDG_GPG_DIR}/**,
+  
+    owner /tmp/mutt* lrw,
+    
+    include if exists <local/mutt_gpg>
+  }
+
+  include if exists <local/mutt>
+}

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -84,7 +84,10 @@ profile mutt @{exec_path} {
   /usr/libexec/sendmail/sendmail rPUx,
   @{bin}/ispell       rPUx, 
   # TODO: Add a profile for abook (Most distros don't ship this anymore though)
-  @{bin}/abook        rPUx, 
+  @{bin}/abook        rPUx,
+  @{bin}/mutt_dotlock rix,
+  #Misc mutt scripts
+  @{lib}/mutt/*       rix,
  
   @{bin}/w3m             rCx -> html-renderer,
   @{bin}/lynx            rCx -> html-renderer,

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -67,8 +67,6 @@ profile mutt @{exec_path} {
   owner @{HOME}/.mutt/**     r,
   owner @{HOME}/.muttrc*     r,
 
-  owner @{HOME}/.cache/mutt rwk,
-
   # Needed for the edit operation.
   owner @{HOME}/ r,
 
@@ -93,6 +91,8 @@ profile mutt @{exec_path} {
 
   # Common location for mail aliases
   owner @{HOME}/.mail_aliases r,
+
+  owner @{HOME}/.cache/mutt rwk,
 
   # Needed to compose a message
   owner /{var/,}tmp/.mutt*/  rw,


### PR DESCRIPTION
AppArmor profile for mutt.

There are an innumerable number of mutt configurations. This AA profile is intended to work with a stock mutt config. Any customizations should be placed in local/mutt