### PR TITLE
Add Profiles for imv and zathura

### DIFF
--- a/apparmor.d/groups/apps/imv-wayland
+++ b/apparmor.d/groups/apps/imv-wayland
@@ -13,6 +13,7 @@ profile imv @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/user-read>
 
   @{exec_path} mr,
 
@@ -22,11 +23,7 @@ profile imv @{exec_path} {
 
   owner @{user_config_dirs}/imv/config r,
 
-  owner @{HOME}/ r,
-  owner @{HOME}/[^.]**  r,
-
-  owner /mnt/** r,
-  owner /media/** r,
+  owner @{MOUNTDIRS}/{,**} r,
 
   owner @{run}/user/@{uid}/imv-*.sock w,
 

--- a/apparmor.d/groups/apps/imv-wayland
+++ b/apparmor.d/groups/apps/imv-wayland
@@ -1,0 +1,34 @@
+# apparmor.d - Full set of apparmor profiles
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/imv-wayland
+profile imv @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/freedesktop.org>
+  include <abstractions/fonts>
+  include <abstractions/fontconfig-cache-read>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /etc/imv_config r,
+  /usr/share/X11/xkb/** r,
+  /tmp/ r,
+
+  owner @{user_config_dirs}/imv/config
+
+  owner @{HOME}/ r,
+  owner @{HOME}/[^.]**  r,
+
+  owner /mnt/** r,
+  owner /media/** r,
+
+  owner @{run}/user/*/imv-*.sock w,
+
+  include if exists <local/imv-wayland>
+}

--- a/apparmor.d/groups/apps/imv-wayland
+++ b/apparmor.d/groups/apps/imv-wayland
@@ -20,7 +20,7 @@ profile imv @{exec_path} {
   /usr/share/X11/xkb/** r,
   /tmp/ r,
 
-  owner @{user_config_dirs}/imv/config
+  owner @{user_config_dirs}/imv/config r,
 
   owner @{HOME}/ r,
   owner @{HOME}/[^.]**  r,
@@ -28,7 +28,7 @@ profile imv @{exec_path} {
   owner /mnt/** r,
   owner /media/** r,
 
-  owner @{run}/user/*/imv-*.sock w,
+  owner @{run}/user/@{uid}/imv-*.sock w,
 
   include if exists <local/imv-wayland>
 }

--- a/apparmor.d/groups/apps/imv-wayland
+++ b/apparmor.d/groups/apps/imv-wayland
@@ -23,8 +23,6 @@ profile imv @{exec_path} {
 
   owner @{user_config_dirs}/imv/config r,
 
-  owner @{MOUNTDIRS}/{,**} r,
-
   owner @{run}/user/@{uid}/imv-*.sock w,
 
   include if exists <local/imv-wayland>

--- a/apparmor.d/groups/apps/zathura
+++ b/apparmor.d/groups/apps/zathura
@@ -26,8 +26,6 @@ profile zathura @{exec_path} {
   owner @{user_config_dirs}/zathura/** r,
   owner @{user_share_dirs}/zathura/** rwk,
 
-  owner @{MOUNTDIRS}/{,**} r,
-
   owner /tmp/gtkprint* rw,
 
   include if exists <local/zathura>

--- a/apparmor.d/groups/apps/zathura
+++ b/apparmor.d/groups/apps/zathura
@@ -13,10 +13,12 @@ profile zathura @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/nameservice-strict>
   include <abstractions/dconf-write>
+  include <abstractions/gtk>
 
   @{exec_path} mr,
 
-  /usr/share/{,**} r,
+  /usr/share/file/{,**} r,
+  /usr/share/X11/xkb/{,**} r,
   /etc/xdg/{,**} r,
   /etc/zathurarc r,
 

--- a/apparmor.d/groups/apps/zathura
+++ b/apparmor.d/groups/apps/zathura
@@ -1,0 +1,35 @@
+# apparmor.d - Full set of apparmor profiles
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/zathura 
+profile zathura @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/freedesktop.org>
+  include <abstractions/fonts>
+  include <abstractions/fontconfig-cache-read>
+  include <abstractions/nameservice-strict>
+  include <abstractions/dconf-write>
+
+  @{exec_path} mr,
+
+  /usr/share/{,**} r,
+  /etc/xdg/{,**} r,
+  /etc/zathurarc r,
+
+  owner @{user_config_dirs}/zathura/** r,
+  owner @{user_share_dirs}/zathura/** rwk,
+
+  owner @{HOME}/ r,
+  owner @{HOME}/[^.]**  r,
+
+  owner /mnt/** r,
+  owner /media/** r,
+
+  owner /tmp/gtkprint* rw,
+
+  include if exists <local/zathura>
+}

--- a/apparmor.d/groups/apps/zathura
+++ b/apparmor.d/groups/apps/zathura
@@ -14,6 +14,7 @@ profile zathura @{exec_path} {
   include <abstractions/nameservice-strict>
   include <abstractions/dconf-write>
   include <abstractions/gtk>
+  include <abstractions/user-read>
 
   @{exec_path} mr,
 
@@ -25,11 +26,7 @@ profile zathura @{exec_path} {
   owner @{user_config_dirs}/zathura/** r,
   owner @{user_share_dirs}/zathura/** rwk,
 
-  owner @{HOME}/ r,
-  owner @{HOME}/[^.]**  r,
-
-  owner /mnt/** r,
-  owner /media/** r,
+  owner @{MOUNTDIRS}/{,**} r,
 
   owner /tmp/gtkprint* rw,
 


### PR DESCRIPTION
Both profiles include permissions to read all user files that do not start with a dot in $HOME
Additionally, read permissions are included for /mnt and /media as this would include any possible mount points that follow the reference.

The existing user-read abstraction only includes predefined directories and would not allow access to arbitrary directories in $HOME
