### PR TITLE
Abook: Fix missing directory

### DIFF
--- a/apparmor.d/profiles-a-f/abook
+++ b/apparmor.d/profiles-a-f/abook
@@ -25,6 +25,7 @@ profile abook @{exec_path} {
 
   /etc/inputrc r,
 
+  owner @{HOME}/.abook/             rw,
   owner @{HOME}/.abook/abookrc       r,
   owner @{HOME}/.abook/addressbook* rw,
 


### PR DESCRIPTION
Allow abook to create ~/.abook