### PR TITLE
Modifications for qbittorrent profile and qt5.d abstractions

### DIFF
--- a/apparmor.d/abstractions/qt5.d/complete
+++ b/apparmor.d/abstractions/qt5.d/complete
@@ -4,3 +4,7 @@
 
   /usr/share/qt{,5,6}/qtlogging.ini r,
   /usr/share/qt{,5,6}/translations/*.qm r,
+
+  # Qt5CT
+  /usr/share/qt5ct/{,**} r,
+  owner @{HOME}/.config/qt5ct/{,**} r,

--- a/apparmor.d/abstractions/qt5.d/complete
+++ b/apparmor.d/abstractions/qt5.d/complete
@@ -7,4 +7,4 @@
 
   # Qt5CT
   /usr/share/qt5ct/{,**} r,
-  owner @{HOME}/.config/qt5ct/{,**} r,
+  owner @{user_config_dirs}/.config/qt5ct/{,**} r,

--- a/apparmor.d/abstractions/qt5.d/complete
+++ b/apparmor.d/abstractions/qt5.d/complete
@@ -7,4 +7,4 @@
 
   # Qt5CT
   /usr/share/qt5ct/{,**} r,
-  owner @{user_config_dirs}/.config/qt5ct/{,**} r,
+  owner @{user_config_dirs}/qt5ct/{,**} r,

--- a/apparmor.d/profiles-m-r/qbittorrent
+++ b/apparmor.d/profiles-m-r/qbittorrent
@@ -23,6 +23,7 @@ profile qbittorrent @{exec_path} {
   include <abstractions/ibus>
   include <abstractions/nameservice-strict>
   include <abstractions/private-files-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
@@ -90,7 +91,6 @@ profile qbittorrent @{exec_path} {
 
   owner @{user_config_dirs}/qBittorrent/ rw,
   owner @{user_config_dirs}/qBittorrent/** rwkl -> @{user_config_dirs}/qBittorrent/#@{int},
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner @{user_share_dirs}/{,data/}qBittorrent/ rw,
   owner @{user_share_dirs}/{,data/}qBittorrent/** rwl -> @{user_share_dirs}/{,data/}qBittorrent/**/#@{int},


### PR DESCRIPTION
This modifications allow read system and user qt5ct configs for better integrations with other DEs (not-KDE).

Reviewing, I see that there are a series of profiles where these changes can be applied (using abstractions/qt5), which allows us to eliminate a couple of lines from the profiles and in this way they integrate better visually when the profile is activated.

The same could be done with Qt6 and qt6ct, although in Debian Stable, at the moment this has very little interest given that most tools are built using Qt5.

If the change is accepted and there are no problems with making the change in the rest of the profiles, I will proceed with it and send the PR.