### PR TITLE
Qt better support (integration with Qt5CT and Qt6CT)

### DIFF
--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -26,7 +26,6 @@
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics-full>
   include <abstractions/nameservice-strict>
-  include <abstractions/qt5>
   include <abstractions/ssl_certs>
   include <abstractions/thumbnails-cache-read>
   include <abstractions/uim>

--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -26,6 +26,7 @@
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics-full>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/ssl_certs>
   include <abstractions/thumbnails-cache-read>
   include <abstractions/uim>
@@ -104,7 +105,6 @@
   /usr/share/chromium/extensions/{,**} r,
   /usr/share/hwdata/pnp.ids r,
   /usr/share/mozilla/extensions/{,**} r,
-  /usr/share/qt{5,}/translations/*.qm r,
   /usr/share/webext/{,**} r,
 
   /etc/@{name}/{,**} r,

--- a/apparmor.d/abstractions/qt5.d/complete
+++ b/apparmor.d/abstractions/qt5.d/complete
@@ -4,7 +4,9 @@
 
   /usr/share/qt{,5,6}/qtlogging.ini r,
   /usr/share/qt{,5,6}/translations/*.qm r,
+  /usr/share/qt{,5,6}/translations/qtwebengine_locales/*.pak r,
+  /usr/share/qt{,5,6}/resources/*.pak r,
 
-  # Qt5CT
-  /usr/share/qt5ct/{,**} r,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
+  # Qt5CT and Qt6CT support and integration with others DE
+  /usr/share/qt{,5,6}ct/{,**} r,
+  owner @{user_config_dirs}/qt{,5,6}ct/{,**} r,

--- a/apparmor.d/abstractions/video.d/complete
+++ b/apparmor.d/abstractions/video.d/complete
@@ -3,6 +3,3 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
   @{sys}/devices/@{pci}/video4linux/video@{int}/uevent r,
-
-  # /dev access devices
-  /dev/video@{int} rw,

--- a/apparmor.d/abstractions/video.d/complete
+++ b/apparmor.d/abstractions/video.d/complete
@@ -3,3 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
   @{sys}/devices/@{pci}/video4linux/video@{int}/uevent r,
+
+  # /dev access devices
+  /dev/video@{int} rw,

--- a/apparmor.d/groups/akonadi/akonadi_akonotes_resource
+++ b/apparmor.d/groups/akonadi/akonadi_akonotes_resource
@@ -13,12 +13,12 @@ profile akonadi_akonotes_resource @{exec_path} {
   include <abstractions/freedesktop.org>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/X-strict>
 
   @{exec_path} mr,
 
   /usr/share/hwdata/*.ids r,
-  /usr/share/qt/translations/*.qm r,
 
   /etc/xdg/kdeglobals r,
   /etc/xdg/kwinrc r,

--- a/apparmor.d/groups/akonadi/akonadi_birthdays_resource
+++ b/apparmor.d/groups/akonadi/akonadi_birthdays_resource
@@ -13,6 +13,7 @@ profile akonadi_birthdays_resource @{exec_path} {
   include <abstractions/freedesktop.org>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/X-strict>
 
   @{exec_path} mr,
@@ -20,7 +21,6 @@ profile akonadi_birthdays_resource @{exec_path} {
   /usr/share/akonadi/plugins/{,**} r,
   /usr/share/hwdata/*.ids r,
   /usr/share/icu/@{int}.@{int}/*.dat r,
-  /usr/share/qt{5,}/translations/*.qm r,
 
   /etc/xdg/kdeglobals r,
   /etc/xdg/kwinrc r,

--- a/apparmor.d/groups/akonadi/akonadi_ical_resource
+++ b/apparmor.d/groups/akonadi/akonadi_ical_resource
@@ -11,6 +11,7 @@ profile akonadi_ical_resource @{exec_path} {
   include <abstractions/base>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/X-strict>
 
   @{exec_path} mr,
@@ -18,7 +19,6 @@ profile akonadi_ical_resource @{exec_path} {
   /usr/share/hwdata/*.ids r,
   /usr/share/icons/{,**} r,
   /usr/share/mime/{,**} r,
-  /usr/share/qt/translations/*.qm r,
 
   owner @{user_cache_dirs}/akonadi_ical_resource_[0-9]/{,*} rwl,
   owner @{user_cache_dirs}/icon-cache.kcache rw,

--- a/apparmor.d/groups/akonadi/akonadi_mailmerge_agent
+++ b/apparmor.d/groups/akonadi/akonadi_mailmerge_agent
@@ -13,6 +13,7 @@ profile akonadi_mailmerge_agent @{exec_path} {
   include <abstractions/freedesktop.org>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/X-strict>
 
   network inet dgram,
@@ -24,8 +25,6 @@ profile akonadi_mailmerge_agent @{exec_path} {
 
   /usr/share/hwdata/*.ids r,
   /usr/share/icu/@{int}.@{int}/*.dat r,
-  /usr/share/qt{5,}/translations/*.qm r,
-  /usr/share/qt5/qtlogging.ini r,
 
   /etc/xdg/kdeglobals r,
   /etc/xdg/kwinrc r,

--- a/apparmor.d/groups/apps/calibre
+++ b/apparmor.d/groups/apps/calibre
@@ -30,6 +30,7 @@ profile calibre @{exec_path} {
   include <abstractions/nvidia>
   include <abstractions/opencl-intel>
   include <abstractions/python>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-shader-cache>
@@ -66,8 +67,6 @@ profile calibre @{exec_path} {
 
   /usr/share/calibre/{,**} r,
   /usr/share/hwdata/pnp.ids r,
-  /usr/share/qt5/**.pak r,
-  /usr/share/qt5ct/** r,
 
   /etc/fstab r,
   /etc/inputrc r,

--- a/apparmor.d/groups/apps/calibre
+++ b/apparmor.d/groups/apps/calibre
@@ -95,8 +95,6 @@ profile calibre @{exec_path} {
   owner @{user_cache_dirs}/gstreamer-@{int}/ rw,
   owner @{user_cache_dirs}/gstreamer-@{int}/registry.*.bin{,.tmp@{rand6}} rw,
 
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-
   owner /tmp/calibre_*_tmp_*/{,**} rw,
   owner /tmp/calibre-*/{,**} rw,
   owner /tmp/@{int}-*/ rw,

--- a/apparmor.d/groups/apps/flameshot
+++ b/apparmor.d/groups/apps/flameshot
@@ -17,6 +17,7 @@ profile flameshot @{exec_path} {
   include <abstractions/freedesktop.org>
   include <abstractions/dri-enumerate>
   include <abstractions/mesa>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/thumbnails-cache-read>
@@ -43,9 +44,6 @@ profile flameshot @{exec_path} {
   owner @{user_config_dirs}/flameshot/#@{int} rw,
   owner @{user_config_dirs}/flameshot/flameshot.ini* rwl -> @{user_config_dirs}/flameshot/#@{int},
   owner @{user_config_dirs}/flameshot/flameshot.ini.lock rwk,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,

--- a/apparmor.d/groups/apps/telegram-desktop
+++ b/apparmor.d/groups/apps/telegram-desktop
@@ -21,6 +21,7 @@ profile telegram-desktop @{exec_path} {
   include <abstractions/freedesktop.org>
   include <abstractions/audio-client>
   include <abstractions/user-download-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-shader-cache>
@@ -76,9 +77,6 @@ profile telegram-desktop @{exec_path} {
   /etc/machine-id r,
 
   /usr/share/hwdata/pnp.ids r,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   # Allowed apps to open
   @{lib}/firefox/firefox rPx,

--- a/apparmor.d/groups/freedesktop/polkit-kde-authentication-agent
+++ b/apparmor.d/groups/freedesktop/polkit-kde-authentication-agent
@@ -30,13 +30,10 @@ profile polkit-kde-authentication-agent @{exec_path} flags=(attach_disconnected)
 
   @{lib}/polkit-[0-9]/polkit-agent-helper-[0-9] rPx,
 
-  /usr/share/qt5ct/** r,
-
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
 
   owner @{user_config_dirs}/breezerc r,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner @{user_cache_dirs}/icon-cache.kcache rw,
 

--- a/apparmor.d/groups/kde/kio_http_cache_cleaner
+++ b/apparmor.d/groups/kde/kio_http_cache_cleaner
@@ -10,11 +10,11 @@ include <tunables/global>
 @{exec_path} += @{lib}/@{multiarch}/{,libexec/}kf{5,6}/kio_http_cache_cleaner
 profile kio_http_cache_cleaner @{exec_path} {
   include <abstractions/base>
+  include <abstractions/qt5>
 
   @{exec_path} mr,
 
   /usr/share/icu/@{int}.@{int}/*.dat r,
-  /usr/share/qt{5,}/translations/*.qm r,
 
   owner @{user_cache_dirs}/kio_http/{,*} rw,
   owner @{user_config_dirs}/kio_httprc r,

--- a/apparmor.d/groups/kde/kiod
+++ b/apparmor.d/groups/kde/kiod
@@ -20,7 +20,6 @@ profile kiod @{exec_path} {
 
   /usr/share/icons/breeze/index.theme r,
   /usr/share/mime/{,**} r,
-  /usr/share/qt/translations/*.qm r,
 
   owner @{user_cache_dirs}/icon-cache.kcache rw,
 

--- a/apparmor.d/groups/kde/kscreenlocker_greet
+++ b/apparmor.d/groups/kde/kscreenlocker_greet
@@ -45,8 +45,6 @@ profile kscreenlocker_greet @{exec_path} {
   @{lib}/@{multiarch}/libexec/kcheckpass rPx,
 
   /usr/share/plasma/** r,
-  /usr/share/qt/translations/*.qm r,
-  /usr/share/qt5ct/** r,
   /usr/share/wallpapers/{,**} r,
   /usr/share/wallpapers/Path/contents/images/*.{jpg,png} r,
   /usr/share/wayland-sessions/{,*.desktop} r,

--- a/apparmor.d/groups/kde/kwalletd
+++ b/apparmor.d/groups/kde/kwalletd
@@ -26,9 +26,6 @@ profile kwalletd @{exec_path} {
   @{bin}/gpgsm   rCx -> gpg,
 
   /usr/share/color-schemes/{,**} r,
-  /usr/share/qt/translations/*.qm r,
-  /usr/share/qt{5,6}/qtlogging.ini r,
-  /usr/share/qt5ct/** r,
 
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
@@ -40,7 +37,6 @@ profile kwalletd @{exec_path} {
   owner @{user_config_dirs}/kwalletrc r,
   owner @{user_config_dirs}/kwalletrc rwl -> @{user_config_dirs}/#@{int},
   owner @{user_config_dirs}/kwalletrc.lock rwk,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner @{user_share_dirs}/kwalletd/ rw,
   owner @{user_share_dirs}/kwalletd/** rwkl -> @{user_share_dirs}/kwalletd/#@{int},

--- a/apparmor.d/groups/kde/kwalletmanager
+++ b/apparmor.d/groups/kde/kwalletmanager
@@ -23,7 +23,6 @@ profile kwalletmanager @{exec_path} {
   @{exec_path} mr,
 
   /usr/share/kxmlgui5/kwalletmanager5/kwalletmanager.rc r,
-  /usr/share/qt5ct/** r,
 
   /etc/fstab r,
   /etc/machine-id r,
@@ -32,7 +31,6 @@ profile kwalletmanager @{exec_path} {
 
   owner @{user_cache_dirs}/icon-cache.kcache rw,
   owner @{user_config_dirs}/#@{int} rw,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_config_dirs}/kwalletmanager5rc rw,
   owner @{user_config_dirs}/kwalletmanager5rc.* rwl -> @{user_config_dirs}/#@{int},
   owner @{user_config_dirs}/kwalletmanager5rc.lock rwk,

--- a/apparmor.d/groups/kde/kwin_wayland
+++ b/apparmor.d/groups/kde/kwin_wayland
@@ -42,7 +42,6 @@ profile kwin_wayland @{exec_path} flags=(attach_disconnected mediate_deleted) {
   /usr/share/libinput/{,**} r,
   /usr/share/pipewire/client.conf r,
   /usr/share/plasma/desktoptheme/** r,
-  /usr/share/qt/translations/*.qm r,
 
   /etc/pipewire/client.conf.d/ r,
   /etc/xdg/kscreenlockerrc r,

--- a/apparmor.d/groups/kde/sddm-greeter
+++ b/apparmor.d/groups/kde/sddm-greeter
@@ -30,7 +30,6 @@ profile sddm-greeter @{exec_path} {
 
   /usr/share/desktop-base/*-theme/login/*.svg r,
   /usr/share/plasma/desktoptheme/** r,
-  /usr/share/qt5ct/** r,
   /usr/share/sddm/{,**} r,
   /usr/share/wayland-sessions/{,*.desktop} r,
   /usr/share/xsessions/{,*.desktop} r,
@@ -58,7 +57,6 @@ profile sddm-greeter @{exec_path} {
   owner @{user_cache_dirs}/sddm-greeter/{,**} rwl,
 
   owner @{user_config_dirs}/plasmarc r,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   # If one is blocked, the others are probed.
   deny owner @{HOME}/#@{int} mrw,

--- a/apparmor.d/profiles-a-f/birdtray
+++ b/apparmor.d/profiles-a-f/birdtray
@@ -15,6 +15,7 @@ profile birdtray @{exec_path} {
   include <abstractions/fonts>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/freedesktop.org>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/mesa>
   include <abstractions/dri-enumerate>
@@ -49,10 +50,6 @@ profile birdtray @{exec_path} {
   owner @{HOME}/.thunderbird/*.*/{Imap,}Mail/ r,
   owner @{HOME}/.thunderbird/*.*/{Imap,}Mail/**/ r,
   owner @{HOME}/.thunderbird/*.*/{Imap,}Mail/**/*.msf r,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/hwdata/pnp.ids r,
 

--- a/apparmor.d/profiles-a-f/convertall
+++ b/apparmor.d/profiles-a-f/convertall
@@ -18,6 +18,7 @@ profile convertall @{exec_path} {
   include <abstractions/mesa>
   include <abstractions/dri-enumerate>
   include <abstractions/python>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/nameservice-strict>
 
@@ -29,10 +30,6 @@ profile convertall @{exec_path} {
   owner @{HOME}/.convertall rw,
 
   deny owner @{PROC}/@{pid}/cmdline r,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/convertall/{,**} r,
   /usr/share/doc/convertall/{,*} r,

--- a/apparmor.d/profiles-a-f/fritzing
+++ b/apparmor.d/profiles-a-f/fritzing
@@ -18,6 +18,7 @@ profile fritzing @{exec_path} {
   include <abstractions/nameservice-strict>
   include <abstractions/mesa>
   include <abstractions/dri-enumerate>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
 
   network inet dgram,
@@ -34,10 +35,6 @@ profile fritzing @{exec_path} {
 
   owner @{HOME}/@{XDG_DOCUMENTS_DIR}/Fritzing/ rw,
   owner @{HOME}/@{XDG_DOCUMENTS_DIR}/Fritzing/** rw,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/fritzing/{,**} r,
 

--- a/apparmor.d/profiles-g-l/kanyremote
+++ b/apparmor.d/profiles-g-l/kanyremote
@@ -21,6 +21,7 @@ profile kanyremote @{exec_path} {
   include <abstractions/python>
   include <abstractions/dri-enumerate>
   include <abstractions/mesa>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
 
@@ -59,9 +60,6 @@ profile kanyremote @{exec_path} {
 
   owner @{HOME}/ r,
   owner @{HOME}/.anyRemote/{,*} rw,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/anyremote/{,**} r,
 

--- a/apparmor.d/profiles-g-l/keepassxc
+++ b/apparmor.d/profiles-g-l/keepassxc
@@ -18,6 +18,7 @@ profile keepassxc @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
@@ -39,7 +40,6 @@ profile keepassxc @{exec_path} {
 
   /usr/share/hwdata/pnp.ids r,
   /usr/share/keepassxc/{,**} r,
-  /usr/share/qt*/{,**} r,
 
   /etc/fstab r,
   /etc/machine-id r,
@@ -58,7 +58,6 @@ profile keepassxc @{exec_path} {
   owner @{user_config_dirs}/BraveSoftware/Brave-Browser{,-Beta,-Dev}/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json rw,
   owner @{user_config_dirs}/chromium/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json rw,
   owner @{user_config_dirs}/google-chrome{,-beta,-unstable}/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json rw,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_config_dirs}/{,kdedefaults/}kdeglobals r,
 
   # Database locations

--- a/apparmor.d/profiles-g-l/linssid
+++ b/apparmor.d/profiles-g-l/linssid
@@ -18,6 +18,7 @@ profile linssid @{exec_path} {
   include <abstractions/nameservice-strict>
   include <abstractions/dri-enumerate>
   include <abstractions/mesa>
+  include <abstractions/qt5>
 
   # For reading/saving config/log files when linssid is started via pkexec
   #capability dac_read_search,
@@ -56,9 +57,6 @@ profile linssid @{exec_path} {
   /usr/share/linssid/{,*} r,
 
   /usr/share/hwdata/pnp.ids r,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   owner @{PROC}/@{pid}/fd/ r,
   owner @{PROC}/@{pid}/net/wireless r,

--- a/apparmor.d/profiles-m-r/megasync
+++ b/apparmor.d/profiles-m-r/megasync
@@ -19,6 +19,7 @@ profile megasync @{exec_path} {
   include <abstractions/dri-enumerate>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/user-download-strict>
@@ -45,10 +46,6 @@ profile megasync @{exec_path} {
   owner @{HOME}/ r,
   owner "@{user_share_dirs}/data/Mega Limited/" rw,
   owner "@{user_share_dirs}/data/Mega Limited/**" rwkl -> "@{user_share_dirs}/data/Mega Limited/MEGAsync/#@{int}",
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   owner @{user_config_dirs}/QtProject.conf r,
 

--- a/apparmor.d/profiles-m-r/merkaartor
+++ b/apparmor.d/profiles-m-r/merkaartor
@@ -17,6 +17,7 @@ profile merkaartor @{exec_path} {
   include <abstractions/mesa>
   include <abstractions/dri-common>
   include <abstractions/dri-enumerate>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/nameservice-strict>
   include <abstractions/ssl_certs>
@@ -43,10 +44,6 @@ profile merkaartor @{exec_path} {
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/hwdata/pnp.ids r,
 

--- a/apparmor.d/profiles-m-r/minitube
+++ b/apparmor.d/profiles-m-r/minitube
@@ -19,6 +19,7 @@ profile minitube @{exec_path} {
   include <abstractions/mesa>
   include <abstractions/audio-client>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-shader-cache>
@@ -57,10 +58,6 @@ profile minitube @{exec_path} {
   owner "@{user_cache_dirs}/Flavio Tordini/" rw,
   owner "@{user_cache_dirs}/Flavio Tordini/Minitube/" rw,
   owner "@{user_cache_dirs}/Flavio Tordini/Minitube/**" rwl -> "@{user_cache_dirs}/Flavio Tordini/Minitube/**",
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   deny /dev/ r,
        /dev/shm/#@{int} rw,

--- a/apparmor.d/profiles-m-r/mkvtoolnix-gui
+++ b/apparmor.d/profiles-m-r/mkvtoolnix-gui
@@ -17,6 +17,7 @@ profile mkvtoolnix-gui @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
@@ -30,7 +31,6 @@ profile mkvtoolnix-gui @{exec_path} {
   @{bin}/mkvmerge      rPx,
   @{bin}/mediainfo-gui rPx,
 
-  /usr/share/qt5ct/** r,
   /usr/share/hwdata/pnp.ids r,
 
   /etc/fstab r,
@@ -49,8 +49,6 @@ profile mkvtoolnix-gui @{exec_path} {
   owner @{user_cache_dirs}/bunkus.org/mkvtoolnix-gui/ rw,
   owner @{user_cache_dirs}/bunkus.org/mkvtoolnix-gui/**/ rw,
   owner @{user_cache_dirs}/bunkus.org/mkvtoolnix-gui/**/@{hex} rw,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner /tmp/#@{int} rw,
   owner /tmp/MKVToolNix-GUI-MuxConfig-* rwl -> /tmp/#@{int},

--- a/apparmor.d/profiles-m-r/pinentry-qt
+++ b/apparmor.d/profiles-m-r/pinentry-qt
@@ -26,7 +26,6 @@ profile pinentry-qt @{exec_path} {
 
   /usr/share/hwdata/pnp.ids r,
   /usr/share/icu/@{int}.@{int}/*.dat r,
-  /usr/share/qt5ct/** r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,
@@ -38,7 +37,6 @@ profile pinentry-qt @{exec_path} {
 
   owner @{user_config_dirs}/kdeglobals r,
   owner @{user_config_dirs}/kwinrc r,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner /tmp/xauth_@{rand6} r,
   owner /dev/shm/#@{int} rw,

--- a/apparmor.d/profiles-m-r/psi
+++ b/apparmor.d/profiles-m-r/psi
@@ -19,6 +19,7 @@ profile psi @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
@@ -44,7 +45,6 @@ profile psi @{exec_path} {
 
   /usr/share/hwdata/pnp.ids r,
   /usr/share/psi/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /etc/debian_version r,
   /etc/fstab r,
@@ -60,7 +60,6 @@ profile psi @{exec_path} {
   owner @{user_config_dirs}/autostart/psi.desktop rw,
   owner @{user_config_dirs}/psi/ rw,
   owner @{user_config_dirs}/psi/** rwkl -> @{user_config_dirs}/psi/#@{int},
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_share_dirs}/psi/ rw,
   owner @{user_share_dirs}/psi/** rwk,
 

--- a/apparmor.d/profiles-m-r/psi-plus
+++ b/apparmor.d/profiles-m-r/psi-plus
@@ -19,6 +19,7 @@ profile psi-plus @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
@@ -44,7 +45,6 @@ profile psi-plus @{exec_path} {
 
   /usr/share/hwdata/pnp.ids r,
   /usr/share/psi-plus/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /etc/debian_version r,
   /etc/fstab r,
@@ -58,7 +58,6 @@ profile psi-plus @{exec_path} {
   owner @{user_config_dirs}/autostart/psi-plus.desktop rw,
   owner @{user_config_dirs}/psi+/ rw,
   owner @{user_config_dirs}/psi+/** rwkl -> @{user_config_dirs}/psi+/#@{int},
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_share_dirs}/psi+/ rw,
   owner @{user_share_dirs}/psi+/** rwk,
 

--- a/apparmor.d/profiles-m-r/qnapi
+++ b/apparmor.d/profiles-m-r/qnapi
@@ -17,6 +17,7 @@ profile qnapi @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/user-download-strict>
@@ -42,7 +43,6 @@ profile qnapi @{exec_path} {
   @{bin}/xdg-open  rCx -> open,
   @{lib}/firefox/firefox rPx,
 
-  /usr/share/qt5ct/** r,
   /usr/share/hwdata/pnp.ids r,
 
   /etc/fstab r,
@@ -60,7 +60,6 @@ profile qnapi @{exec_path} {
   owner @{user_config_dirs}/qnapi.ini.* rwl -> @{user_config_dirs}/#@{int},
   owner @{user_config_dirs}/qnapi.ini.mlXXXY rwl -> @{user_config_dirs}/#@{int},
 
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_cache_dirs}/ rw,
 
         /tmp/ r,

--- a/apparmor.d/profiles-m-r/qpdfview
+++ b/apparmor.d/profiles-m-r/qpdfview
@@ -17,6 +17,7 @@ profile qpdfview @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/thumbnails-cache-read>
@@ -35,7 +36,6 @@ profile qpdfview @{exec_path} {
 
   /usr/share/hwdata/pnp.ids r,
   /usr/share/poppler/** r,
-  /usr/share/qt5ct/** r,
   /usr/share/djvu/** r,
 
   /etc/fstab r,
@@ -54,8 +54,6 @@ profile qpdfview @{exec_path} {
 
   owner @{user_share_dirs}/qpdfview/ rw,
   owner @{user_share_dirs}/qpdfview/** rwk,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner /dev/shm/#@{int} rw,
   owner /tmp/@{hex} rw,

--- a/apparmor.d/profiles-m-r/qtox
+++ b/apparmor.d/profiles-m-r/qtox
@@ -16,6 +16,7 @@ profile qtox @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/user-download-strict>
 
@@ -28,8 +29,6 @@ profile qtox @{exec_path} {
   @{exec_path} mr,
 
   @{open_path}  rPx -> child-open,
-
-  /usr/share/qt5ct/** r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,
@@ -49,9 +48,6 @@ profile qtox @{exec_path} {
 
   owner @{user_share_dirs}/qTox/ rw,
   owner @{user_share_dirs}/qTox/** rw,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner @{PROC}/@{pid}/cmdline r,
         @{PROC}/sys/kernel/core_pattern r,  # for KCrash::initialize()

--- a/apparmor.d/profiles-m-r/quiterss
+++ b/apparmor.d/profiles-m-r/quiterss
@@ -15,6 +15,7 @@ profile quiterss @{exec_path} {
   include <abstractions/fonts>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/freedesktop.org>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/mesa>
@@ -36,10 +37,6 @@ profile quiterss @{exec_path} {
   @{exec_path} mr,
 
   @{bin}/xdg-open rCx -> open,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/quiterss/** r,
   owner @{user_config_dirs}/QuiteRss/ rw,

--- a/apparmor.d/profiles-m-r/rpi-imager
+++ b/apparmor.d/profiles-m-r/rpi-imager
@@ -21,6 +21,7 @@ profile rpi-imager @{exec_path} {
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
   include <abstractions/opencl>
+  include <abstractions/qt5>
   include <abstractions/qt5-shader-cache>
   include <abstractions/ssl_certs>
   include <abstractions/user-download-strict>
@@ -43,7 +44,6 @@ profile rpi-imager @{exec_path} {
   /etc/fstab r,
   /etc/X11/cursors/*.theme r,
   /usr/share/hwdata/pnp.ids r,
-  /usr/share/qt5ct/** r,
   /usr/share/X11/xkb/{,**} r,
 
   /etc/machine-id r,
@@ -53,7 +53,6 @@ profile rpi-imager @{exec_path} {
   owner "@{user_cache_dirs}/Raspberry Pi/**" rwl -> "@{user_cache_dirs}/Raspberry Pi/**",
   owner "@{user_config_dirs}/Raspberry Pi/{,**}" rw,
   owner @{user_cache_dirs}/ rw,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_config_dirs}/QtProject.conf r,
 
   owner @{PROC}/@{pid}/cmdline r,

--- a/apparmor.d/profiles-s-z/smplayer
+++ b/apparmor.d/profiles-s-z/smplayer
@@ -19,6 +19,7 @@ profile smplayer @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/user-download-strict>
@@ -45,7 +46,6 @@ profile smplayer @{exec_path} {
   @{bin}/youtube-dl rPx,
   @{bin}/yt-dlp     rPx,
 
-  /usr/share/qt5ct/** r,
   /usr/share/hwdata/pnp.ids r,
 
   /etc/fstab r,
@@ -62,7 +62,6 @@ profile smplayer @{exec_path} {
   owner @{user_config_dirs}/smplayer/ rw,
   owner @{user_config_dirs}/smplayer/* rwkl -> @{user_config_dirs}/smplayer/#@{int},
 
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_cache_dirs}/#@{int} rw,
 
   owner /tmp/qtsingleapp-smplay-* rw,

--- a/apparmor.d/profiles-s-z/smtube
+++ b/apparmor.d/profiles-s-z/smtube
@@ -18,6 +18,7 @@ profile smtube @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/ssl_certs>
   include <abstractions/gstreamer>
@@ -42,10 +43,6 @@ profile smtube @{exec_path} {
   owner @{user_config_dirs}/smplayer/hdpi.ini rw,
   owner @{user_config_dirs}/smplayer/hdpi.ini.lock rwk,
   owner @{user_config_dirs}/smplayer/hdpi.ini.* rwl -> @{user_config_dirs}/smplayer/#@{int},
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   # Cache
   owner @{user_cache_dirs}/ rw,

--- a/apparmor.d/profiles-s-z/strawberry
+++ b/apparmor.d/profiles-s-z/strawberry
@@ -19,6 +19,7 @@ profile strawberry @{exec_path} {
   include <abstractions/dri-enumerate>
   include <abstractions/mesa>
   include <abstractions/audio-client>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/nameservice-strict>
@@ -64,9 +65,6 @@ profile strawberry @{exec_path} {
 
   owner @{user_cache_dirs}/xine-lib/ rw,
   owner @{user_cache_dirs}/xine-lib/plugins.cache{,.new} rw,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
        owner @{PROC}/@{pid}/mountinfo r,
        owner @{PROC}/@{pid}/mounts r,

--- a/apparmor.d/profiles-s-z/thunderbird
+++ b/apparmor.d/profiles-s-z/thunderbird
@@ -27,6 +27,7 @@ profile thunderbird @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/ssl_certs>
   include <abstractions/thumbnails-cache-read>
   include <abstractions/uim>
@@ -93,7 +94,6 @@ profile thunderbird @{exec_path} {
   /usr/share/gvfs/remote-volume-monitors/{,*} r,
   /usr/share/lightning/{,**} r,
   /usr/share/mozilla/extensions/{,**} r,
-  /usr/share/qt5ct/** r,
   /usr/share/xul-ext/kwallet5/* r,
 
   /etc/@{name}/{,**} r,
@@ -109,7 +109,6 @@ profile thunderbird @{exec_path} {
 
   owner @{user_config_dirs}/kwalletrc r,
   owner @{user_config_dirs}/mimeapps.list.* rw,
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner @{user_mail_dirs}/ rw,
   owner @{user_mail_dirs}/** rwl -> @{user_mail_dirs}/**,

--- a/apparmor.d/profiles-s-z/transmission-qt
+++ b/apparmor.d/profiles-s-z/transmission-qt
@@ -15,6 +15,7 @@ profile transmission-qt @{exec_path} {
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
   include <abstractions/private-files-strict>
+  include <abstractions/qt5>
   include <abstractions/qt5-settings-write>
   include <abstractions/ssl_certs>
   include <abstractions/user-download-strict>
@@ -46,10 +47,6 @@ profile transmission-qt @{exec_path} {
        owner @{PROC}/@{pid}/mounts r,
              @{PROC}/@{pid}/net/route r,
              @{PROC}/sys/kernel/random/uuid r,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /usr/share/hwdata/pnp.ids r,
 

--- a/apparmor.d/profiles-s-z/usbguard-applet-qt
+++ b/apparmor.d/profiles-s-z/usbguard-applet-qt
@@ -16,6 +16,7 @@ profile usbguard-applet-qt @{exec_path} {
   include <abstractions/fontconfig-cache-read>
   include <abstractions/freedesktop.org>
   include <abstractions/mesa>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/dri-enumerate>
   include <abstractions/nameservice-strict>
@@ -38,10 +39,6 @@ profile usbguard-applet-qt @{exec_path} {
         @{PROC}/sys/kernel/core_pattern r,
 
   /usr/share/hwdata/pnp.ids r,
-
-  # To configure Qt5 settings (theme, font, icons, etc.) under DE/WM without Qt integration
-  owner @{user_config_dirs}/qt5ct/{,**} r,
-  /usr/share/qt5ct/** r,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,

--- a/apparmor.d/profiles-s-z/vidcutter
+++ b/apparmor.d/profiles-s-z/vidcutter
@@ -17,6 +17,7 @@ profile vidcutter @{exec_path} {
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
   include <abstractions/python>
+  include <abstractions/qt5>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-shader-cache>
@@ -49,8 +50,6 @@ profile vidcutter @{exec_path} {
 
   owner @{user_config_dirs}/vidcutter/ rw,
   owner @{user_config_dirs}/vidcutter/* rwkl -> @{user_config_dirs}/vidcutter/#@{int},
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner /tmp/vidcutter-@{uuid} w,
   owner /tmp/#@{int} rw,

--- a/apparmor.d/profiles-s-z/vlc
+++ b/apparmor.d/profiles-s-z/vlc
@@ -26,6 +26,7 @@ profile vlc @{exec_path} {
   include <abstractions/gstreamer>
   include <abstractions/ibus>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/ssl_certs>
   include <abstractions/user-download-strict>
 
@@ -56,7 +57,6 @@ profile vlc @{exec_path} {
   owner @{user_cache_dirs}/vlc/ rw,
   owner @{user_cache_dirs}/vlc/{,**} rw,
 
-  owner @{user_config_dirs}/qt5ct/{,**} r,
   owner @{user_config_dirs}/vlc/ rw,
   owner @{user_config_dirs}/vlc/** rwkl -> @{user_config_dirs}/vlc/#@{int},
 

--- a/apparmor.d/profiles-s-z/wpa-gui
+++ b/apparmor.d/profiles-s-z/wpa-gui
@@ -17,14 +17,12 @@ profile wpa-gui @{exec_path} {
   include <abstractions/gtk>
   include <abstractions/mesa>
   include <abstractions/nameservice-strict>
+  include <abstractions/qt5>
   include <abstractions/X>
 
   @{exec_path} mr,
 
   /usr/share/hwdata/pnp.ids r,
-  /usr/share/qt5ct/** r,
-
-  owner @{user_config_dirs}/qt5ct/{,**} r,
 
   owner /tmp/wpa_ctrl_@{pid}-[0-9] w,
   owner /dev/shm/#@{int} rw,


### PR DESCRIPTION
In this PR what we are looking for is to simplify profile access to the Qt5CT and Qt6CT customization tools, along with some small improvements that apply to QT5 and QT6 in general (in their directories /usr/share/qt{5,6 })

In this way, using the abstraction/qt5 we guarantee that the apps that need it can access the desktop customization/theming, and other resources necessary for proper functioning by default (translations, among other resources in /usr/share for Qt5 and Qt6).

**Note**: to keep in mind, we only enter abstractions/qt5 where abstractions/kde-strict is not specified, since the latter includes abstractions/qt5.