### PR TITLE
Fix access to /tmp using libpam-tmpdir in Debian for qBittorrent

### DIFF
--- a/apparmor.d/profiles-m-r/qbittorrent
+++ b/apparmor.d/profiles-m-r/qbittorrent
@@ -108,6 +108,8 @@ profile qbittorrent @{exec_path} {
   owner /tmp/qtsingleapp-qBitto-* rw,
   owner /tmp/qtsingleapp-qBitto-*-lockfile rwk,
   owner /tmp/tmp* rw,
+  owner /tmp/user/@{uid}/.qBittorrent/ rw,
+  owner /tmp/user/@{uid}/.qBittorrent/** rw,
 
   owner @{PROC}/@{pids}/cmdline r,
   owner @{PROC}/@{pids}/comm r,


### PR DESCRIPTION
In Debian with the use of libpam-tmpdir, the paths for $TMP and $TMPDIR for PAM sessions are affected by much stronger rules and permissions, providing additional security to the environment.

Those rules for the directory

`/tmp/user/@{uid}/<affected_program>
`

In the case of qBitorrent this applies to the following directory:

`/tmp/user/@{uid}/.qBitorrent
`

This PR fixes the bug and allows qBittorrent to work correctly under these conditions.

Note: This PR would also have positive effects on Whonix, which uses libpam-tmpdir according to this link
(https://forums.whonix.org/t/make-symlink-attacks-and-other-tmp-based-attacks-harder-or-impossible-using-libpam-tmpdir/8488)