### PR TITLE
New profile: Microsoft Edge and better support in abstractions/chromium

### DIFF
--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -158,6 +158,10 @@
   owner /tmp/tmp.*/ rw,
   owner /tmp/tmp.*/** rwk,
 
+  # libpam-tmpdir support
+  owner /tmp/user/@{uid}/ rw, 
+  owner /tmp/user/@{uid}/** rwk,
+
         /dev/shm/ r,
   owner /dev/shm/.@{domain}* rw,
 

--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -109,6 +109,7 @@
   /etc/@{name}/{,**} r,
   /etc/fstab r,
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r, # Debian ubication
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,

--- a/apparmor.d/abstractions/video.d/complete
+++ b/apparmor.d/abstractions/video.d/complete
@@ -3,3 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
   @{sys}/devices/@{pci}/video4linux/video@{int}/uevent r,
+
+  # Access to video /dev devices
+  /dev/video@{int} rw,

--- a/apparmor.d/abstractions/vulkan-strict
+++ b/apparmor.d/abstractions/vulkan-strict
@@ -15,6 +15,7 @@
   /etc/vulkan/implicit_layer.d/{,*.json} r,
 
   owner @{user_share_dirs}/vulkan/implicit_layer.d/{,*.json} r,
+  owner @{user_cache_dirs}/radv_builtin_shaders64 r, #Vulkan radv shaders cache
 
   @{sys}/class/ r,
   @{sys}/class/drm/ r,
@@ -24,3 +25,4 @@
   @{sys}/devices/@{pci}/drm/card@{int}/metrics/@{uuid}/id r,
 
   include if exists <abstractions/vulkan-strict.d>
+

--- a/apparmor.d/profiles-m-r/msedge
+++ b/apparmor.d/profiles-m-r/msedge
@@ -1,0 +1,37 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2018-2021 Mikhail Morfikov
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{name} = msedge{,-beta,-dev}
+@{domain} = com.microsoft.Edge
+@{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
+@{config_dirs} = @{user_config_dirs}/microsoft-edge{,-beta,-dev}
+@{cache_dirs} = @{user_cache_dirs}/microsoft-edge{,-beta,-dev}
+
+@{exec_path} = @{lib_dirs}/@{name}
+profile msedge /opt/microsoft/msedge{,-beta,-dev}/msedge{,-beta,-dev} {
+  include <abstractions/base>
+  include <abstractions/app/chromium>
+
+  @{exec_path} mrix,
+  @{lib_dirs}/microsoft-edge{,beta,-dev} rpx,
+
+  @{bin}/man  rpux, #  For "chrome --help"
+
+  @{lib_dirs}/xdg-mime       rix, #-> xdg-mime,
+  @{lib_dirs}/xdg-settings   rix, #-> xdg-settings,
+ 
+  @{lib_dirs}/msedge_crashpad_handler rpx,
+
+  @{lib_dirs}/*.so* mr,
+  @{lib_dirs}/WidevineCdm/_platform_specific/linux_*/libwidevinecdm.so mr,
+
+  owner @{user_cache_dirs}/Microsoft/** rwk,
+
+  include if exists <local/msedge>
+}

--- a/apparmor.d/profiles-m-r/msedge
+++ b/apparmor.d/profiles-m-r/msedge
@@ -1,6 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2024 Jose Maldonado <josemald89@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -14,7 +14,7 @@ include <tunables/global>
 @{cache_dirs} = @{user_cache_dirs}/microsoft-edge{,-beta,-dev}
 
 @{exec_path} = @{lib_dirs}/@{name}
-profile msedge /opt/microsoft/msedge{,-beta,-dev}/msedge{,-beta,-dev} {
+profile msedge @{exec_path} {
   include <abstractions/base>
   include <abstractions/app/chromium>
 

--- a/apparmor.d/profiles-m-r/msedge-crashpad-handlers
+++ b/apparmor.d/profiles-m-r/msedge-crashpad-handlers
@@ -1,0 +1,36 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2018-2022 Mikhail Morfikov
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
+@{config_dirs} = @{user_config_dirs}/microsoft-edge{,-beta,-dev}
+
+@{exec_path} = @{lib_dirs}/msedge_crashpad_handler
+profile msedge-crashpad-handler /opt/microsoft/msedge{,-beta,-dev}/msedge_crashpad_handler {
+  include <abstractions/base>
+
+  capability sys_ptrace,
+
+  ptrace peer=msedge,
+  signal (send) peer=msedge,
+
+  @{exec_path} mrix,
+
+  owner "@{config_dirs}/Crash Reports/**" rwk,
+
+        @{PROC}/sys/kernel/yama/ptrace_scope r,
+  owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pids}/mem r,
+  owner @{PROC}/@{pids}/stat r,
+  owner @{PROC}/@{pids}/task/ r,
+
+  @{sys}/devices/system/cpu/cpufreq/policy@{int}/scaling_cur_freq r,
+  @{sys}/devices/system/cpu/cpufreq/policy@{int}/scaling_max_freq r,
+
+  include if exists <local/msedge-crashpad-handler>
+}

--- a/apparmor.d/profiles-m-r/msedge-crashpad-handlers
+++ b/apparmor.d/profiles-m-r/msedge-crashpad-handlers
@@ -1,6 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2018-2022 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2024 Jose Maldonado <josemald89@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -11,7 +11,7 @@ include <tunables/global>
 @{config_dirs} = @{user_config_dirs}/microsoft-edge{,-beta,-dev}
 
 @{exec_path} = @{lib_dirs}/msedge_crashpad_handler
-profile msedge-crashpad-handler /opt/microsoft/msedge{,-beta,-dev}/msedge_crashpad_handler {
+profile msedge-crashpad-handler @{exec_path} {
   include <abstractions/base>
 
   capability sys_ptrace,

--- a/apparmor.d/profiles-m-r/msedge-sandbox
+++ b/apparmor.d/profiles-m-r/msedge-sandbox
@@ -1,6 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2024 Jose Maldonado <josemald89@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -10,7 +10,7 @@ include <tunables/global>
 @{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
 
 @{exec_path} = @{lib_dirs}/msedge-sandbox
-profile msedge-sandbox /opt/microsoft/msedge{,-beta,-dev}/msedge-sandbox {
+profile msedge-sandbox @{exec_path} {
   include <abstractions/base>
 
   capability setgid,

--- a/apparmor.d/profiles-m-r/msedge-sandbox
+++ b/apparmor.d/profiles-m-r/msedge-sandbox
@@ -1,0 +1,32 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2018-2021 Mikhail Morfikov
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
+
+@{exec_path} = @{lib_dirs}/msedge-sandbox
+profile msedge-sandbox /opt/microsoft/msedge{,-beta,-dev}/msedge-sandbox {
+  include <abstractions/base>
+
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability sys_chroot,
+  capability sys_resource,
+
+  @{exec_path} mr,
+
+  @{lib_dirs}/msedge{,-beta,-dev}      rpx,
+
+        @{PROC} r,
+        @{PROC}/@{pids}/ r,
+  owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/oom_{,score_}adj rw,
+
+  include if exists <local/msedge-sandbox>
+}

--- a/apparmor.d/profiles-m-r/msedge-wrapper
+++ b/apparmor.d/profiles-m-r/msedge-wrapper
@@ -1,6 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2024 Jose Maldonado <josemald89@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -10,7 +10,7 @@ include <tunables/global>
 @{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
 
 @{exec_path} = @{lib_dirs}/microsoft-edge{,-beta,-dev}
-profile msedge-wrapper /opt/microsoft/msedge{,-beta,-dev}/microsoft-edge{,-beta,-dev} flags=(attach_disconnected) {
+profile msedge-wrapper @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/consoles>
 

--- a/apparmor.d/profiles-m-r/msedge-wrapper
+++ b/apparmor.d/profiles-m-r/msedge-wrapper
@@ -1,0 +1,40 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2018-2021 Mikhail Morfikov
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{lib_dirs} = /opt/microsoft/msedge{,-beta,-dev}
+
+@{exec_path} = @{lib_dirs}/microsoft-edge{,-beta,-dev}
+profile msedge-wrapper /opt/microsoft/msedge{,-beta,-dev}/microsoft-edge{,-beta,-dev} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/consoles>
+
+  @{exec_path} r,
+
+  @{sh_path}                   rix,
+  @{bin}/cat                   rix,
+  @{bin}/dirname               rix,
+  @{bin}/mkdir                 rix,
+  @{bin}/readlink              rix,
+  @{bin}/touch                 rix,
+  @{bin}/which{,.debianutils}  rix,
+
+  @{lib_dirs}/msedge   rpx,
+
+  owner @{user_config_dirs}/msedge-flags.conf r,
+
+  owner @{PROC}/@{pid}/fd/* rw,
+
+  # File Inherit
+  owner @{HOME}/.xsession-errors w,
+
+  # Silencer
+  deny @{user_share_dirs}/gvfs-metadata/* r,
+
+  include if exists <local/msedge-wrapper>
+}


### PR DESCRIPTION
This commit add new profile for Microsoft Edge browser and variants (beta,dev). The new profile is based in actual chrome profile. Tested with actual Edge, in Debian Stable and enforced rules. All ok using GPU Rasterization and Vulkan, not HWAccel for encoding video because this is very unstable yet in all Chromium based browsers.

Add support for **libpam-tmpdir** for **abstractions/app/chromium** and all browser using these abstractions (Chrome, Chromium, Edge, and others). This fix access and use of browser with **libpam-tmpdir** installed (Debian and Whonix)

Fix a denied access to RADV user cache (Vulkan-amdgpu) in abstractions/app/chromium (Vulkan is optional in Chromium-based browser, but the backend is perfectly usable now).