### PR TITLE
plasmashell: add local wallpaper rules

### DIFF
--- a/apparmor.d/groups/kde/plasmashell
+++ b/apparmor.d/groups/kde/plasmashell
@@ -106,6 +106,7 @@ profile plasmashell @{exec_path} flags=(mediate_deleted) {
   owner @{user_cache_dirs}/ksvg-elements.lock rwlk,
   owner @{user_cache_dirs}/ksycoca{5,6}_* rwlk -> @{user_cache_dirs}/#@{int},
   owner @{user_cache_dirs}/org.kde.dirmodel-qml.kcache rw,
+  owner @{user_cache_dirs}/plasma_engine_potd/{,**} rw,
   owner @{user_cache_dirs}/plasma_theme_*.kcache rw,
   owner @{user_cache_dirs}/plasma-svgelements rw,
   owner @{user_cache_dirs}/plasma-svgelements.@{rand6} rwl -> @{user_cache_dirs}/#@{int},
@@ -165,6 +166,7 @@ profile plasmashell @{exec_path} flags=(mediate_deleted) {
   owner @{user_share_dirs}/plasma/{,**} r,
   owner @{user_share_dirs}/plasmashell/** rwkl -> @{user_share_dirs}/plasmashell/**,
   owner @{user_share_dirs}/user-places.xbel{,*} rwl,
+  owner @{user_share_dirs}/wallpapers/{,**} rw,
 
         /tmp/.mount_nextcl@{rand6}/{,*} r,
   owner @{tmp}/#@{int} rw,


### PR DESCRIPTION
Allow plasmashell to access wallpapers in the cache folder and the user share folder.