### PR TITLE
Fix access to OpenSC configuration

### DIFF
--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -119,6 +119,7 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   /etc/mailcap r,
   /etc/mime.types r,
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
   /etc/sysconfig/proxy r,
   /etc/xdg/* r,
   /etc/xul-ext/kwallet5.js r,

--- a/apparmor.d/groups/gnome/gsd-smartcard
+++ b/apparmor.d/groups/gnome/gsd-smartcard
@@ -31,6 +31,7 @@ profile gsd-smartcard @{exec_path} flags=(attach_disconnected) {
   /usr/share/glib-2.0/schemas/gschemas.compiled r,
 
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
 
   owner @{GDM_HOME}/greeter-dconf-defaults r,
   owner @{gdm_config_dirs}/dconf/user r,

--- a/apparmor.d/groups/gnome/seahorse
+++ b/apparmor.d/groups/gnome/seahorse
@@ -36,6 +36,8 @@ profile seahorse @{exec_path} {
 
   /etc/pki/trust/blocklist/ r,
   /etc/gcrypt/hwf.deny r,
+  /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
 
   owner @{HOME}/@{XDG_SSH_DIR}/{,**} r,
 

--- a/apparmor.d/groups/whonix/torbrowser
+++ b/apparmor.d/groups/whonix/torbrowser
@@ -64,6 +64,7 @@ profile torbrowser @{exec_path} flags=(attach_disconnected) {
   /etc/mailcap r,
   /etc/mime.types r,
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
   /etc/sysconfig/proxy r,
   /etc/xdg/* r,
   /etc/xul-ext/kwallet5.js r,

--- a/apparmor.d/profiles-m-r/pkcs11-register
+++ b/apparmor.d/profiles-m-r/pkcs11-register
@@ -13,6 +13,7 @@ profile pkcs11-register @{exec_path} {
   @{exec_path} mr,
 
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
 
   owner @{HOME}/.mozilla/firefox/*/pkcs11.txt rw,
   owner @{HOME}/.mozilla/firefox/profiles.ini r,

--- a/apparmor.d/profiles-m-r/rngd
+++ b/apparmor.d/profiles-m-r/rngd
@@ -25,6 +25,7 @@ profile rngd @{exec_path} flags=(attach_disconnected) {
   /etc/conf.d/rngd r,
   /etc/machine-id r,
   /etc/opensc.conf r,
+  /etc/opensc/opensc.conf r,
   /var/lib/dbus/machine-id r,
 
   @{sys}/devices/virtual/misc/hw_random/rng_available r,


### PR DESCRIPTION
Hi! 

These changes fix access to OpenSC config in Debian and derivates. In this case, the correct path is `/etc/opensc/opensc.conf`. Only read permission. 