### PR TITLE
Minor fixes for various abstractions/profiles (exec permission and noise reduction)

### DIFF
--- a/apparmor.d/abstractions/thumbnails-cache-read
+++ b/apparmor.d/abstractions/thumbnails-cache-read
@@ -7,7 +7,7 @@
   owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/ r,
   owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/ r,
   owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/*.png r,
-  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png r -> @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int},
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png r,
   owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png.@{rand6} r,
   owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int} r,
 

--- a/apparmor.d/abstractions/thumbnails-cache-read
+++ b/apparmor.d/abstractions/thumbnails-cache-read
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
   owner @{user_cache_dirs}/thumbnails/ r,
-  owner @{user_cache_dirs}/thumbnails/{*large,normal}/ r,
-  owner @{user_cache_dirs}/thumbnails/{*large,normal}/*.png r,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/ r,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/ r,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/*.png r,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png r -> @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int},
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png.@{rand6} r,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int} r,
 
   include if exists <abstractions/thumbnails-cache-read.d>

--- a/apparmor.d/abstractions/thumbnails-cache-write
+++ b/apparmor.d/abstractions/thumbnails-cache-write
@@ -4,9 +4,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
   owner @{user_cache_dirs}/thumbnails/ rw,
-  owner @{user_cache_dirs}/thumbnails/{large,normal}/ rw,
-  owner @{user_cache_dirs}/thumbnails/{large,normal}/*.png rwl -> @{user_cache_dirs}/thumbnails/{large,normal}/#@{int},
-  owner @{user_cache_dirs}/thumbnails/{large,normal}/*.png.@{rand6} rw,
-  owner @{user_cache_dirs}/thumbnails/{large,normal}/#@{int} rw,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/ rw,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/ rw,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/gnome-thumbnail-factory/*.png rw,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png rwl -> @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int},
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/*.png.@{rand6} rw,
+  owner @{user_cache_dirs}/thumbnails/{fail,*large,normal}/#@{int} rw,
 
   include if exists <abstractions/thumbnails-cache-write.d>

--- a/apparmor.d/profiles-a-f/anacron
+++ b/apparmor.d/profiles-a-f/anacron
@@ -17,6 +17,7 @@ profile anacron @{exec_path} {
 
   @{sh_path}         rix,
   @{bin}/run-parts   rCx -> run-parts,
+  @{bin}/exim4       rPx,
 
   / r,
   /etc/anacrontab r,

--- a/apparmor.d/profiles-a-f/exim4
+++ b/apparmor.d/profiles-a-f/exim4
@@ -55,5 +55,7 @@ profile exim4 @{exec_path} {
         @{run}/exim4/ r,
   owner @{run}/exim4/exim.pid rw,
 
+  @{PROC}/sys/net/ipv6/conf/all/disable_ipv6 r,
+
   include if exists <local/exim4>
 }


### PR DESCRIPTION
Hi! Three minor changes in abstractions/profiles

First, the `abstractions/thumbnails-cache-read` and `abstractions/thumbnails-cache-write`, right now don´t have access to `@{user_cache_dirs}/thumbnails/fail` folder.  For this reason, the `gsd-housekeepin` profile is unable to enter these directories and perform the daily cleaning task that it executes on them.

Adding these dirs to the abstractions solves the problem, and at the same time takes advantage of both abstractions having the same content (and their respective permissions). 

Second, `exim4` in Debian Stable, access to `@{PROC}/sys/net/ipv6/conf/all/disable_ipv6` in read mode, for checking connection with IPv6. This change allow this access and reduce noise in log for `exim4`. 

Finally, `anacron` runs `exim4` upon completion of task execution. This is a default behavior in Debian Stable (12) and right now the profile for `anacron` denied this permission. This change allow this exec permission, and allows `anacron` task information to be sent using `exim4` successfully. 

All this change are tested in Debian Stable using enforced rules for all profile mentioned. Not problem, all ok. 

