### PR TITLE
Create editor abstraction

### DIFF
--- a/apparmor.d/abstractions/app/editor
+++ b/apparmor.d/abstractions/app/editor
@@ -2,7 +2,6 @@
 # Copyright (C) 2024 Zane Zakraisek <zz@eng.utah.edu>
 # SPDX-License-Identifier: GPL-2.0-only
 
-  include <abstractions/base>
   include <abstractions/nameservice-strict>
 
   @{bin}/sensible-editor        mr,
@@ -26,4 +25,4 @@
   owner @{user_cache_dirs}/ r,
   owner @{user_cache_dirs}/vim/** wr,
 
-  include if exists <abstractions/editor.d>
+  include if exists <abstractions/app/editor.d>

--- a/apparmor.d/abstractions/editor
+++ b/apparmor.d/abstractions/editor
@@ -1,0 +1,29 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2024 Zane Zakraisek <zz@eng.utah.edu>
+# SPDX-License-Identifier: GPL-2.0-only
+
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  @{bin}/sensible-editor        mr,
+  @{bin}/vim                  mrix,
+  @{bin}/vim.*                mrix,
+  @{sh_path}                   rix,
+  @{bin}/which{,.debianutils}  rix,
+
+  /usr/share/vim/{,**} r,
+  /usr/share/terminfo/** r,
+
+  /etc/vimrc r,
+  /etc/vim/{,**} r,
+
+  owner @{HOME}/.selected_editor r,
+  owner @{HOME}/.viminfo{,.tmp} rw,
+  owner @{HOME}/.vimrc r,
+
+  # Vim swap file 
+  owner @{HOME}/ r,
+  owner @{user_cache_dirs}/ r,
+  owner @{user_cache_dirs}/vim/** wr,
+
+  include if exists <abstractions/editor.d>

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -104,30 +104,8 @@ profile mutt @{exec_path} {
   }
 
   profile editor {
-    include <abstractions/base>
-    include <abstractions/nameservice-strict>
+    include <abstractions/editor>
 
-    @{bin}/sensible-editor        mr,
-    @{bin}/vim                  mrix,
-    @{bin}/vim.*                mrix,
-    @{bin}/{,ba,da}sh            rix,
-    @{bin}/which{,.debianutils}  rix,
-
-    /usr/share/vim/{,**} r,
-    /usr/share/terminfo/** r,
-
-    /etc/vimrc r,
-    /etc/vim/{,**} r,
-
-    owner @{HOME}/.selected_editor r,
-    owner @{HOME}/.viminfo{,.tmp} rw,
-    owner @{HOME}/.vimrc r,
-  
-    # Vim swap file 
-    owner @{HOME}/ r,
-    owner @{user_cache_dirs}/ r,
-    owner @{user_cache_dirs}/vim/** wr,
-   
     # This is the file that holds the message
     owner /{var/,}tmp/{.,}mutt* rw,
 

--- a/apparmor.d/profiles-m-r/mutt
+++ b/apparmor.d/profiles-m-r/mutt
@@ -104,7 +104,8 @@ profile mutt @{exec_path} {
   }
 
   profile editor {
-    include <abstractions/editor>
+    include <abstractions/base>
+    include <abstractions/app/editor>
 
     # This is the file that holds the message
     owner /{var/,}tmp/{.,}mutt* rw,

--- a/apparmor.d/profiles-s-z/task
+++ b/apparmor.d/profiles-s-z/task
@@ -35,7 +35,8 @@ profile task @{exec_path} {
   owner @{HOME}/.task/{,**} rwk,
 
   profile editor {
-    include <abstractions/editor>
+    include <abstractions/base>
+    include <abstractions/app/editor>
 
     # Taskwarrior related files
     owner @{HOME}/.task/   r,

--- a/apparmor.d/profiles-s-z/task
+++ b/apparmor.d/profiles-s-z/task
@@ -35,29 +35,7 @@ profile task @{exec_path} {
   owner @{HOME}/.task/{,**} rwk,
 
   profile editor {
-    include <abstractions/base>
-    include <abstractions/nameservice-strict>
-
-    @{bin}/sensible-editor        mr,
-    @{bin}/vim                  mrix,
-    @{bin}/vim.*                mrix,
-    @{sh_path}                   rix,
-    @{bin}/which{,.debianutils}  rix,
-
-    /usr/share/vim/{,**} r,
-    /usr/share/terminfo/** r,
-
-    /etc/vimrc r,
-    /etc/vim/{,**} r,
-
-    owner @{HOME}/.selected_editor r,
-    owner @{HOME}/.viminfo{,.tmp} rw,
-    owner @{HOME}/.vimrc r,
-
-    # Vim swap file 
-    owner @{HOME}/ r,
-    owner @{user_cache_dirs}/ r,
-    owner @{user_cache_dirs}/vim/** wr,
+    include <abstractions/editor>
 
     # Taskwarrior related files
     owner @{HOME}/.task/   r,


### PR DESCRIPTION
I'm counting seven child profiles named "editor" that all include roughly the same boiler plate policies. 
This PR creates an editor abstraction and converts a couple profiles over to it.

If you're okay with this, I can open another PR converting the remaining child profiles.