### PR TITLE
Update signal-desktop

### DIFF
--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -71,7 +71,7 @@ profile signal-desktop @{exec_path} {
   owner @{PROC}/@{pids}/task/@{tid}/status r,
 
   @{sys}/devices/system/cpu/kernel_max r,
-  @{sys}/devices/virtual/tty/tty0/active r,
+  @{sys}/devices/virtual/tty/tty@{int}/active r,
   @{sys}/fs/cgroup/user.slice/** r,
 
 

--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -72,9 +72,8 @@ profile signal-desktop @{exec_path} {
 
   @{sys}/devices/system/cpu/kernel_max r,
   @{sys}/devices/virtual/tty/tty0/active r,
-  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/cpu.max r,
-  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/memory.high r,
-  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/memory.max r,
+  @{sys}/fs/cgroup/user.slice/** r,
+
 
   include if exists <local/signal-desktop>
 }

--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -8,7 +8,8 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{name} = signal-desktop{,-beta}
-@{lib_dirs} = "/opt/Signal{, Beta}"
+@{lib_dirs} = "/usr/lib/signal-desktop"
+@{lib_dirs} += "/opt/Signal{, Beta}"
 @{config_dirs} = "@{user_config_dirs}/Signal{, Beta}"
 
 @{exec_path} = @{lib_dirs}/@{name}
@@ -16,7 +17,6 @@ profile signal-desktop @{exec_path} {
   include <abstractions/base>
   include <abstractions/audio-client>
   include <abstractions/common/chromium>
-  include <abstractions/consoles>
   include <abstractions/desktop>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
@@ -47,6 +47,7 @@ profile signal-desktop @{exec_path} {
   @{lib_dirs}/resources/app.asar.unpacked/node_modules/**.node mr,
   @{lib_dirs}/resources/app.asar.unpacked/node_modules/**.so mr,
   @{lib_dirs}/resources/app.asar.unpacked/node_modules/**.so.@{int} mr,
+  @{lib_dirs}/chrome_crashpad_handler rix,
 
   /var/lib/dbus/machine-id r,
   /etc/machine-id r,
@@ -68,6 +69,12 @@ profile signal-desktop @{exec_path} {
   owner @{PROC}/@{pids}/statm r,
   owner @{PROC}/@{pids}/task/ r,
   owner @{PROC}/@{pids}/task/@{tid}/status r,
+
+  @{sys}/devices/system/cpu/kernel_max r,
+  @{sys}/devices/virtual/tty/tty0/active r,
+  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/cpu.max r,
+  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/memory.high r,
+  @{sys}/fs/cgroup/user.slice/user-1001.slice/session-1.scope/memory.max r,
 
   include if exists <local/signal-desktop>
 }

--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -73,6 +73,9 @@ profile signal-desktop @{exec_path} {
   @{sys}/devices/system/cpu/kernel_max r,
   @{sys}/devices/virtual/tty/tty@{int}/active r,
   @{sys}/fs/cgroup/user.slice/** r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/cpu.max r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/memory.high r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/memory.max r,
 
 
   include if exists <local/signal-desktop>

--- a/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
+++ b/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
@@ -7,17 +7,22 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{SIGNAL_INSTALLDIR} = "/opt/Signal{, Beta}"
-@{SIGNAL_HOMEDIR} = "@{user_config_dirs}/Signal{, Beta}"
+@{lib_dirs} = "/usr/lib/signal-desktop"
+@{lib_dirs} += "/opt/Signal{, Beta}"
+@{config_dirs} = "@{user_config_dirs}/Signal{, Beta}"
 
-#@{exec_path} = @{SIGNAL_INSTALLDIR}/chrome-sandbox  # (#FIXME#)
-@{exec_path} = "/opt/Signal{, Beta}/chrome-sandbox"
+@{exec_path} = @{lib_dirs}/chrome-sandbox
 profile signal-desktop-chrome-sandbox @{exec_path} {
   include <abstractions/base>
 
+  capability sys_admin,
+  capability sys_chroot,
+
   @{exec_path} mr,
 
-  @{SIGNAL_INSTALLDIR}/signal-desktop{,-beta} rPx,
+  @{lib_dirs}/signal-desktop{,-beta} rPx,
+
+  @{PROC}/@{pid}/ r,
 
   include if exists <local/signal-desktop-chrome-sandbox>
 }


### PR DESCRIPTION
Tested on debian (using the official signal repo) and arch linux

For debian, the install path is at /opt while arch uses /usr/lib/
