### PR TITLE
Convert remaining profiles to editor abstraction

### DIFF
--- a/apparmor.d/abstractions/app/editor
+++ b/apparmor.d/abstractions/app/editor
@@ -5,8 +5,7 @@
   include <abstractions/nameservice-strict>
 
   @{bin}/sensible-editor        mr,
-  @{bin}/vim                  mrix,
-  @{bin}/vim.*                mrix,
+  @{bin}/vim{,.*}             mrix,
   @{sh_path}                   rix,
   @{bin}/which{,.debianutils}  rix,
 
@@ -17,12 +16,13 @@
   /etc/vim/{,**} r,
 
   owner @{HOME}/.selected_editor r,
-  owner @{HOME}/.viminfo{,.tmp} rw,
+  owner @{HOME}/.viminf@{c}{,.tmp} rw,
   owner @{HOME}/.vimrc r,
 
   # Vim swap file 
   owner @{HOME}/ r,
   owner @{user_cache_dirs}/ r,
-  owner @{user_cache_dirs}/vim/** wr,
+  owner @{user_cache_dirs}/vim/{,**} rw,
+  owner @{user_config_dirs}/vim/{,**} r,
 
   include if exists <abstractions/app/editor.d>

--- a/apparmor.d/groups/apt/apt
+++ b/apparmor.d/groups/apt/apt
@@ -153,20 +153,9 @@ profile apt @{exec_path} flags=(attach_disconnected) {
 
   profile editor flags=(complain) {
     include <abstractions/base>
-    include <abstractions/nameservice-strict>
-
-    @{sh_path}                   rix,
-    @{bin}/sensible-editor        mr,
-    @{bin}/vim.*                mrix,
-    @{bin}/which{,.debianutils}  rix,
-
-    /usr/share/vim/{,**} r,
+    include <abstractions/app/editor>
 
     /etc/apt/sources.list rw,
-    /etc/vim/{,**} r,
-
-    owner @{HOME}/.viminfo{,.tmp} rw,
-    owner @{HOME}/.selected_editor r,
 
     include if exists <local/apt_editor>
   }

--- a/apparmor.d/groups/cron/crontab
+++ b/apparmor.d/groups/cron/crontab
@@ -35,20 +35,9 @@ profile crontab @{exec_path} {
 
   profile editor {
     include <abstractions/base>
-    include <abstractions/nameservice-strict>
+    include <abstractions/app/editor>
 
     capability fsetid,
-
-    @{bin}/sensible-editor mr,
-    @{bin}/vim.*           mrix,
-    @{sh_path}              rix,
-    @{bin}/which{,.debianutils}            rix,
-
-    owner @{HOME}/.selected_editor r,
-
-    /usr/share/vim/{,**} r,
-    /etc/vim/{,**} r,
-    owner @{HOME}/.viminfo{,.tmp} rw,
 
           /tmp/ r,
     owner @{tmp}/crontab.*/crontab rw,

--- a/apparmor.d/profiles-g-l/git
+++ b/apparmor.d/profiles-g-l/git
@@ -165,30 +165,12 @@ profile git @{exec_path} {
 
   profile editor {
     include <abstractions/base>
-    include <abstractions/nameservice-strict>
-
-    @{bin}/sensible-editor mr,
-    @{bin}/vim             mrix,
-    @{bin}/vim.*           mrix,
-    @{sh_path}              rix,
-    @{bin}/which{,.debianutils}            rix,
-
-    /usr/share/vim/{,**} r,
-    /usr/share/terminfo/** r,
-
-    /etc/vimrc r,
-    /etc/vim/{,**} r,
-
+    include <abstractions/app/editor>
+  
     owner @{user_projects_dirs}/**/ r,
     owner @{user_projects_dirs}/**/.git/@{int} rw,
     owner @{user_projects_dirs}/**/.git/*MSG rw,
-
-    owner @{HOME}/.selected_editor r,
-    owner @{HOME}/.viminfo{,.tmp} rw,
-
-    owner @{user_cache_dirs}/vim/{,**} rw,
-    owner @{user_config_dirs}/vim/{,**} r,
-
+  
     # The git repository files
     owner @{user_build_dirs}/ r,
     owner @{user_build_dirs}/** rw,

--- a/apparmor.d/profiles-m-r/pass
+++ b/apparmor.d/profiles-m-r/pass
@@ -75,22 +75,12 @@ profile pass @{exec_path} {
   profile editor {
     include <abstractions/base>
     include <abstractions/consoles>
-    include <abstractions/nameservice-strict>
+    include <abstractions/app/editor>
 
-    @{bin}/vim{,.*} mrix,
-
-    /etc/vim/{,**} r,
-    /etc/vimrc r,
-    /usr/share/terminfo/** r,
-    /usr/share/vim/{,**} r,
     /tmp/ r,
-
-    owner @{HOME}/.viminf{o,z}{,.tmp} rw,
 
     owner @{user_password_store_dirs}/{,**/} r,
 
-    owner @{user_cache_dirs}/vim/{,**} rw,
-    owner @{user_config_dirs}/vim/{,**} rw,
     owner /dev/shm/pass.*/{,*} rw,
 
     deny owner @{HOME}/ r,

--- a/apparmor.d/profiles-s-z/vipw-vigr
+++ b/apparmor.d/profiles-s-z/vipw-vigr
@@ -40,23 +40,11 @@ profile vipw-vigr @{exec_path} {
 
   profile editor {
     include <abstractions/base>
-    include <abstractions/nameservice-strict>
+    include <abstractions/app/editor>
 
     capability fsetid,
 
-    @{bin}/sensible-editor mr,
-    @{bin}/vim.*           mrix,
-    @{sh_path}              rix,
-    @{bin}/which{,.debianutils}            rix,
-
-    owner @{HOME}/.selected_editor r,
-
-    /usr/share/vim/{,**} r,
-    /etc/vim/{,**} r,
-    owner @{HOME}/.viminfo{,.tmp} rw,
-
     /etc/{passwd,shadow,gshadow,group}.edit rw,
-
   }
 
   include if exists <local/vipw-vigr>


### PR DESCRIPTION
Although I do not use all the profiles here (AKA, have not tested all of these), this PR just abstracts the common editor rules to the editor abstraction.


The only rule that changes is in the pass profile
Pass profile: ` owner @{user_config_dirs}/vim/{,**} rw,`
editor abstr:  ` owner @{user_config_dirs}/vim/{,**} r,`

None of the other editor profiles allowed write access under the `@{user_config_dirs}/vim/` dir, and I don't see why it would be needed.