### PR TITLE
Firefox: using stacking for glxtest and vaapitest

### DIFF
--- a/apparmor.d/abstractions/app/firefox
+++ b/apparmor.d/abstractions/app/firefox
@@ -51,11 +51,11 @@
   @{lib_dirs}/{,**}             r,
   @{lib_dirs}/*.so              mr,
   @{lib_dirs}/crashreporter     rPx,
-  @{lib_dirs}/glxtest           rPx,
+  @{lib_dirs}/glxtest           rPx -> firefox//&firefox-glxtest,
   @{lib_dirs}/minidump-analyzer rPx,
   @{lib_dirs}/pingsender        rPx,
   @{lib_dirs}/plugin-container  rPx,
-  @{lib_dirs}/vaapitest         rPx,
+  @{lib_dirs}/vaapitest         rPx -> firefox//&firefox-vaapitest,
 
   # Desktop integration
   @{bin}/lsb_release            rPx -> lsb_release,


### PR DESCRIPTION
The current implementation results in the following errors for the Firefox profile:

 @{lib}/firefox/glxtest rix -> firefox-glxtest,  # no new privs

@{lib}/firefox/vaapitest rix -> firefox-vaapitest,   # no new privs

Using stacking as suggested on https://apparmor.pujol.io/development/structure/#no-new-privileges gets rid of these errors.