### PR TITLE
add multiple profiles

### DIFF
--- a/apparmor.d/profiles-a-f/atool
+++ b/apparmor.d/profiles-a-f/atool
@@ -1,6 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2019-2021 Mikhail Morfikov
-# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -8,9 +7,10 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/atool
-profile atool /{,usr/}{,s}bin/atool {
+profile atool @{exec_path} {
   include <abstractions/base>
-  include <abstractions/user-write>
+  include <abstractions/perl>
+  include <abstractions/user-write-strict>
 
   @{exec_path} mr,
 
@@ -45,8 +45,6 @@ profile atool /{,usr/}{,s}bin/atool {
   @{bin}/unzip rix,
   @{bin}/xz rix,
   @{bin}/zip rix,
-
-  /usr/share/perl5/{,**} r,
 
   include if exists <local/atool>
 }

--- a/apparmor.d/profiles-a-f/atool
+++ b/apparmor.d/profiles-a-f/atool
@@ -1,0 +1,52 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2019-2021 Mikhail Morfikov
+# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/3.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/atool
+profile atool /{,usr/}{,s}bin/atool {
+  include <abstractions/base>
+  include <abstractions/user-write>
+
+  @{exec_path} mr,
+
+  @{bin}/7z rix,
+  @{bin}/arc rix,
+  @{bin}/arj rix,
+  @{bin}/bzip2 rix,
+  @{bin}/bzip2 rix,
+  @{bin}/bzip rix,
+  @{bin}/compress rix,
+  @{bin}/cpio rix,
+  @{bin}/gunzip rix,
+  @{bin}/gzip rix,
+  @{bin}/gzip rix,
+  @{bin}/jar rix,
+  @{bin}/lha rix,
+  @{bin}/lrunzip rix,
+  @{bin}/lrzcat rix,
+  @{bin}/lrzip rix,
+  @{bin}/lrz rix,
+  @{bin}/lrztar rix,
+  @{bin}/lrzuntar rix,
+  @{bin}/lzip rix,
+  @{bin}/lzma rix,
+  @{bin}/lzop rix,
+  @{bin}/lzop rix,
+  @{bin}/rar rix,
+  @{bin}/tar rix,
+  @{bin}/unace rix,
+  @{bin}/unrar rix,
+  @{bin}/unxz rix,
+  @{bin}/unzip rix,
+  @{bin}/xz rix,
+  @{bin}/zip rix,
+
+  /usr/share/perl5/{,**} r,
+
+  include if exists <local/atool>
+}

--- a/apparmor.d/profiles-a-f/exiftool
+++ b/apparmor.d/profiles-a-f/exiftool
@@ -1,6 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2019-2021 Mikhail Morfikov
-# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
@@ -10,11 +9,9 @@ include <tunables/global>
 @{exec_path} = @{bin}/vendor_perl/exiftool
 profile exiftool @{exec_path} {
   include <abstractions/base>
-  include <abstractions/user-read>
+  include <abstractions/user-read-strict>
 
   @{exec_path} mr,
-
-  /usr/share/perl5/{,**} r,
 
   include if exists <local/exiftool>
 }

--- a/apparmor.d/profiles-a-f/exiftool
+++ b/apparmor.d/profiles-a-f/exiftool
@@ -9,6 +9,7 @@ include <tunables/global>
 @{exec_path} = @{bin}/vendor_perl/exiftool
 profile exiftool @{exec_path} {
   include <abstractions/base>
+  include <abstractions/perl>
   include <abstractions/user-read-strict>
 
   @{exec_path} mr,

--- a/apparmor.d/profiles-a-f/exiftool
+++ b/apparmor.d/profiles-a-f/exiftool
@@ -7,12 +7,14 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = @{bin}/mediainfo
-profile mediainfo @{exec_path} {
+@{exec_path} = @{bin}/vendor_perl/exiftool
+profile exiftool @{exec_path} {
   include <abstractions/base>
   include <abstractions/user-read>
 
   @{exec_path} mr,
 
-  include if exists <local/mediainfo>
+  /usr/share/perl5/{,**} r,
+
+  include if exists <local/exiftool>
 }

--- a/apparmor.d/profiles-g-l/highlight
+++ b/apparmor.d/profiles-g-l/highlight
@@ -1,23 +1,22 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2019-2021 Mikhail Morfikov
-# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = @{bin}/
-profile highlight /{,usr/}{,s}bin/highlight {
+@{exec_path} = @{bin}/highlight
+profile highlight @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
-  include <abstractions/user-read>
+  include <abstractions/user-read-strict>
+
+  @{exec_path} mr,
 
   /etc/machine-id r,
   /etc/highlight/{,**} r,
   /usr/share/highlight/{,**} r,
-
-  @{exec_path} mr,
 
   include if exists <local/highlight>
 }

--- a/apparmor.d/profiles-g-l/highlight
+++ b/apparmor.d/profiles-g-l/highlight
@@ -7,12 +7,17 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = @{bin}/mediainfo
-profile mediainfo @{exec_path} {
+@{exec_path} = @{bin}/
+profile highlight /{,usr/}{,s}bin/highlight {
   include <abstractions/base>
+  include <abstractions/nameservice-strict>
   include <abstractions/user-read>
+
+  /etc/machine-id r,
+  /etc/highlight/{,**} r,
+  /usr/share/highlight/{,**} r,
 
   @{exec_path} mr,
 
-  include if exists <local/mediainfo>
+  include if exists <local/highlight>
 }

--- a/apparmor.d/profiles-g-l/imv-wayland
+++ b/apparmor.d/profiles-g-l/imv-wayland
@@ -1,5 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,

--- a/apparmor.d/profiles-m-r/mediainfo
+++ b/apparmor.d/profiles-m-r/mediainfo
@@ -10,7 +10,7 @@ include <tunables/global>
 @{exec_path} = @{bin}/mediainfo
 profile mediainfo @{exec_path} {
   include <abstractions/base>
-  include <abstractions/user-read>
+  include <abstractions/user-read-strict>
 
   @{exec_path} mr,
 

--- a/apparmor.d/profiles-m-r/mediainfo-gui
+++ b/apparmor.d/profiles-m-r/mediainfo-gui
@@ -15,7 +15,7 @@ profile mediainfo-gui @{exec_path} {
   include <abstractions/fonts>
   include <abstractions/freedesktop.org>
   include <abstractions/gtk>
-  include <abstractions/user-read>
+  include <abstractions/user-read-strict>
 
   @{exec_path} mr,
 

--- a/apparmor.d/profiles-m-r/mediainfo-gui
+++ b/apparmor.d/profiles-m-r/mediainfo-gui
@@ -15,14 +15,12 @@ profile mediainfo-gui @{exec_path} {
   include <abstractions/fonts>
   include <abstractions/freedesktop.org>
   include <abstractions/gtk>
-  include <abstractions/user-download-strict>
+  include <abstractions/user-read>
 
   @{exec_path} mr,
 
   @{bin}/xdg-open    rCx -> open,
 
-  owner @{user_music_dirs}/** r,
-  owner @{user_videos_dirs}/** r,
 
   profile open {
     include <abstractions/base>

--- a/apparmor.d/profiles-s-z/zathura
+++ b/apparmor.d/profiles-s-z/zathura
@@ -1,5 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/3.0>,


### PR DESCRIPTION
This adds profiles for:

**atool 
exiftool
highlight**

It also changes **mediainfo** and adds permissions for reading any user files. This is necessary because unlike what the previous profile suggested, mediainfo can parse more file formats aside from audio and video files and is often used by preview scripts for tui applications. The same is true for exiftool and highlight. 

atool also requires write permissions for user files to allow decompression.