### PR TITLE
systemd-oomd update

### DIFF
--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -32,6 +32,8 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
   @{sys}/fs/cgroup/cgroup.controllers r,
   @{sys}/fs/cgroup/memory.pressure r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/session.slice/memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,


### PR DESCRIPTION
Add missing `memory.*` paths that are currently get denied.

```
DENIED  systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
DENIED  systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
DENIED  systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
DENIED  systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
DENIED  systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
```

There's also weird `app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice` which I don't know how to allow.