### PR TITLE
Update kmod

### DIFF
--- a/apparmor.d/profiles-g-l/kmod
+++ b/apparmor.d/profiles-g-l/kmod
@@ -34,6 +34,8 @@ profile kmod @{exec_path} flags=(attach_disconnected) {
   @{lib}/modprobe.d/{,*.conf} r,
   @{lib}/modules/*/modules.* rw,
 
+  @{run}/modprobe.d/{,*.conf} r,
+
   /etc/depmod.d/{,**} r,
   /etc/modprobe.d/{,*.conf} r,
 


### PR DESCRIPTION
Should fix
`aa-log`
```
ALLOWED kmod open owner @{run}/modprobe.d/ comm=modprobe requested_mask=r denied_mask=r
```
`/var/log/audit.log`
```
type=AVC msg=audit(1717430600.947:2040): apparmor="ALLOWED" operation="open" class="file" profile="lspci" name="/run/modprobe.d/" pid=3053 comm="lspci" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0^]FSUID="remorin" OUID="root"
```
`aa-log --rules`
```
profile kmod {
  @{run}/modprobe.d/ r,
}
```


@roddhjav, should I prepend `owner`, `aa-log` mentiones it, but `--rules` doesn't? 