### PR TITLE
Update lspci

### DIFF
--- a/apparmor.d/profiles-g-l/lspci
+++ b/apparmor.d/profiles-g-l/lspci
@@ -24,6 +24,7 @@ profile lspci @{exec_path} flags=(attach_disconnected) {
   /usr/share/misc/pci.ids.gz r,
   /usr/share/pci.ids r,
 
+  @{run}/modprobe.d/{,*.conf} r,
   /etc/modprobe.d/{,*.conf} r,
   /etc/udev/hwdb.bin r,
 


### PR DESCRIPTION
Should fix
```
$ aa-log | grep lspci
ALLOWED lspci open @{run}/modprobe.d/ comm=lspci requested_mask=r denied_mask=r
ALLOWED lspci open @{run}/modprobe.d/ comm=lspci requested_mask=r denied_mask=r
$ aa-log -r | grep -A 2 lspci
profile lspci {
  @{run}/modprobe.d/ r,
}
```