### PR TITLE
fix(systemd-oomd): add `cgroup/system.slice/` and `app-dbus*` paths

### DIFF
--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -30,11 +30,9 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
   owner @{run}/systemd/journal/socket w,
 
   @{sys}/fs/cgroup/cgroup.controllers r,
-  @{sys}/fs/cgroup/memory.pressure r,
+  @{sys}/fs/cgroup/memory.* r,
   @{sys}/fs/cgroup/system.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/session.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/{,**/}memory.* r,
+  @{sys}/fs/cgroup/user.slice/{,**/}/memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,

--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -34,8 +34,7 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
   @{sys}/fs/cgroup/system.slice/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/session.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/*org.a11y.atspi.Registry.slice/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/{,**/}memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,

--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -35,7 +35,7 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/session.slice/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-dbus*org.a11y.atspi.Registry.slice/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/*org.a11y.atspi.Registry.slice/memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,

--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -31,9 +31,11 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
 
   @{sys}/fs/cgroup/cgroup.controllers r,
   @{sys}/fs/cgroup/memory.pressure r,
+  @{sys}/fs/cgroup/system.slice/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.* r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/memory.* r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/session.slice/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/memory.* r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-dbus*org.a11y.atspi.Registry.slice/memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,


### PR DESCRIPTION
Should fix
```
$ aa-log | grep systemd-oomd
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/system.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
```