### PR TITLE
fix(pacman): add `attach_disconnected`

### DIFF
--- a/apparmor.d/groups/pacman/pacman
+++ b/apparmor.d/groups/pacman/pacman
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/pacman
-profile pacman @{exec_path} {
+profile pacman @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/consoles>
   include <abstractions/disks-read>

--- a/dists/flags/arch.flags
+++ b/dists/flags/arch.flags
@@ -1,7 +1,7 @@
 archlinux-keyring-wkd-sync complain
 makepkg complain
 mkinitcpio attach_disconnected,complain
-pacman complain
+pacman attach_disconnected,complain
 pacman-conf attach_disconnected,complain
 pacman-hook-dconf complain
 pacman-hook-depmod complain


### PR DESCRIPTION
[Should fix](https://bbs.archlinux.org/viewtopic.php?id=245453) #350 
```
$ aa-log -r | grep pacman -A 2
profile pacman flags=(attach_disconnected) {
  owner dev/tty2 rw,  # file_inherit Failed name lookup - disconnected path
}
```