### PR TITLE
fix(polkit-gnome-authentication-agent): include dconf-write

### DIFF
--- a/apparmor.d/groups/freedesktop/polkit-gnome-authentication-agent
+++ b/apparmor.d/groups/freedesktop/polkit-gnome-authentication-agent
@@ -12,6 +12,7 @@ include <tunables/global>
 @{exec_path} += @{lib}/polkit-gnome/polkit-gnome-authentication-agent-1
 profile polkit-gnome-authentication-agent @{exec_path} {
   include <abstractions/base>
+  include <abstractions/dconf-write>
   include <abstractions/gnome-strict>
 
   @{exec_path} mr,


### PR DESCRIPTION
Should fix
```
$ aa-log -f 1 polkit-gnome-authentication-agent 
ALLOWED polkit-gnome-authentication-agent mkdir owner @{run}/user/@{uid}/dconf/ comm=polkit-gnome-au requested_mask=c denied_mask=c
ALLOWED polkit-gnome-authentication-agent mknod owner @{run}/user/@{uid}/dconf/user comm=polkit-gnome-au requested_mask=c denied_mask=c
ALLOWED polkit-gnome-authentication-agent open owner @{run}/user/@{uid}/dconf/user comm=polkit-gnome-au requested_mask=wrc denied_mask=wrc
ALLOWED polkit-gnome-authentication-agent open owner @{user_config_dirs}/dconf/user comm=polkit-gnome-au requested_mask=r denied_mask=r
$ aa-log -f 1 -r polkit-gnome-authentication-agent 
profile polkit-gnome-authentication-agent {
  owner @{user_config_dirs}/dconf/user r,

  owner @{run}/user/@{uid}/dconf/ w,
  owner @{run}/user/@{uid}/dconf/user rw,
}

```