### PR TITLE
fix(nm-dispatcher): add modem-manager-gui

### DIFF
--- a/apparmor.d/groups/network/nm-dispatcher
+++ b/apparmor.d/groups/network/nm-dispatcher
@@ -81,6 +81,8 @@ profile nm-dispatcher @{exec_path} flags=(attach_disconnected) {
 
   /dev/tty rw,
 
+  @{run}/modem-manager-gui/{,timestamps} rw,
+
   profile systemctl {
     include <abstractions/base>
     include <abstractions/app/systemctl>


### PR DESCRIPTION
Should fix
```
$ aa-log -f 1 nm-dispatcher 
ALLOWED nm-dispatcher mkdir owner @{run}/modem-manager-gui/ comm=python3 requested_mask=c denied_mask=c
ALLOWED nm-dispatcher mknod owner @{run}/modem-manager-gui/timestamps comm=python3 requested_mask=c denied_mask=c
ALLOWED nm-dispatcher open owner @{run}/modem-manager-gui/timestamps comm=python3 requested_mask=wc denied_mask=wc
ALLOWED nm-dispatcher open owner @{run}/modem-manager-gui/timestamps comm=python3 requested_mask=r denied_mask=r
ALLOWED nm-dispatcher truncate owner @{run}/modem-manager-gui/timestamps comm=python3 requested_mask=w denied_mask=w
$ aa-log -f 1 -r nm-dispatcher 
profile nm-dispatcher {
  @{run}/modem-manager-gui/ w,
  @{run}/modem-manager-gui/timestamps rw,
}

```