### PR TITLE
fix(xdg-document-portal): add `abstractions/nameservice-strict`

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-document-portal
+++ b/apparmor.d/groups/freedesktop/xdg-document-portal
@@ -12,6 +12,7 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
   include <abstractions/bus-session>
   include <abstractions/bus/org.freedesktop.impl.portal.PermissionStore>
   include <abstractions/deny-sensitive-home>
+  include <abstractions/nameservice-strict>
 
   capability sys_admin,
   capability sys_nice,
@@ -34,9 +35,6 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
        peer=(name=:*, label=gnome-shell),
 
   @{exec_path} mr,
-
-  /etc/nsswitch.conf r,
-  /etc/passwd r,
 
   @{bin}/flatpak         rPUx,
   @{bin}/fusermount{,3}  rCx -> fusermount,

--- a/apparmor.d/groups/freedesktop/xdg-document-portal
+++ b/apparmor.d/groups/freedesktop/xdg-document-portal
@@ -35,6 +35,9 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
+  /etc/nsswitch.conf r,
+  /etc/passwd r,
+
   @{bin}/flatpak         rPUx,
   @{bin}/fusermount{,3}  rCx -> fusermount,
 


### PR DESCRIPTION
Should fix
```
$ aa-log -f 1 xdg-document-portal 
ALLOWED xdg-document-portal open /etc/nsswitch.conf comm=xdg-document-po requested_mask=r denied_mask=r
ALLOWED xdg-document-portal open /etc/passwd comm=xdg-document-po requested_mask=r denied_mask=r
$ aa-log -f 1 -r xdg-document-portal 
profile xdg-document-portal {
  /etc/nsswitch.conf r,
  /etc/passwd r,
}

```