### PR TITLE
fix(xdg-permission-store): add `nameservice-strict` and `.local/`

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-permission-store
+++ b/apparmor.d/groups/freedesktop/xdg-permission-store
@@ -10,6 +10,7 @@ include <tunables/global>
 profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/bus-session>
+  include <abstractions/nameservice-strict>
 
   capability sys_nice,
 
@@ -24,6 +25,8 @@ profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
        peer=(name=:*, label=gnome-shell),
 
   @{exec_path} mr,
+
+  owner @{HOME}/.local/ w,
 
   @{HOME}/@{XDG_DATA_DIR}/flatpak/db/gnome rw,
 


### PR DESCRIPTION
Should fix
```
$ aa-log xdg-permission-store 
ALLOWED xdg-permission-store open /etc/nsswitch.conf comm=xdg-permission- requested_mask=r denied_mask=r
ALLOWED xdg-permission-store open /etc/passwd comm=xdg-permission- requested_mask=r denied_mask=r
ALLOWED xdg-permission-store mkdir owner /.local/ comm=xdg-permission- requested_mask=c denied_mask=c
$ aa-log -r xdg-permission-store 
profile xdg-permission-store {
  owner /.local/ w,

  /etc/nsswitch.conf r,
  /etc/passwd r,
}

```