### PR TITLE
fix(gvfsd, gvsfsd-fuse): add `abstractions/nameservice-strict`

### DIFF
--- a/apparmor.d/groups/gvfs/gvfsd
+++ b/apparmor.d/groups/gvfs/gvfsd
@@ -11,6 +11,7 @@ include <tunables/global>
 profile gvfsd @{exec_path} {
   include <abstractions/base>
   include <abstractions/bus-session>
+  include <abstractions/nameservice-strict>
 
   #aa:dbus own bus=session name=org.gtk.vfs.Daemon
   #aa:dbus own bus=session name=org.gtk.vfs.MountTracker path=/org/gtk/vfs/mounttracker

--- a/apparmor.d/groups/gvfs/gvfsd-fuse
+++ b/apparmor.d/groups/gvfs/gvfsd-fuse
@@ -12,6 +12,7 @@ profile gvfsd-fuse @{exec_path} {
   include <abstractions/base>
   include <abstractions/bus-session>
   include <abstractions/bus/org.gtk.vfs.MountTracker>
+  include <abstractions/nameservice-strict>
 
   mount fstype={fuse,fuse.*} -> @{run}/user/@{uid}/gvfs/,
 


### PR DESCRIPTION
Should fix
```
$ aa-log -f 1 gvfsd
ALLOWED gvfsd open /etc/nsswitch.conf comm=gvfsd requested_mask=r denied_mask=r
ALLOWED gvfsd open /etc/passwd comm=gvfsd requested_mask=r denied_mask=r
ALLOWED gvfsd-fuse open /etc/nsswitch.conf comm=gvfsd-fuse requested_mask=r denied_mask=r
ALLOWED gvfsd-fuse open /etc/passwd comm=gvfsd-fuse requested_mask=r denied_mask=r
$ aa-log -f 1 -r gvfsd
profile gvfsd {
  /etc/nsswitch.conf r,
  /etc/passwd r,
}

profile gvfsd-fuse {
  /etc/nsswitch.conf r,
  /etc/passwd r,
}

```