### PR TITLE
fix(systemd-oomd): remove second slash

### DIFF
--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -32,7 +32,7 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
   @{sys}/fs/cgroup/cgroup.controllers r,
   @{sys}/fs/cgroup/memory.* r,
   @{sys}/fs/cgroup/system.slice/memory.* r,
-  @{sys}/fs/cgroup/user.slice/{,**/}/memory.* r,
+  @{sys}/fs/cgroup/user.slice/{,**/}memory.* r,
 
   @{PROC}/pressure/cpu r,
   @{PROC}/pressure/io r,


### PR DESCRIPTION
Additional slash before `memory.*` caused the path to not work.

<details>
<summary>Fixes (tested after `systemctl reload apparmor.service`)</summary>

```
$ aa-log systemd-oomd 
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.pressure comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.min comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.low comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.swap.current comm=systemd-oomd requested_mask=r denied_mask=r
ALLOWED systemd-oomd open @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.stat comm=systemd-oomd requested_mask=r denied_mask=r
$ aa-log -r systemd-oomd 
profile systemd-oomd {
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.current r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.low r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.min r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.pressure r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.stat r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/memory.swap.current r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.current r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.low r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.min r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.pressure r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.stat r,
  @{sys}/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/memory.swap.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.low r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.min r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.pressure r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.stat r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/app-dbus\x2d:*\x2dorg.a11y.atspi.Registry.slice/memory.swap.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.low r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.min r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.pressure r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.stat r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/app.slice/memory.swap.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.current r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.low r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.min r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.pressure r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.stat r,
  @{sys}/fs/cgroup/user.slice/user-966.slice/user@966.service/session.slice/memory.swap.current r,
}

```
</details>