### PR TITLE
fix(authentication.d/complete): add missing copyright

### DIFF
--- a/apparmor.d/abstractions/authentication.d/complete
+++ b/apparmor.d/abstractions/authentication.d/complete
@@ -1,5 +1,4 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 

--- a/apparmor.d/abstractions/authentication.d/complete
+++ b/apparmor.d/abstractions/authentication.d/complete
@@ -1,3 +1,7 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2020-2021 Mikhail Morfikov
+# Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
 
   @{bin}/pam-tmpdir-helper rPx,
 


### PR DESCRIPTION
This file was missing the comment at the beginning.