### PR TITLE
Update docs to be more legible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@
   `polkit`, `NetworkManager`, `OpenVPN`, `GDM`, `rtkit`, `colord`
 - Confine all Desktop environments
 - Confine all user services such as `Pipewire`, `Gvfsd`, `dbus`, `xdg`, `xwayland`
-- Confine some *"special"* user applications: web browser, file browser...
+- Confine some *"special"* user applications: web browsers, file managers, etc
 - Should not break a normal usage of the confined software
 
 **Goals**
 
 - Target both desktops and servers
 - Support all distributions that support AppArmor:
-    * Archlinux
+    * Arch Linux
     * Ubuntu 22.04
     * Debian 12
     * OpenSUSE Tumbleweed
-- Support major desktop environments:
+- Support for all major desktop environments:
     * Gnome
     * KDE
     * XFCE *(work in progress)*
@@ -54,7 +54,7 @@ This is fundamentally different from how AppArmor is usually used on Linux serve
 
 **Presentations**
 
-Building large set of AppArmor profiles:
+Building the largest set of AppArmor profiles:
 
 - [Linux Security Summit North America (LSS-NA 2023)](https://events.linuxfoundation.org/linux-security-summit-north-america/) *([Slide](https://lssna2023.sched.com/event/1K7bI/building-the-largest-working-set-of-apparmor-profiles-alexandre-pujol-the-collaboratory-tudublin), [Video](https://www.youtube.com/watch?v=OzyalrOzxE8))*
 - [Ubuntu Summit 2023](https://events.canonical.com/event/31/) *([Slide](https://events.canonical.com/event/31/contributions/209/), [Video](https://www.youtube.com/watch?v=GK1J0TlxnFI))*

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -8,7 +8,7 @@ There are over 50000 Linux packages and even more applications. It is simply not
 
 **What to confine and why?**
 
-We take inspiration from the [Android/ChromeOS Security Model](https://arxiv.org/pdf/1904.05572v2.pdf), and we apply it to the Linux world. Modern [Linux security distributions](https://clip-os.org/en/) usually consider an immutable core base image with a carefully selected set of applications. Everything else should be sandboxed. Therefore, this project tries to confine all the *core* applications you will usually find in a Linux system: all systemd services, xwayland, network, bluetooth, your desktop environment... Non-core user applications are out of scope as they should be sandboxed using a dedicated tool (minijail, bubblewrap, toolbox...).
+We take inspiration from the [Android/ChromeOS Security Model](https://arxiv.org/pdf/1904.05572v2.pdf), and we apply it to the Linux world. Modern [Linux security distributions](https://clip-os.org/en/) usually consider an immutable core base image with a carefully selected set of applications. Everything else should be sandboxed. Therefore, this project tries to confine all the *core* applications you will usually find in a Linux system: all systemd services, xwayland, network, bluetooth, your desktop environment, etc. Non-core user applications are out of scope as they should be sandboxed using a dedicated tool (minijail, bubblewrap, toolbox, etc).
 
 This is fundamentally different from how AppArmor is usually used on Linux servers as it is common to only confine the applications that face the internet and/or the users.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ directories. Example:
 @{XDG_PROJECTS_DIR}+="Git" "Papers"
 ```
 
-Then restart the apparmor service to reload the profiles in the kernel:
+Then restart the AppArmor service to reload the profiles in the kernel:
 ```sh
 sudo systemctl restart apparmor.service
 ```
@@ -105,4 +105,4 @@ You can extend any profile with your own rules by creating a file in the `/etc/a
     `rPx` allows transition to the Firefox profile. Use `rPUx` to allow transition to an unconfined state if you do not have the profile for a given program.
 
 
-Then, reload the apparmor rules with `sudo systemctl restart apparmor`.
+Then, reload the AppArmor rules with `sudo systemctl restart AppArmor`.

--- a/docs/development/install.md
+++ b/docs/development/install.md
@@ -19,7 +19,7 @@ make package dist=<distribution>
 ```
 Then you can install the package with `dpkg`, `pacman` or `rpm`.
 
-**:material-arch: Archlinux**
+**:material-arch: Arch Linux**
 ```sh
 make pkg
 ```

--- a/docs/development/integration.md
+++ b/docs/development/integration.md
@@ -44,8 +44,8 @@ To build a VM image for development purpose, run the following from the `tests` 
 
 | Distribution | Flavor | Build command | VM name |
 |:------------:|:------:|:-------------:|:-------:|
-| Archlinux | Gnome | `make archlinux flavor=gnome` | `arch-gnome` |
-| Archlinux | KDE | `make archlinux flavor=kde` | `arch-kde` |
+| Arch Linux | Gnome | `make archlinux flavor=gnome` | `arch-gnome` |
+| Arch Linux | KDE | `make archlinux flavor=kde` | `arch-kde` |
 | Debian | Server | `make debian flavor=server` | `debian-server` |
 | OpenSUSE | KDE | `make opensuse falvor=kde` | `opensuse-kde` |
 | Ubuntu | Server | `make ubuntu flavor=server` | `ubuntu-server` |

--- a/docs/enforce.md
+++ b/docs/enforce.md
@@ -6,16 +6,16 @@ The default package configuration installs all profiles in *complain* mode. This
 
 !!! warning
 
-    - You need to test it in complain mode first and ensure your system boot!
-    - When reporting issue. Please ensure the profiles are in complain mode
+    - Please test in complain mode first and ensure your system boots!
+    - When reporting an issue, please ensure the affected profiles are in complain mode.
 
 
-#### :material-arch: Archlinux
+#### :material-arch: Arch Linux
 
 In `PKGBUILD`, replace `make` by `make enforce`:
 ```diff
--  make
-+  make enforce
+-  make DISTRIBUTION=arch
++  make enforce DISTRIBUTION=arch
 ```
 
 #### :material-ubuntu: Ubuntu & :material-debian: Debian

--- a/docs/full-system-policy.md
+++ b/docs/full-system-policy.md
@@ -6,8 +6,8 @@ title: Full system policy (FSP)
 
     Full system policy is still under early development:
     
-    - Do not run it outside a development VM! 
-    - This is an **advanced** feature, you should understand what you are doing
+    - Do not run this outside of a development VM! 
+    - This is an **advanced** feature, you should understand what you are doing before use.
 
     **You have been warned!!!**
 
@@ -28,7 +28,7 @@ Particularly:
 - Any non-standard system app need to be explicitly profiled and allowed to run. For instance, if you want to use your own proxy or VPN software, you need to ensure it is correctly profiled and allowed to run in the `systemd` profile.
 - Desktop environment must be explicitly supported, your UI will not start otherwise. Again, it is a **feature**.
 - FSP mode will run unknown user application into the `default` profile. It might be enough for your application. If not you have to make a profile for it.
-- In FSP mode, all sandbox manager **must** have a profile. Then user sandboxed application (flatpak, snap...) will work as expected.
+- In FSP mode, all sandbox managers **must** have a profile. Then user sandboxed applications (flatpak, snap, etc) will work as expected.
 
 
 ## Install
@@ -43,7 +43,7 @@ cache-loc /etc/apparmor/earlypolicy/
 Optimize=compress-fast
 ```
 
-**:material-arch: Archlinux**
+**:material-arch: Arch Linux**
 
 In `PKGBUILD`, replace `make` by `make full`:
 ```diff
@@ -94,7 +94,7 @@ To work as intended, all privileged services started by systemd **must** have a 
 /usr/lib/systemd/system/*.service
 ```
 
-The main [fallback](#fallback) profile (`default`) is not intended to be used by privileged program or service. Such programs must have they dedicated profile and will fail otherwise. This is a **feature**, not a bug.
+The main [fallback](#fallback) profile (`default`) is not intended to be used by privileged program or service. Such programs must have a dedicated profile and will fail otherwise. This is a **feature**, not a bug.
 
 **`systemd-user`**
 
@@ -120,14 +120,14 @@ To work as intended, userland services started by `systemd --user` **should** ha
 
 ### Fallback
 
-In addition to the `systemd` profiles, a full system policy needs to ensure that no program run in an unconfined state at any time. The fallback profiles consist of a set generic specialized profiles:
+In addition to the `systemd` profiles, a full system policy needs to ensure that no programs run in an unconfined state at any time. The fallback profiles consist of a set generic specialized profiles:
 
 - **`default`** is used for any *classic* user application with a GUI. It has full access to user home directories.
 - **`bwrap`, `bwrap-app`** are used for *classic* user application that are sandboxed with **bwrap**.
 
 !!! warning
 
-    The main fallback profile (`default`) is not intended to be used by priviligied program or service. Such programs **must** have they dedicaded profile and would break otherwise.
+    The main fallback profile (`default`) is not intended to be used by privileged program or service. Such programs **must** have they dedicated profile and would break otherwise.
 
 Additionally, special user access can be setup using PAM rules set such as a random shell interactively opened (as user or as root). 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Business Benefits of an LSM
 - Confine all root processes such as all `systemd` tools, `bluetooth`, `dbus`, `polkit`, `NetworkManager`, `OpenVPN`, `GDM`, `rtkit`, `colord`
 - Confine all Desktop environments
 - Confine all user services such as `Pipewire`, `Gvfsd`, `dbus`, `xdg`, `xwayland`
-- Confine some *"special"* user applications: web browser, file browser...
+- Confine some *"special"* user applications: web browsers, file managers, etc
 - Should not break a normal usage of the confined software
 
 See the [Concepts](concepts.md)' page for more detail on the architecture.
@@ -32,19 +32,19 @@ See the [Concepts](concepts.md)' page for more detail on the architecture.
 **Goals**
 
 - Target both desktops and servers
-- Support all distributions that support AppArmor:
-    * [:material-arch: Archlinux](install.md#archlinux)
+- Support for all distributions that support AppArmor:
+    * [:material-arch: Arch Linux](install.md#archlinux)
     * [:material-ubuntu: Ubuntu 22.04](install.md#ubuntu-debian)
     * [:material-debian: Debian 12](install.md#ubuntu-debian)
     * [:simple-suse: OpenSUSE Tumbleweed](install.md#opensuse)
-- Support all major desktop environments:
+- Support for all major desktop environments:
     - [x] :material-gnome: Gnome
     - [ ] :simple-kde: KDE *(work in progress)*
 - Fully tested (Work in progress)
 
 **Presentations**
 
-Building large set of AppArmor profiles:
+Building the largest set of AppArmor profiles:
 
 - [Linux Security Summit North America (LSS-NA 2023)](https://events.linuxfoundation.org/linux-security-summit-north-america/) *([Slide](https://lssna2023.sched.com/event/1K7bI/building-the-largest-working-set-of-apparmor-profiles-alexandre-pujol-the-collaboratory-tudublin), [Video](https://www.youtube.com/watch?v=OzyalrOzxE8))*
 - [Ubuntu Summit 2023](https://events.canonical.com/event/31/) *([Slide](https://events.canonical.com/event/31/contributions/209/), [Video](https://www.youtube.com/watch?v=GK1J0TlxnFI))*

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,17 +4,17 @@ title: Installation
 
 !!! warning
 
-    In order to not break your system, the default package configuration installs all profiles in complain mode. They can be enforced later. See the [Enforce Mode](enforce.md) page.
+    To prevent the risk of breaking your system, the default package configuration installs all profiles in complain mode. They can be enforced later. See the [Enforce Mode](enforce.md) page.
 
 !!! danger
 
-    Do **not** install this project if your Desktop Environement and Display Manager is not supported. Your system will not boot, and that would be a feature.
+    Do **not** expect this project to work correctly if your Desktop Environment and Display Manager are not supported. Your Desktop Environment or Display Manager might not load, and that would be a feature.
 
 ## Requirements
 
 **AppArmor**
 
-An `apparmor` based Linux distribution is required. The default profiles and abstractions shipped with AppArmor must be installed.
+An `AppArmor` supported Linux distribution is required. The default profiles and abstractions shipped with AppArmor must be installed.
 
 **Desktop environment**
 
@@ -28,7 +28,7 @@ The following desktop environments are supported:
 
 * Go >= 1.18
 
-## :material-arch: Archlinux
+## :material-arch: Arch Linux
 
 `apparmor.d-git` is available in the [Arch User Repository][aur]:
 ```
@@ -72,7 +72,7 @@ sudo dpkg -i ../apparmor.d_*.deb
 
 !!! warning
 
-    **Beware**: do not install a `.deb` made for Debian on Ubuntu, the packages are differents.
+    **Beware**: do not install a `.deb` made for Debian on Ubuntu, the packages are different.
 
     If your distribution is based on Ubuntu or Debian, you may want to manually set the target distribution by exporting `DISTRIBUTION=debian` if is Debian based, or `DISTRIBUTION=ubuntu` if it is Ubuntu based.
 
@@ -97,7 +97,7 @@ sudo make profile-names...
 
 !!! warning
 
-    Partial installation is discouraged because profile dependencies are not fetched. To prevent some apparmor issues, the dependencies are automatically switched to unconfined (`rPx` -> `rPUx`). The installation process warns on the missing profiles so that you can easily install them if desired. (PR is welcome see [#77](https://github.com/roddhjav/apparmor.d/issues/77))
+    Partial installation is discouraged because profile dependencies are not fetched. To prevent some AppArmor issues, the dependencies are automatically switched to unconfined (`rPx` -> `rPUx`). The installation process warns on the missing profiles so that you can easily install them if desired. (PR is welcome see [#77](https://github.com/roddhjav/apparmor.d/issues/77))
 
     For instance, `sudo make pass` gives:
     ```sh
@@ -115,7 +115,7 @@ sudo make profile-names...
 
 ## Uninstall
 
-- :material-arch: Archlinux `sudo pacman -R apparmor.d`
+- :material-arch: Arch Linux `sudo pacman -R apparmor.d`
 - :material-ubuntu: Ubuntu & :material-debian: Debian `sudo apt purge apparmor.d`
 - :simple-suse: OpenSUSE `sudo zypper remove apparmor.d`
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -11,7 +11,7 @@ Known bugs are tracked on the meta issue **[#75](https://github.com/roddhjav/app
 
     * `deny` rules are enforced even in complain mode,
     * `attach_disconnected` (and `mediate_deleted`) will break the program if they are required and missing in the profile,
-    * If apparmor does not find the profile to transition `rPx`.
+    * If AppArmor does not find the profile to transition `rPx`.
 
 ### Pacman "could not get current working directory"
 
@@ -25,7 +25,7 @@ error: could not get current working directory
 
 This is **a feature, not a bug!** It can safely be ignored. Pacman tries to get your current directory. You will only get this error when you run pacman in your home directory.
 
-According to the Archlinux guideline, on Archlinux, packages cannot install files under `/home/`. Therefore, the [`pacman`][pacman] profile purposely does not allow access of your home directory.
+According to the Arch Linux guideline, on Arch Linux, packages cannot install files under `/home/`. Therefore, the [`pacman`][pacman] profile purposely does not allow access of your home directory.
 
 This provides a basic protection against some packages (on the AUR) that may have rogue install script.
 

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -2,15 +2,15 @@
 title: System Recovery
 ---
 
-Issue in some core profiles like the systemd suite, or the desktop environment can fully break your system. This should not happen a lot, but if it does here is the process to recover your system on Archlinux:
+An issue in some core profiles like the systemd suite, or the desktop environment can prevent your system from starting correctly. This is rare, but if it does happen this is the process to recover your system on an Arch Linux system **without subvolumes**:
 
-1. Boot from a Archlinux live USB
-1. If you root partition is encryped, decrypt it: `cryptsetup open /dev/<your-disk-id> vg0`
+1. Boot from an Arch Linux live USB
+1. If you root partition is encrypted, decrypt it: `cryptsetup open /dev/<your-disk-id> vg0`
 1. Mount your root partition: `mount /dev/<your-plain-disk-id> /mnt`
 1. Chroot into your system: `arch-chroot /mnt`
-1. Check the AppArmor messages to see what profile is faulty: `aa-log`
+1. Check the AppArmor logs to see which profile is faulty: `aa-log`
 1. Temporarily fix the issue with either:
-    - When only one profile is faultily, remove it: `rm /etc/apparmor.d/<profile-name>`
+    - When only one profile is causing problems, remove it: `rm /etc/apparmor.d/<profile-name>`
     - Otherwise, you can also remove the package: `pacman -R apparmor.d`
     - Alternatively, you may temporarily disable apparmor as it will allow you to
       boot and study the log: `systemctl disable apparmor`

--- a/docs/report.md
+++ b/docs/report.md
@@ -16,6 +16,16 @@ If this command produce nothing, try:
 aa-log -s -R
 ```
 
+If the log file is empty, check that Auditd is running:
+```sh
+sudo systemctl status auditd.service
+```
+
+If Auditd is disabled aa-log will not have new results, you can enable Auditd by doing the following command:
+```sh
+sudo systemctl enable auditd.service --now
+```
+
 You can get more logs with:
 
 1. `aa-log -R -s` that will provide all apparmor logs since boot time (if journalctl collect them)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,8 +76,7 @@ ps (complain)                   user        ps auxZ
 
 ## AppArmor Log
 
-Ensure that `auditd` is installed and running on your system in order to read AppArmor log from `/var/log/audit/audit.log`. Then you can see the log with the provided command `aa-log` allowing you to review AppArmor generated messages in
-a colorful way.
+Ensure that `Auditd` is installed and running on your system in order to read AppArmor log from `/var/log/audit/audit.log`. Then you can see the log with the provided command `aa-log` allowing you to review AppArmor generated messages in a colorful way.
 
 Other AppArmor userspace tools such as `aa-enforce`, `aa-complain`, and `aa-logprof` should work as expected.
 


### PR DESCRIPTION
Fixes some spelling mistakes, re-words parts to be more understandable, specifies recovery instructions are not meant for subvolume installs, adds Auditd information to `report.md`