### PR TITLE
feat(profiles-g-l): vim syntax support

### DIFF
--- a/apparmor.d/profiles-g-l/gajim
+++ b/apparmor.d/profiles-g-l/gajim
@@ -2,7 +2,6 @@
 # Copyright (C) 2015-2020 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -139,3 +138,5 @@ profile gajim @{exec_path} {
 
   include if exists <local/gajim>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gajim
+++ b/apparmor.d/profiles-g-l/gajim
@@ -2,6 +2,7 @@
 # Copyright (C) 2015-2020 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ganyremote
+++ b/apparmor.d/profiles-g-l/ganyremote
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ganyremote
+++ b/apparmor.d/profiles-g-l/ganyremote
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -95,3 +94,5 @@ profile ganyremote @{exec_path} {
 
   include if exists <local/ganyremote>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gconfd
+++ b/apparmor.d/profiles-g-l/gconfd
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gconfd
+++ b/apparmor.d/profiles-g-l/gconfd
@@ -2,7 +2,6 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -23,3 +22,5 @@ profile gconfd @{exec_path} {
 
   include if exists <local/gconfd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gdisk
+++ b/apparmor.d/profiles-g-l/gdisk
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gdisk
+++ b/apparmor.d/profiles-g-l/gdisk
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -33,3 +32,5 @@ profile gdisk @{exec_path} {
 
   include if exists <local/gdisk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gdk-pixbuf-query-loaders
+++ b/apparmor.d/profiles-g-l/gdk-pixbuf-query-loaders
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -26,3 +25,5 @@ profile gdk-pixbuf-query-loaders @{exec_path} {
 
   include if exists <local/gdk-pixbuf-query-loaders>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gdk-pixbuf-query-loaders
+++ b/apparmor.d/profiles-g-l/gdk-pixbuf-query-loaders
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ghc-pkg
+++ b/apparmor.d/profiles-g-l/ghc-pkg
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ghc-pkg
+++ b/apparmor.d/profiles-g-l/ghc-pkg
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile ghc-pkg @{exec_path} {
 
   include if exists <local/ghc-pkg>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gio-querymodules
+++ b/apparmor.d/profiles-g-l/gio-querymodules
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -24,3 +23,5 @@ profile gio-querymodules @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/gio-querymodules>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gio-querymodules
+++ b/apparmor.d/profiles-g-l/gio-querymodules
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/git
+++ b/apparmor.d/profiles-g-l/git
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2022 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -181,3 +180,5 @@ profile git @{exec_path} {
 
   include if exists <local/git>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/git
+++ b/apparmor.d/profiles-g-l/git
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2022 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gitstatusd
+++ b/apparmor.d/profiles-g-l/gitstatusd
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -26,3 +25,5 @@ profile gitstatusd @{exec_path} {
 
   include if exists <local/gitstatusd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gitstatusd
+++ b/apparmor.d/profiles-g-l/gitstatusd
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/glib-compile-resources
+++ b/apparmor.d/profiles-g-l/glib-compile-resources
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -21,3 +20,5 @@ profile glib-compile-resources @{exec_path} {
 
   include if exists <local/glib-compile-resources>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/glib-compile-resources
+++ b/apparmor.d/profiles-g-l/glib-compile-resources
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/glib-compile-schemas
+++ b/apparmor.d/profiles-g-l/glib-compile-schemas
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -30,3 +29,5 @@ profile glib-compile-schemas @{exec_path} {
 
   include if exists <local/glib-compile-schemas>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/glib-compile-schemas
+++ b/apparmor.d/profiles-g-l/glib-compile-schemas
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/glib-pacrunner
+++ b/apparmor.d/profiles-g-l/glib-pacrunner
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile glib-pacrunner @{exec_path} {
 
   include if exists <local/glib-pacrunner>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/glib-pacrunner
+++ b/apparmor.d/profiles-g-l/glib-pacrunner
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/globaltime
+++ b/apparmor.d/profiles-g-l/globaltime
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/globaltime
+++ b/apparmor.d/profiles-g-l/globaltime
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -26,3 +25,5 @@ profile globaltime @{exec_path} {
 
   include if exists <local/globaltime>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/glxgears
+++ b/apparmor.d/profiles-g-l/glxgears
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/glxgears
+++ b/apparmor.d/profiles-g-l/glxgears
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile glxgears @{exec_path} {
 
   include if exists <local/glxgears>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/glxinfo
+++ b/apparmor.d/profiles-g-l/glxinfo
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/glxinfo
+++ b/apparmor.d/profiles-g-l/glxinfo
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile glxinfo @{exec_path} {
 
   include if exists <local/glxinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpa
+++ b/apparmor.d/profiles-g-l/gpa
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpa
+++ b/apparmor.d/profiles-g-l/gpa
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -54,3 +53,5 @@ profile gpa @{exec_path} {
 
   include if exists <local/gpa>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gparted
+++ b/apparmor.d/profiles-g-l/gparted
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gparted
+++ b/apparmor.d/profiles-g-l/gparted
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -105,3 +104,5 @@ profile gparted @{exec_path} {
 
   include if exists <local/gparted>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpartedbin
+++ b/apparmor.d/profiles-g-l/gpartedbin
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpartedbin
+++ b/apparmor.d/profiles-g-l/gpartedbin
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -155,3 +154,5 @@ profile gpartedbin @{exec_path} {
 
   include if exists <local/gpartedbin>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpasswd
+++ b/apparmor.d/profiles-g-l/gpasswd
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpasswd
+++ b/apparmor.d/profiles-g-l/gpasswd
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -45,3 +44,5 @@ profile gpasswd @{exec_path} {
 
   include if exists <local/gpasswd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gping
+++ b/apparmor.d/profiles-g-l/gping
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -18,3 +17,5 @@ profile gping @{exec_path} {
 
   include if exists <local/gping>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gping
+++ b/apparmor.d/profiles-g-l/gping
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpo
+++ b/apparmor.d/profiles-g-l/gpo
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpo
+++ b/apparmor.d/profiles-g-l/gpo
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -45,3 +44,5 @@ profile gpo @{exec_path} {
 
   include if exists <local/gpo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpodder
+++ b/apparmor.d/profiles-g-l/gpodder
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpodder
+++ b/apparmor.d/profiles-g-l/gpodder
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -94,3 +93,5 @@ profile gpodder @{exec_path} {
 
   include if exists <local/gpodder>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpodder-migrate2tres
+++ b/apparmor.d/profiles-g-l/gpodder-migrate2tres
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gpodder-migrate2tres
+++ b/apparmor.d/profiles-g-l/gpodder-migrate2tres
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -27,3 +26,5 @@ profile gpodder-migrate2tres @{exec_path} {
 
   include if exists <local/gpodder-migrate2tres>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpu-manager
+++ b/apparmor.d/profiles-g-l/gpu-manager
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -35,3 +34,5 @@ profile gpu-manager @{exec_path} {
 
   include if exists <local/gpu-manager>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gpu-manager
+++ b/apparmor.d/profiles-g-l/gpu-manager
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/groupadd
+++ b/apparmor.d/profiles-g-l/groupadd
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -38,3 +37,5 @@ profile groupadd @{exec_path} {
 
   include if exists <local/groupadd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/groupadd
+++ b/apparmor.d/profiles-g-l/groupadd
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/groupdel
+++ b/apparmor.d/profiles-g-l/groupdel
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/groupdel
+++ b/apparmor.d/profiles-g-l/groupdel
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -41,3 +40,5 @@ profile groupdel @{exec_path} {
 
   include if exists <local/groupdel>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/groupmod
+++ b/apparmor.d/profiles-g-l/groupmod
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/groupmod
+++ b/apparmor.d/profiles-g-l/groupmod
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -42,3 +41,5 @@ profile groupmod @{exec_path} {
 
   include if exists <local/groupmod>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/groups
+++ b/apparmor.d/profiles-g-l/groups
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/groups
+++ b/apparmor.d/profiles-g-l/groups
@@ -2,7 +2,6 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -20,3 +19,5 @@ profile groups @{exec_path} {
 
   include if exists <local/groups>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/grpck
+++ b/apparmor.d/profiles-g-l/grpck
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/grpck
+++ b/apparmor.d/profiles-g-l/grpck
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -35,3 +34,5 @@ profile grpck @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/grpck>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gsettings
+++ b/apparmor.d/profiles-g-l/gsettings
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -27,3 +26,5 @@ profile gsettings @{exec_path} {
 
   include if exists <local/gsettings>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gsettings
+++ b/apparmor.d/profiles-g-l/gsettings
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gsimplecal
+++ b/apparmor.d/profiles-g-l/gsimplecal
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gsimplecal
+++ b/apparmor.d/profiles-g-l/gsimplecal
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -19,3 +18,5 @@ profile gsimplecal @{exec_path} {
 
   include if exists <local/gsimplecal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gsmartcontrol
+++ b/apparmor.d/profiles-g-l/gsmartcontrol
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gsmartcontrol
+++ b/apparmor.d/profiles-g-l/gsmartcontrol
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -111,3 +110,5 @@ profile gsmartcontrol @{exec_path} {
 
   include if exists <local/gsmartcontrol>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gsmartcontrol-root
+++ b/apparmor.d/profiles-g-l/gsmartcontrol-root
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gsmartcontrol-root
+++ b/apparmor.d/profiles-g-l/gsmartcontrol-root
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile gsmartcontrol-root @{exec_path} {
 
   include if exists <local/gsmartcontrol-root>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gssproxy
+++ b/apparmor.d/profiles-g-l/gssproxy
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gssproxy
+++ b/apparmor.d/profiles-g-l/gssproxy
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -27,3 +26,5 @@ profile gssproxy @{exec_path} {
 
   include if exists <local/gssproxy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gtk-query-immodules
+++ b/apparmor.d/profiles-g-l/gtk-query-immodules
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -25,3 +24,5 @@ profile gtk-query-immodules @{exec_path} {
 
   include if exists <local/gtk-query-immodules>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gtk-query-immodules
+++ b/apparmor.d/profiles-g-l/gtk-query-immodules
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gtk-update-icon-cache
+++ b/apparmor.d/profiles-g-l/gtk-update-icon-cache
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -25,3 +24,5 @@ profile gtk-update-icon-cache @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/gtk-update-icon-cache>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/gtk-update-icon-cache
+++ b/apparmor.d/profiles-g-l/gtk-update-icon-cache
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gtk-youtube-viewer
+++ b/apparmor.d/profiles-g-l/gtk-youtube-viewer
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/gtk-youtube-viewer
+++ b/apparmor.d/profiles-g-l/gtk-youtube-viewer
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -120,3 +119,5 @@ profile gtk-youtube-viewer @{exec_path} {
 
   include if exists <local/gtk-youtube-viewer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hardinfo
+++ b/apparmor.d/profiles-g-l/hardinfo
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hardinfo
+++ b/apparmor.d/profiles-g-l/hardinfo
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -198,3 +197,5 @@ profile hardinfo @{exec_path} {
 
   include if exists <local/hardinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/haveged
+++ b/apparmor.d/profiles-g-l/haveged
@@ -29,3 +29,5 @@ profile haveged @{exec_path} {
 
   include if exists <local/haveged>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hbbr
+++ b/apparmor.d/profiles-g-l/hbbr
@@ -1,6 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -24,3 +23,5 @@ profile hbbr @{exec_path} {
 
   include if exists <local/hbbr>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hbbr
+++ b/apparmor.d/profiles-g-l/hbbr
@@ -1,5 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hbbs
+++ b/apparmor.d/profiles-g-l/hbbs
@@ -1,5 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hbbs
+++ b/apparmor.d/profiles-g-l/hbbs
@@ -1,6 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile hbbs @{exec_path} {
 
   include if exists <local/hbbs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hciconfig
+++ b/apparmor.d/profiles-g-l/hciconfig
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hciconfig
+++ b/apparmor.d/profiles-g-l/hciconfig
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -21,3 +20,5 @@ profile hciconfig @{exec_path} {
 
   include if exists <local/hciconfig>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hddtemp
+++ b/apparmor.d/profiles-g-l/hddtemp
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hddtemp
+++ b/apparmor.d/profiles-g-l/hddtemp
@@ -2,7 +2,6 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -39,3 +38,5 @@ profile hddtemp @{exec_path} {
 
   include if exists <local/hddtemp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hdparm
+++ b/apparmor.d/profiles-g-l/hdparm
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hdparm
+++ b/apparmor.d/profiles-g-l/hdparm
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -35,3 +34,5 @@ profile hdparm @{exec_path} flags=(complain) {
 
   include if exists <local/hdparm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hexchat
+++ b/apparmor.d/profiles-g-l/hexchat
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hexchat
+++ b/apparmor.d/profiles-g-l/hexchat
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -53,3 +52,5 @@ profile hexchat @{exec_path} {
 
   include if exists <local/hexchat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/highlight
+++ b/apparmor.d/profiles-g-l/highlight
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -21,3 +20,5 @@ profile highlight @{exec_path} {
 
   include if exists <local/highlight>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/highlight
+++ b/apparmor.d/profiles-g-l/highlight
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/host
+++ b/apparmor.d/profiles-g-l/host
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -28,3 +27,5 @@ profile host @{exec_path} {
 
   include if exists <local/host>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/host
+++ b/apparmor.d/profiles-g-l/host
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hostname
+++ b/apparmor.d/profiles-g-l/hostname
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hostname
+++ b/apparmor.d/profiles-g-l/hostname
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -26,3 +25,5 @@ profile hostname @{exec_path} {
 
   include if exists <local/hostname>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/htop
+++ b/apparmor.d/profiles-g-l/htop
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/htop
+++ b/apparmor.d/profiles-g-l/htop
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -137,3 +136,5 @@ profile htop @{exec_path} {
 
   include if exists <local/htop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hugeadm
+++ b/apparmor.d/profiles-g-l/hugeadm
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hugeadm
+++ b/apparmor.d/profiles-g-l/hugeadm
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -60,3 +59,5 @@ profile hugeadm @{exec_path} {
 
   include if exists <local/hugeadm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hugo
+++ b/apparmor.d/profiles-g-l/hugo
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hugo
+++ b/apparmor.d/profiles-g-l/hugo
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -47,3 +46,5 @@ profile hugo @{exec_path} {
 
   include if exists <local/hugo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hw-probe
+++ b/apparmor.d/profiles-g-l/hw-probe
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hw-probe
+++ b/apparmor.d/profiles-g-l/hw-probe
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -230,3 +229,5 @@ profile hw-probe @{exec_path} {
 
   include if exists <local/hw-probe>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hwinfo
+++ b/apparmor.d/profiles-g-l/hwinfo
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/hwinfo
+++ b/apparmor.d/profiles-g-l/hwinfo
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -114,3 +113,5 @@ profile hwinfo @{exec_path} {
 
   include if exists <local/hwinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hypnotix
+++ b/apparmor.d/profiles-g-l/hypnotix
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -89,3 +88,5 @@ profile hypnotix @{exec_path} {
 
   include if exists <local/hypnotix>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/hypnotix
+++ b/apparmor.d/profiles-g-l/hypnotix
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/i2cdetect
+++ b/apparmor.d/profiles-g-l/i2cdetect
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/i2cdetect
+++ b/apparmor.d/profiles-g-l/i2cdetect
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -18,3 +17,5 @@ profile i2cdetect @{exec_path} {
 
   include if exists <local/i2cdetect>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/i3lock
+++ b/apparmor.d/profiles-g-l/i3lock
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/i3lock
+++ b/apparmor.d/profiles-g-l/i3lock
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -37,3 +36,5 @@ profile i3lock @{exec_path} {
 
   include if exists <local/i3lock>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/i3lock-fancy
+++ b/apparmor.d/profiles-g-l/i3lock-fancy
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/i3lock-fancy
+++ b/apparmor.d/profiles-g-l/i3lock-fancy
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -72,3 +71,5 @@ profile i3lock-fancy @{exec_path} {
 
   include if exists <local/i3lock-fancy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/iceauth
+++ b/apparmor.d/profiles-g-l/iceauth
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iceauth
+++ b/apparmor.d/profiles-g-l/iceauth
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -24,3 +23,5 @@ profile iceauth @{exec_path} {
 
   include if exists <local/iceauth>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/id
+++ b/apparmor.d/profiles-g-l/id
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/id
+++ b/apparmor.d/profiles-g-l/id
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile id @{exec_path} {
 
   include if exists <local/id>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ifconfig
+++ b/apparmor.d/profiles-g-l/ifconfig
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ifconfig
+++ b/apparmor.d/profiles-g-l/ifconfig
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -31,3 +30,5 @@ profile ifconfig @{exec_path} {
 
   include if exists <local/ifconfig>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ifup
+++ b/apparmor.d/profiles-g-l/ifup
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -130,3 +129,5 @@ profile ifup @{exec_path} {
 
   include if exists <local/ifup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ifup
+++ b/apparmor.d/profiles-g-l/ifup
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/im-launch
+++ b/apparmor.d/profiles-g-l/im-launch
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/im-launch
+++ b/apparmor.d/profiles-g-l/im-launch
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -41,3 +40,5 @@ profile im-launch @{exec_path} {
 
   include if exists <local/im-launch>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/imv-wayland
+++ b/apparmor.d/profiles-g-l/imv-wayland
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/imv-wayland
+++ b/apparmor.d/profiles-g-l/imv-wayland
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -28,3 +27,5 @@ profile imv @{exec_path} {
 
   include if exists <local/imv-wayland>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/initd-kexec
+++ b/apparmor.d/profiles-g-l/initd-kexec
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/initd-kexec
+++ b/apparmor.d/profiles-g-l/initd-kexec
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -55,3 +54,5 @@ profile initd-kexec @{exec_path} {
 
   include if exists <local/initd-kexec>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/initd-kexec-load
+++ b/apparmor.d/profiles-g-l/initd-kexec-load
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/initd-kexec-load
+++ b/apparmor.d/profiles-g-l/initd-kexec-load
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -79,3 +78,5 @@ profile initd-kexec-load @{exec_path} {
 
   include if exists <local/initd-kexec-load>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/initd-kmod
+++ b/apparmor.d/profiles-g-l/initd-kmod
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/initd-kmod
+++ b/apparmor.d/profiles-g-l/initd-kmod
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -61,3 +60,5 @@ profile initd-kmod @{exec_path} {
 
   include if exists <local/initd-kmod>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/install-catalog
+++ b/apparmor.d/profiles-g-l/install-catalog
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/install-catalog
+++ b/apparmor.d/profiles-g-l/install-catalog
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -28,3 +27,5 @@ profile install-catalog @{exec_path} {
 
   include if exists <local/install-catalog>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/install-info
+++ b/apparmor.d/profiles-g-l/install-info
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -31,3 +30,5 @@ profile install-info @{exec_path} {
 
   include if exists <local/install-info>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/install-info
+++ b/apparmor.d/profiles-g-l/install-info
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/install-printerdriver
+++ b/apparmor.d/profiles-g-l/install-printerdriver
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/install-printerdriver
+++ b/apparmor.d/profiles-g-l/install-printerdriver
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -23,3 +22,5 @@ profile install-printerdriver @{exec_path} flags=(complain) {
 
   include if exists <local/install-printerdriver>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/inxi
+++ b/apparmor.d/profiles-g-l/inxi
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/inxi
+++ b/apparmor.d/profiles-g-l/inxi
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -172,3 +171,5 @@ profile inxi @{exec_path} {
 
   include if exists <local/inxi>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ioping
+++ b/apparmor.d/profiles-g-l/ioping
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ioping
+++ b/apparmor.d/profiles-g-l/ioping
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -48,3 +47,5 @@ profile ioping @{exec_path} {
 
   include if exists <local/ioping>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/iotop
+++ b/apparmor.d/profiles-g-l/iotop
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iotop
+++ b/apparmor.d/profiles-g-l/iotop
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -40,3 +39,5 @@ profile iotop @{exec_path} {
 
   include if exists <local/iotop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ip
+++ b/apparmor.d/profiles-g-l/ip
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ip
+++ b/apparmor.d/profiles-g-l/ip
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -52,3 +51,5 @@ profile ip @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ip>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/ipcalc
+++ b/apparmor.d/profiles-g-l/ipcalc
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/ipcalc
+++ b/apparmor.d/profiles-g-l/ipcalc
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -18,3 +17,5 @@ profile ipcalc @{exec_path} {
 
   include if exists <local/ipcalc>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/irqbalance
+++ b/apparmor.d/profiles-g-l/irqbalance
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -43,3 +42,5 @@ profile irqbalance @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/irqbalance>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/irqbalance
+++ b/apparmor.d/profiles-g-l/irqbalance
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/issue-generator
+++ b/apparmor.d/profiles-g-l/issue-generator
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile issue-generator @{exec_path} {
 
   include if exists <local/issue-generator>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/issue-generator
+++ b/apparmor.d/profiles-g-l/issue-generator
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iw
+++ b/apparmor.d/profiles-g-l/iw
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iw
+++ b/apparmor.d/profiles-g-l/iw
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile iw @{exec_path} {
 
   include if exists <local/iw>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/iwconfig
+++ b/apparmor.d/profiles-g-l/iwconfig
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iwconfig
+++ b/apparmor.d/profiles-g-l/iwconfig
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile iwconfig @{exec_path} {
 
   include if exists <local/iwconfig>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/iwlist
+++ b/apparmor.d/profiles-g-l/iwlist
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/iwlist
+++ b/apparmor.d/profiles-g-l/iwlist
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile iwlist @{exec_path} {
 
   include if exists <local/iwlist>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jackdbus
+++ b/apparmor.d/profiles-g-l/jackdbus
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jackdbus
+++ b/apparmor.d/profiles-g-l/jackdbus
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -28,3 +27,5 @@ profile jackdbus @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/jackdbus>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jami-gnome
+++ b/apparmor.d/profiles-g-l/jami-gnome
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jami-gnome
+++ b/apparmor.d/profiles-g-l/jami-gnome
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -58,3 +57,5 @@ profile jami-gnome @{exec_path} {
 
   include if exists <local/jami-gnome>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jdownloader
+++ b/apparmor.d/profiles-g-l/jdownloader
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jdownloader
+++ b/apparmor.d/profiles-g-l/jdownloader
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -125,3 +124,5 @@ profile jdownloader @{exec_path} {
 
   include if exists <local/jdownloader>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jekyll
+++ b/apparmor.d/profiles-g-l/jekyll
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jekyll
+++ b/apparmor.d/profiles-g-l/jekyll
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -34,3 +33,5 @@ profile jekyll @{exec_path} {
 
   include if exists <local/jekyll>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jgmenu
+++ b/apparmor.d/profiles-g-l/jgmenu
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jgmenu
+++ b/apparmor.d/profiles-g-l/jgmenu
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -58,3 +57,5 @@ profile jgmenu @{exec_path} {
 
   include if exists <local/jgmenu>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jitterentropy-rngd
+++ b/apparmor.d/profiles-g-l/jitterentropy-rngd
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jitterentropy-rngd
+++ b/apparmor.d/profiles-g-l/jitterentropy-rngd
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -23,3 +22,5 @@ profile jitterentropy-rngd @{exec_path} {
 
   include if exists <local/jitterentropy-rngd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/jmtpfs
+++ b/apparmor.d/profiles-g-l/jmtpfs
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/jmtpfs
+++ b/apparmor.d/profiles-g-l/jmtpfs
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -63,3 +62,5 @@ profile jmtpfs @{exec_path} {
 
   include if exists <local/jmtpfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kanyremote
+++ b/apparmor.d/profiles-g-l/kanyremote
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kanyremote
+++ b/apparmor.d/profiles-g-l/kanyremote
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -99,3 +98,5 @@ profile kanyremote @{exec_path} {
 
   include if exists <local/kanyremote>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kcheckpass
+++ b/apparmor.d/profiles-g-l/kcheckpass
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kcheckpass
+++ b/apparmor.d/profiles-g-l/kcheckpass
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -24,3 +23,5 @@ profile kcheckpass @{exec_path} {
 
   include if exists <local/kcheckpass>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kconfig-hardened-check
+++ b/apparmor.d/profiles-g-l/kconfig-hardened-check
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kconfig-hardened-check
+++ b/apparmor.d/profiles-g-l/kconfig-hardened-check
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -28,3 +27,5 @@ profile kconfig-hardened-check @{exec_path} {
 
   include if exists <local/kconfig-hardened-check>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/keepassxc
+++ b/apparmor.d/profiles-g-l/keepassxc
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/keepassxc
+++ b/apparmor.d/profiles-g-l/keepassxc
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -100,3 +99,5 @@ profile keepassxc @{exec_path} {
 
   include if exists <local/keepassxc>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/keepassxc-cli
+++ b/apparmor.d/profiles-g-l/keepassxc-cli
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/keepassxc-cli
+++ b/apparmor.d/profiles-g-l/keepassxc-cli
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -16,3 +15,5 @@ profile keepassxc-cli @{exec_path} {
 
   include if exists <local/keepassxc-cli>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/keepassxc-proxy
+++ b/apparmor.d/profiles-g-l/keepassxc-proxy
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/keepassxc-proxy
+++ b/apparmor.d/profiles-g-l/keepassxc-proxy
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -48,3 +47,5 @@ profile keepassxc-proxy @{exec_path} {
 
   include if exists <local/keepassxc-proxy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kernel-install
+++ b/apparmor.d/profiles-g-l/kernel-install
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kernel-install
+++ b/apparmor.d/profiles-g-l/kernel-install
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -66,3 +65,5 @@ profile kernel-install @{exec_path} {
 
   include if exists <local/kernel-install>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kerneloops
+++ b/apparmor.d/profiles-g-l/kerneloops
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile kerneloops @{exec_path} {
 
   include if exists <local/kerneloops>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kerneloops
+++ b/apparmor.d/profiles-g-l/kerneloops
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kerneloops-applet
+++ b/apparmor.d/profiles-g-l/kerneloops-applet
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -25,3 +24,5 @@ profile kerneloops-applet @{exec_path} {
 
   include if exists <local/kerneloops-applet>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kerneloops-applet
+++ b/apparmor.d/profiles-g-l/kerneloops-applet
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kexec
+++ b/apparmor.d/profiles-g-l/kexec
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kexec
+++ b/apparmor.d/profiles-g-l/kexec
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile kexec @{exec_path} flags=(complain) {
 
   include if exists <local/kexec>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kmod
+++ b/apparmor.d/profiles-g-l/kmod
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kmod
+++ b/apparmor.d/profiles-g-l/kmod
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -77,3 +76,5 @@ profile kmod @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/kmod>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kodi
+++ b/apparmor.d/profiles-g-l/kodi
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kodi
+++ b/apparmor.d/profiles-g-l/kodi
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -67,3 +66,5 @@ profile kodi @{exec_path} {
 
   include if exists <local/kodi>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kodi-xrandr
+++ b/apparmor.d/profiles-g-l/kodi-xrandr
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -23,3 +22,5 @@ profile kodi-xrandr @{exec_path} {
 
   include if exists <local/kodi-xrandr>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/kodi-xrandr
+++ b/apparmor.d/profiles-g-l/kodi-xrandr
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kvm-ok
+++ b/apparmor.d/profiles-g-l/kvm-ok
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/kvm-ok
+++ b/apparmor.d/profiles-g-l/kvm-ok
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -47,3 +46,5 @@ profile kvm-ok @{exec_path} {
 
   include if exists <local/kvm-ok>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/labwc
+++ b/apparmor.d/profiles-g-l/labwc
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/labwc
+++ b/apparmor.d/profiles-g-l/labwc
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -57,3 +56,5 @@ profile labwc @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/labwc>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/landscape-sysinfo
+++ b/apparmor.d/profiles-g-l/landscape-sysinfo
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/landscape-sysinfo
+++ b/apparmor.d/profiles-g-l/landscape-sysinfo
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -47,3 +46,5 @@ profile landscape-sysinfo @{exec_path} {
 
   include if exists <local/landscape-sysinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/landscape-sysinfo.wrapper
+++ b/apparmor.d/profiles-g-l/landscape-sysinfo.wrapper
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/landscape-sysinfo.wrapper
+++ b/apparmor.d/profiles-g-l/landscape-sysinfo.wrapper
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -34,3 +33,5 @@ profile landscape-sysinfo.wrapper @{exec_path} {
 
   include if exists <local/landscape-sysinfo.wrapper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/language-validate
+++ b/apparmor.d/profiles-g-l/language-validate
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/language-validate
+++ b/apparmor.d/profiles-g-l/language-validate
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -24,3 +23,5 @@ profile language-validate @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/language-validate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/last
+++ b/apparmor.d/profiles-g-l/last
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/last
+++ b/apparmor.d/profiles-g-l/last
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -29,3 +28,5 @@ profile last @{exec_path} {
 
   include if exists <local/last>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lastlog
+++ b/apparmor.d/profiles-g-l/lastlog
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -23,3 +22,5 @@ profile lastlog @{exec_path} {
 
   include if exists <local/lastlog>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lastlog
+++ b/apparmor.d/profiles-g-l/lastlog
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/libreoffice
+++ b/apparmor.d/profiles-g-l/libreoffice
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -89,3 +88,5 @@ profile libreoffice @{exec_path} {
 
   include if exists <local/libreoffice>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/libreoffice
+++ b/apparmor.d/profiles-g-l/libreoffice
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/light
+++ b/apparmor.d/profiles-g-l/light
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/light
+++ b/apparmor.d/profiles-g-l/light
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -37,3 +36,5 @@ profile light @{exec_path} {
 
   include if exists <local/light>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/light-locker
+++ b/apparmor.d/profiles-g-l/light-locker
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/light-locker
+++ b/apparmor.d/profiles-g-l/light-locker
@@ -2,7 +2,6 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -39,3 +38,5 @@ profile light-locker @{exec_path} {
 
   include if exists <local/light-locker>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/light-locker-command
+++ b/apparmor.d/profiles-g-l/light-locker-command
@@ -2,6 +2,7 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/light-locker-command
+++ b/apparmor.d/profiles-g-l/light-locker-command
@@ -2,7 +2,6 @@
 # Copyright (C) 2017-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -16,3 +15,5 @@ profile light-locker-command @{exec_path} {
 
   include if exists <local/light-locker-command>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lightworks
+++ b/apparmor.d/profiles-g-l/lightworks
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lightworks
+++ b/apparmor.d/profiles-g-l/lightworks
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -27,3 +26,5 @@ profile lightworks @{exec_path} {
 
   include if exists <local/lightworks>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lightworks-ntcardvt
+++ b/apparmor.d/profiles-g-l/lightworks-ntcardvt
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lightworks-ntcardvt
+++ b/apparmor.d/profiles-g-l/lightworks-ntcardvt
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -16,3 +15,5 @@ profile lightworks-ntcardvt @{exec_path} {
 
   include if exists <local/lightworks-ntcardvt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/linssid
+++ b/apparmor.d/profiles-g-l/linssid
@@ -2,6 +2,7 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/linssid
+++ b/apparmor.d/profiles-g-l/linssid
@@ -2,7 +2,6 @@
 # Copyright (C) 2020-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -110,3 +109,5 @@ profile linssid @{exec_path} {
 
   include if exists <local/linssid>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/linux-check-removal
+++ b/apparmor.d/profiles-g-l/linux-check-removal
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/linux-check-removal
+++ b/apparmor.d/profiles-g-l/linux-check-removal
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -51,3 +50,5 @@ profile linux-check-removal @{exec_path} flags=(complain) {
 
   include if exists <local/linux-check-removal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/linux-version
+++ b/apparmor.d/profiles-g-l/linux-version
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/linux-version
+++ b/apparmor.d/profiles-g-l/linux-version
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -21,3 +20,5 @@ profile linux-version @{exec_path} {
 
   include if exists <local/linux-version>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/locale-gen
+++ b/apparmor.d/profiles-g-l/locale-gen
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/locale-gen
+++ b/apparmor.d/profiles-g-l/locale-gen
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -41,3 +40,5 @@ profile locale-gen @{exec_path} {
 
   include if exists <local/locale-gen>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/localepurge
+++ b/apparmor.d/profiles-g-l/localepurge
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/localepurge
+++ b/apparmor.d/profiles-g-l/localepurge
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -58,3 +57,5 @@ profile localepurge @{exec_path} {
 
   include if exists <local/localepurge>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/login
+++ b/apparmor.d/profiles-g-l/login
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -74,3 +73,5 @@ profile login @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/login>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/login
+++ b/apparmor.d/profiles-g-l/login
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/logrotate
+++ b/apparmor.d/profiles-g-l/logrotate
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2022 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/logrotate
+++ b/apparmor.d/profiles-g-l/logrotate
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2022 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -105,3 +104,5 @@ profile logrotate @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/logrotate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/losetup
+++ b/apparmor.d/profiles-g-l/losetup
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -26,3 +25,5 @@ profile losetup @{exec_path} {
 
   include if exists <local/losetup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/losetup
+++ b/apparmor.d/profiles-g-l/losetup
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/low-memory-monitor
+++ b/apparmor.d/profiles-g-l/low-memory-monitor
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -19,3 +18,5 @@ profile low-memory-monitor @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/low-memory-monitor>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/low-memory-monitor
+++ b/apparmor.d/profiles-g-l/low-memory-monitor
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lsblk
+++ b/apparmor.d/profiles-g-l/lsblk
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lsblk
+++ b/apparmor.d/profiles-g-l/lsblk
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -31,3 +30,5 @@ profile lsblk @{exec_path} {
 
   include if exists <local/lsblk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lscpu
+++ b/apparmor.d/profiles-g-l/lscpu
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lscpu
+++ b/apparmor.d/profiles-g-l/lscpu
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -31,3 +30,5 @@ profile lscpu @{exec_path} {
 
   include if exists <local/lscpu>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lsinitramfs
+++ b/apparmor.d/profiles-g-l/lsinitramfs
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile lsinitramfs @{exec_path} {
 
   include if exists <local/lsinitramfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lsinitramfs
+++ b/apparmor.d/profiles-g-l/lsinitramfs
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lspci
+++ b/apparmor.d/profiles-g-l/lspci
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lspci
+++ b/apparmor.d/profiles-g-l/lspci
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -45,3 +44,5 @@ profile lspci @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/lspci>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lsusb
+++ b/apparmor.d/profiles-g-l/lsusb
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lsusb
+++ b/apparmor.d/profiles-g-l/lsusb
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -22,3 +21,5 @@ profile lsusb @{exec_path} {
 
   include if exists <local/lsusb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lvm
+++ b/apparmor.d/profiles-g-l/lvm
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lvm
+++ b/apparmor.d/profiles-g-l/lvm
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -51,3 +50,5 @@ profile lvm @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/lvm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lvmconfig
+++ b/apparmor.d/profiles-g-l/lvmconfig
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -18,3 +17,5 @@ profile lvmconfig @{exec_path} {
 
   include if exists <local/lvmconfig>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lvmconfig
+++ b/apparmor.d/profiles-g-l/lvmconfig
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lvmdump
+++ b/apparmor.d/profiles-g-l/lvmdump
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lvmdump
+++ b/apparmor.d/profiles-g-l/lvmdump
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -18,3 +17,5 @@ profile lvmdump @{exec_path} {
   include if exists <local/lvmdump>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lvmpolld
+++ b/apparmor.d/profiles-g-l/lvmpolld
@@ -1,6 +1,7 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lvmpolld
+++ b/apparmor.d/profiles-g-l/lvmpolld
@@ -1,7 +1,6 @@
 # apparmor.d - Full set of apparmor profiles
 # Copyright (C) 2022 Jeroen Rijken
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -21,3 +20,5 @@ profile lvmpolld @{exec_path} {
 
   include if exists <local/lvmpolld>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lxappearance
+++ b/apparmor.d/profiles-g-l/lxappearance
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lxappearance
+++ b/apparmor.d/profiles-g-l/lxappearance
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -68,3 +67,5 @@ profile lxappearance @{exec_path} {
 
   include if exists <local/lxappearance>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/lynx
+++ b/apparmor.d/profiles-g-l/lynx
@@ -2,6 +2,7 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
+# vim:syntax=apparmor
 
 abi <abi/3.0>,
 

--- a/apparmor.d/profiles-g-l/lynx
+++ b/apparmor.d/profiles-g-l/lynx
@@ -2,7 +2,6 @@
 # Copyright (C) 2019-2021 Mikhail Morfikov
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
-# vim:syntax=apparmor
 
 abi <abi/3.0>,
 
@@ -38,3 +37,5 @@ profile lynx @{exec_path} {
 
   include if exists <local/lynx>
 }
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add vim modeline instructing the editor to use syntax plugin provided by apparmor.

Continuation of #379 and #380 to keep the diff list relatively short.