### PR TITLE
Fix signal menu

### DIFF
--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -43,6 +43,7 @@ profile signal-desktop @{exec_path} {
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/memory.high r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/memory.max r,
 
+  @{PROC}/@{pid}/fd/ r,
   @{PROC}/vmstat r,
 
   include if exists <local/signal-desktop>

--- a/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
+++ b/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
@@ -22,6 +22,8 @@ profile signal-desktop-chrome-sandbox @{exec_path} {
   @{lib_dirs}/signal-desktop{,-beta} rPx,
 
   @{PROC}/@{pid}/ r,
+  @{PROC}/@{pid}/oom_adj w,
+  @{PROC}/@{pid}/oom_score_adj w,
 
   include if exists <local/signal-desktop-chrome-sandbox>
 }


### PR DESCRIPTION
Selecting the context menu crashes the application. The added permissions avoid this.

I have not added this yet, since everything seems to work just fine without it., but there was one additional denied permission in my logs for signal-desktop-chrome-sandbox:

`capability dac_override,`
