### PR TITLE
feat(profiles-s-z): vim syntax support

### DIFF
--- a/apparmor.d/profiles-s-z/YACReader
+++ b/apparmor.d/profiles-s-z/YACReader
@@ -44,3 +44,5 @@ profile YACReader @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
   include if exists <local/YACReader>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/YACReaderLibrary
+++ b/apparmor.d/profiles-s-z/YACReaderLibrary
@@ -47,3 +47,5 @@ profile YACReaderLibrary @{exec_path} flags=(attach_disconnected,mediate_deleted
 
   include if exists <local/YACReaderLibrary>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/s3fs
+++ b/apparmor.d/profiles-s-z/s3fs
@@ -70,3 +70,5 @@ profile s3fs @{exec_path} {
 
   include if exists <local/s3fs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sanoid
+++ b/apparmor.d/profiles-s-z/sanoid
@@ -31,3 +31,5 @@ profile sanoid @{exec_path} flags=(complain) {
 
   include if exists <local/sanoid>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sbctl
+++ b/apparmor.d/profiles-s-z/sbctl
@@ -40,3 +40,5 @@ profile sbctl @{exec_path} {
 
   include if exists <local/sbctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/scrcpy
+++ b/apparmor.d/profiles-s-z/scrcpy
@@ -38,3 +38,5 @@ profile scrcpy @{exec_path} {
 
   include if exists <local/scrcpy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/scrot
+++ b/apparmor.d/profiles-s-z/scrot
@@ -29,3 +29,5 @@ profile scrot @{exec_path} {
 
   include if exists <local/scrot>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sdcv
+++ b/apparmor.d/profiles-s-z/sdcv
@@ -22,3 +22,5 @@ profile sdcv @{exec_path} {
 
   include if exists <local/sdcv>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/secure-time-sync
+++ b/apparmor.d/profiles-s-z/secure-time-sync
@@ -31,3 +31,5 @@ profile secure-time-sync @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/secure-time-sync>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sensors
+++ b/apparmor.d/profiles-s-z/sensors
@@ -45,3 +45,5 @@ profile sensors @{exec_path} {
 
   include if exists <local/sensors>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sensors-detect
+++ b/apparmor.d/profiles-s-z/sensors-detect
@@ -74,3 +74,5 @@ profile sensors-detect @{exec_path} {
 
   include if exists <local/sensors-detect>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/setpci
+++ b/apparmor.d/profiles-s-z/setpci
@@ -19,3 +19,5 @@ profile setpci @{exec_path} flags=(complain) {
 
   include if exists <local/setpci>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/setvtrgb
+++ b/apparmor.d/profiles-s-z/setvtrgb
@@ -19,3 +19,5 @@ profile setvtrgb @{exec_path} {
 
   include if exists <local/setvtrgb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sfdisk
+++ b/apparmor.d/profiles-s-z/sfdisk
@@ -34,3 +34,5 @@ profile sfdisk @{exec_path} {
 
   include if exists <local/sfdisk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sgdisk
+++ b/apparmor.d/profiles-s-z/sgdisk
@@ -25,3 +25,5 @@ profile sgdisk @{exec_path} {
 
   include if exists <local/sgdisk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sing-box
+++ b/apparmor.d/profiles-s-z/sing-box
@@ -35,3 +35,5 @@ profile sing-box @{exec_path} {
   
   include if exists <local/sing-box>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/slirp4netns
+++ b/apparmor.d/profiles-s-z/slirp4netns
@@ -42,3 +42,5 @@ profile slirp4netns @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/slirp4netns>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/smartctl
+++ b/apparmor.d/profiles-s-z/smartctl
@@ -27,3 +27,5 @@ profile smartctl @{exec_path} {
 
   include if exists <local/smartctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/smartd
+++ b/apparmor.d/profiles-s-z/smartd
@@ -53,3 +53,5 @@ profile smartd @{exec_path} {
 
   include if exists <local/smartd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/smbspool
+++ b/apparmor.d/profiles-s-z/smbspool
@@ -16,3 +16,5 @@ profile smbspool @{exec_path} {
 
   include if exists <local/smbspool>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/smplayer
+++ b/apparmor.d/profiles-s-z/smplayer
@@ -87,3 +87,5 @@ profile smplayer @{exec_path} {
   include if exists <local/smplayer>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/smtube
+++ b/apparmor.d/profiles-s-z/smtube
@@ -102,3 +102,5 @@ profile smtube @{exec_path} {
 
   include if exists <local/smtube>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap
+++ b/apparmor.d/profiles-s-z/snap
@@ -111,3 +111,5 @@ profile snap @{exec_path} {
 
   include if exists <local/snap>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-bootstrap
+++ b/apparmor.d/profiles-s-z/snap-bootstrap
@@ -14,3 +14,5 @@ profile snap-bootstrap @{exec_path} {
 
   include if exists <local/snap-bootstrap>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-device-helper
+++ b/apparmor.d/profiles-s-z/snap-device-helper
@@ -21,3 +21,5 @@ profile snap-device-helper @{exec_path} {
 
   include if exists <local/snap-device-helper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-discard-ns
+++ b/apparmor.d/profiles-s-z/snap-discard-ns
@@ -31,3 +31,5 @@ profile snap-discard-ns @{exec_path} {
 
   include if exists <local/snap-discard-ns>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-failure
+++ b/apparmor.d/profiles-s-z/snap-failure
@@ -32,3 +32,5 @@ profile snap-failure @{exec_path} {
 
   include if exists <local/snap-failure>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-repair
+++ b/apparmor.d/profiles-s-z/snap-repair
@@ -14,3 +14,5 @@ profile snap-repair @{exec_path} {
 
   include if exists <local/snap-repair>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-seccomp
+++ b/apparmor.d/profiles-s-z/snap-seccomp
@@ -28,3 +28,5 @@ profile snap-seccomp @{exec_path} {
 
   include if exists <local/snap-seccomp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snap-update-ns
+++ b/apparmor.d/profiles-s-z/snap-update-ns
@@ -55,3 +55,5 @@ profile snap-update-ns @{exec_path} {
 
   include if exists <local/snap-update-ns>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snapd
+++ b/apparmor.d/profiles-s-z/snapd
@@ -181,3 +181,5 @@ profile snapd @{exec_path} {
 
   include if exists <local/snapd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snapd-aa-prompt-listener
+++ b/apparmor.d/profiles-s-z/snapd-aa-prompt-listener
@@ -22,3 +22,5 @@ profile snapd-aa-prompt-listener @{exec_path} {
 
   include if exists <local/snapd-aa-prompt-listener>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snapd-aa-prompt-ui
+++ b/apparmor.d/profiles-s-z/snapd-aa-prompt-ui
@@ -20,3 +20,5 @@ profile snapd-aa-prompt-ui @{exec_path} {
 
   include if exists <local/snapd-aa-prompt-ui>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snapd-apparmor
+++ b/apparmor.d/profiles-s-z/snapd-apparmor
@@ -28,3 +28,5 @@ profile snapd-apparmor @{exec_path} {
 
   include if exists <local/snapd-apparmor>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/snapd-core-fixup
+++ b/apparmor.d/profiles-s-z/snapd-core-fixup
@@ -14,3 +14,5 @@ profile snapd-core-fixup @{exec_path} {
 
   include if exists <local/snapd-core-fixup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spacefm-auth
+++ b/apparmor.d/profiles-s-z/spacefm-auth
@@ -16,3 +16,5 @@ profile spacefm-auth @{exec_path} {
 
   include if exists <local/spacefm-auth>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spectre-meltdown-checker
+++ b/apparmor.d/profiles-s-z/spectre-meltdown-checker
@@ -187,3 +187,5 @@ profile spectre-meltdown-checker @{exec_path} {
 
   include if exists <local/spectre-meltdown-checker>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/speedtest
+++ b/apparmor.d/profiles-s-z/speedtest
@@ -34,3 +34,5 @@ profile speedtest @{exec_path} {
 
   include if exists <local/speedtest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spice-client-glib-usb-acl-helper
+++ b/apparmor.d/profiles-s-z/spice-client-glib-usb-acl-helper
@@ -24,3 +24,5 @@ profile spice-client-glib-usb-acl-helper @{exec_path} {
 
   include if exists <local/spice-client-glib-usb-acl-helper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spice-vdagent
+++ b/apparmor.d/profiles-s-z/spice-vdagent
@@ -47,3 +47,5 @@ profile spice-vdagent @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/spice-vdagent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spice-vdagentd
+++ b/apparmor.d/profiles-s-z/spice-vdagentd
@@ -30,3 +30,5 @@ profile spice-vdagentd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/spice-vdagentd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/spotify
+++ b/apparmor.d/profiles-s-z/spotify
@@ -56,3 +56,5 @@ profile spotify @{exec_path} {
 
   include if exists <local/spotify>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ss
+++ b/apparmor.d/profiles-s-z/ss
@@ -45,3 +45,5 @@ profile ss @{exec_path} {
 
   include if exists <local/ss>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sslocal
+++ b/apparmor.d/profiles-s-z/sslocal
@@ -29,3 +29,5 @@ profile sslocal @{exec_path} {
 
   include if exists <local/sslocal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ssmanager
+++ b/apparmor.d/profiles-s-z/ssmanager
@@ -29,3 +29,5 @@ profile ssmanager @{exec_path} {
 
   include if exists <local/ssmanager>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ssserver
+++ b/apparmor.d/profiles-s-z/ssserver
@@ -28,3 +28,5 @@ profile ssserver @{exec_path} {
 
   include if exists <local/ssserver>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ssservice
+++ b/apparmor.d/profiles-s-z/ssservice
@@ -16,3 +16,5 @@ profile ssservice @{exec_path} {
 
   include if exists <local/ssservice>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ssurl
+++ b/apparmor.d/profiles-s-z/ssurl
@@ -24,3 +24,5 @@ profile ssurl @{exec_path} {
 
   include if exists <local/ssurl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/start-pulseaudio-x11
+++ b/apparmor.d/profiles-s-z/start-pulseaudio-x11
@@ -25,3 +25,5 @@ profile start-pulseaudio-x11 @{exec_path} {
 
   include if exists <local/start-pulseaudio-x11>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/startx
+++ b/apparmor.d/profiles-s-z/startx
@@ -47,3 +47,5 @@ profile startx @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/startx>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam
+++ b/apparmor.d/profiles-s-z/steam
@@ -397,3 +397,5 @@ profile steam @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   
   include if exists <local/steam>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-fossilize
+++ b/apparmor.d/profiles-s-z/steam-fossilize
@@ -49,3 +49,5 @@ profile steam-fossilize @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steam-fossilize>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-game-native
+++ b/apparmor.d/profiles-s-z/steam-game-native
@@ -35,3 +35,5 @@ profile steam-game-native @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steam-game-native>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-game-proton
+++ b/apparmor.d/profiles-s-z/steam-game-proton
@@ -105,3 +105,5 @@ profile steam-game-proton @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steam-game-proton>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-gameoverlayui
+++ b/apparmor.d/profiles-s-z/steam-gameoverlayui
@@ -69,3 +69,5 @@ profile steam-gameoverlayui @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steam-gameoverlayui>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-launch
+++ b/apparmor.d/profiles-s-z/steam-launch
@@ -44,3 +44,5 @@ profile steam-launch @{exec_path} {
 
   include if exists <local/steam-launch>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-launcher
+++ b/apparmor.d/profiles-s-z/steam-launcher
@@ -27,3 +27,5 @@ profile steam-launcher @{exec_path} flags=(attach_disconnected) {
   
   include if exists <local/steam-launcher>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steam-runtime
+++ b/apparmor.d/profiles-s-z/steam-runtime
@@ -80,3 +80,5 @@ profile steam-runtime @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steam-runtime>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/steamerrorreporter
+++ b/apparmor.d/profiles-s-z/steamerrorreporter
@@ -39,3 +39,5 @@ profile steamerrorreporter @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/steamerrorreporter>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/strawberry
+++ b/apparmor.d/profiles-s-z/strawberry
@@ -79,3 +79,5 @@ profile strawberry @{exec_path} {
 
   include if exists <local/strawberry>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/strawberry-tagreader
+++ b/apparmor.d/profiles-s-z/strawberry-tagreader
@@ -29,3 +29,5 @@ profile strawberry-tagreader @{exec_path} {
 
   include if exists <local/strawberry-tagreader>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/su
+++ b/apparmor.d/profiles-s-z/su
@@ -28,3 +28,5 @@ profile su @{exec_path} {
 
   include if exists <local/su>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sudo
+++ b/apparmor.d/profiles-s-z/sudo
@@ -47,3 +47,5 @@ profile sudo @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/sudo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sulogin
+++ b/apparmor.d/profiles-s-z/sulogin
@@ -27,3 +27,5 @@ profile sulogin @{exec_path} {
 
   include if exists <local/sulogin>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swaplabel
+++ b/apparmor.d/profiles-s-z/swaplabel
@@ -19,3 +19,5 @@ profile swaplabel @{exec_path} {
 
   include if exists <local/swaplabel>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swapon
+++ b/apparmor.d/profiles-s-z/swapon
@@ -28,3 +28,5 @@ profile swapon @{exec_path} {
 
   include if exists <local/swapon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/switcheroo-control
+++ b/apparmor.d/profiles-s-z/switcheroo-control
@@ -34,3 +34,5 @@ profile switcheroo-control @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/switcheroo-control>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/switcherooctl
+++ b/apparmor.d/profiles-s-z/switcherooctl
@@ -18,3 +18,5 @@ profile switcherooctl @{exec_path} {
 
   include if exists <local/switcherooctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swtpm
+++ b/apparmor.d/profiles-s-z/swtpm
@@ -29,3 +29,5 @@ profile swtpm @{exec_path} {
 
   include if exists <local/swtpm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swtpm_ioctl
+++ b/apparmor.d/profiles-s-z/swtpm_ioctl
@@ -17,3 +17,5 @@ profile swtpm_ioctl @{exec_path} {
 
   include if exists <local/swtpm_ioctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swtpm_localca
+++ b/apparmor.d/profiles-s-z/swtpm_localca
@@ -31,3 +31,5 @@ profile swtpm_localca @{exec_path} {
 
   include if exists <local/swtpm_localca>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/swtpm_setup
+++ b/apparmor.d/profiles-s-z/swtpm_setup
@@ -27,3 +27,5 @@ profile swtpm_setup @{exec_path} {
 
   include if exists <local/swtpm_setup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sync
+++ b/apparmor.d/profiles-s-z/sync
@@ -15,3 +15,5 @@ profile sync @{exec_path} {
 
   include if exists <local/sync>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/syncoid
+++ b/apparmor.d/profiles-s-z/syncoid
@@ -31,3 +31,5 @@ profile syncoid @{exec_path} flags=(complain) {
 
   include if exists <local/syncoid>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/syncthing
+++ b/apparmor.d/profiles-s-z/syncthing
@@ -45,3 +45,5 @@ profile syncthing @{exec_path} {
 
   include if exists <local/syncthing>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/sysctl
+++ b/apparmor.d/profiles-s-z/sysctl
@@ -32,3 +32,5 @@ profile sysctl @{exec_path} {
 
   include if exists <local/sysctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/system-config-printer
+++ b/apparmor.d/profiles-s-z/system-config-printer
@@ -58,3 +58,5 @@ profile system-config-printer @{exec_path} flags=(complain) {
 
   include if exists <local/system-config-printer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/system-config-printer-applet
+++ b/apparmor.d/profiles-s-z/system-config-printer-applet
@@ -31,3 +31,5 @@ profile system-config-printer-applet @{exec_path} {
 
   include if exists <local/system-config-printer-applet>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/task
+++ b/apparmor.d/profiles-s-z/task
@@ -47,3 +47,5 @@ profile task @{exec_path} {
   
   include if exists <local/task>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tasksel
+++ b/apparmor.d/profiles-s-z/tasksel
@@ -80,3 +80,5 @@ profile tasksel @{exec_path} flags=(complain) {
 
   include if exists <local/tasksel>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/taskwarrior-tui
+++ b/apparmor.d/profiles-s-z/taskwarrior-tui
@@ -30,3 +30,5 @@ profile taskwarrior-tui @{exec_path} {
 
   include if exists <local/taskwarrior-tui>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/terminator
+++ b/apparmor.d/profiles-s-z/terminator
@@ -64,3 +64,5 @@ profile terminator @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/terminator>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tftp
+++ b/apparmor.d/profiles-s-z/tftp
@@ -17,3 +17,5 @@ profile tftp @{exec_path} {
 
   include if exists <local/tftp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/thermald
+++ b/apparmor.d/profiles-s-z/thermald
@@ -82,3 +82,5 @@ profile thermald @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/thermald>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/thinkfan
+++ b/apparmor.d/profiles-s-z/thinkfan
@@ -28,3 +28,5 @@ profile thinkfan @{exec_path} {
   include if exists <local/thinkfan>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/thunderbird
+++ b/apparmor.d/profiles-s-z/thunderbird
@@ -179,3 +179,5 @@ profile thunderbird @{exec_path} {
 
   include if exists <local/thunderbird>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/thunderbird-glxtest
+++ b/apparmor.d/profiles-s-z/thunderbird-glxtest
@@ -27,3 +27,5 @@ profile thunderbird-glxtest @{exec_path} {
 
   include if exists <local/thunderbird-glxtest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/thunderbird-vaapitest
+++ b/apparmor.d/profiles-s-z/thunderbird-vaapitest
@@ -28,3 +28,5 @@ profile thunderbird-vaapitest @{exec_path} {
 
   include if exists <local/thunderbird-vaapitest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tint2
+++ b/apparmor.d/profiles-s-z/tint2
@@ -62,3 +62,5 @@ profile tint2 @{exec_path} {
 
   include if exists <local/tint2>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tint2conf
+++ b/apparmor.d/profiles-s-z/tint2conf
@@ -41,3 +41,5 @@ profile tint2conf @{exec_path} {
 
   include if exists <local/tint2conf>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/top
+++ b/apparmor.d/profiles-s-z/top
@@ -68,3 +68,5 @@ profile top @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/top>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/torify
+++ b/apparmor.d/profiles-s-z/torify
@@ -16,3 +16,5 @@ profile torify @{exec_path} {
 
   include if exists <local/torify>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/torsocks
+++ b/apparmor.d/profiles-s-z/torsocks
@@ -25,3 +25,5 @@ profile torsocks @{exec_path} {
 
   include if exists <local/torsocks>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tpacpi-bat
+++ b/apparmor.d/profiles-s-z/tpacpi-bat
@@ -28,3 +28,5 @@ profile tpacpi-bat @{exec_path} {
 
   include if exists <local/tpacpi-bat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/transmission-gtk
+++ b/apparmor.d/profiles-s-z/transmission-gtk
@@ -50,3 +50,5 @@ profile transmission-gtk @{exec_path} {
 
   include if exists <local/transmission-gtk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/transmission-qt
+++ b/apparmor.d/profiles-s-z/transmission-qt
@@ -52,3 +52,5 @@ profile transmission-qt @{exec_path} {
 
   include if exists <local/transmission-qt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/tune2fs
+++ b/apparmor.d/profiles-s-z/tune2fs
@@ -34,3 +34,5 @@ profile tune2fs @{exec_path} {
 
   include if exists <local/tune2fs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udev-dmi-memory-id
+++ b/apparmor.d/profiles-s-z/udev-dmi-memory-id
@@ -19,3 +19,5 @@ profile udev-dmi-memory-id @{exec_path} {
 
   include if exists <local/udev-dmi-memory-id>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udiskie
+++ b/apparmor.d/profiles-s-z/udiskie
@@ -68,3 +68,5 @@ profile udiskie @{exec_path} {
 
   include if exists <local/udiskie>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udiskie-info
+++ b/apparmor.d/profiles-s-z/udiskie-info
@@ -24,3 +24,5 @@ profile udiskie-info @{exec_path} {
 
   include if exists <local/udiskie-info>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udiskie-mount
+++ b/apparmor.d/profiles-s-z/udiskie-mount
@@ -24,3 +24,5 @@ profile udiskie-mount @{exec_path} {
 
   include if exists <local/udiskie-mount>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udiskie-umount
+++ b/apparmor.d/profiles-s-z/udiskie-umount
@@ -24,3 +24,5 @@ profile udiskie-umount @{exec_path} {
 
   include if exists <local/udiskie-umount>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udisksctl
+++ b/apparmor.d/profiles-s-z/udisksctl
@@ -23,3 +23,5 @@ profile udisksctl @{exec_path} {
 
   include if exists <local/udisksctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/udisksd
+++ b/apparmor.d/profiles-s-z/udisksd
@@ -150,3 +150,5 @@ profile udisksd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/udisksd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/umount
+++ b/apparmor.d/profiles-s-z/umount
@@ -48,3 +48,5 @@ profile umount @{exec_path} {
 
   include if exists <local/umount>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/umount.udisks2
+++ b/apparmor.d/profiles-s-z/umount.udisks2
@@ -15,3 +15,5 @@ profile umount.udisks2 @{exec_path} flags=(complain) {
 
   include if exists <local/umount.udisks2>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uname
+++ b/apparmor.d/profiles-s-z/uname
@@ -21,3 +21,5 @@ profile uname @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/uname>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unhide-linux
+++ b/apparmor.d/profiles-s-z/unhide-linux
@@ -36,3 +36,5 @@ profile unhide-linux @{exec_path} {
 
   include if exists <local/unhide-linux>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unhide-posix
+++ b/apparmor.d/profiles-s-z/unhide-posix
@@ -39,3 +39,5 @@ profile unhide-posix @{exec_path} {
 
   include if exists <local/unhide-posix>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unhide-rb
+++ b/apparmor.d/profiles-s-z/unhide-rb
@@ -23,3 +23,5 @@ profile unhide-rb @{exec_path} {
 
   include if exists <local/unhide-rb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unhide-tcp
+++ b/apparmor.d/profiles-s-z/unhide-tcp
@@ -33,3 +33,5 @@ profile unhide-tcp @{exec_path} {
 
   include if exists <local/unhide-tcp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unix-chkpwd
+++ b/apparmor.d/profiles-s-z/unix-chkpwd
@@ -30,3 +30,5 @@ profile unix-chkpwd @{exec_path} {
 
   include if exists <local/unix-chkpwd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/unmkinitramfs
+++ b/apparmor.d/profiles-s-z/unmkinitramfs
@@ -52,3 +52,5 @@ profile unmkinitramfs @{exec_path} {
 
   include if exists <local/unmkinitramfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-alternatives
+++ b/apparmor.d/profiles-s-z/update-alternatives
@@ -32,3 +32,5 @@ profile update-alternatives @{exec_path} {
 
   include if exists <local/update-alternatives>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-ca-certificates
+++ b/apparmor.d/profiles-s-z/update-ca-certificates
@@ -59,3 +59,5 @@ profile update-ca-certificates @{exec_path} {
 
   include if exists <local/update-ca-certificates>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-ca-trust
+++ b/apparmor.d/profiles-s-z/update-ca-trust
@@ -38,3 +38,5 @@ profile update-ca-trust @{exec_path} {
 
   include if exists <local/update-ca-trust>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-command-not-found
+++ b/apparmor.d/profiles-s-z/update-command-not-found
@@ -47,3 +47,5 @@ profile update-command-not-found @{exec_path} {
 
   include if exists <local/update-command-not-found>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-cracklib
+++ b/apparmor.d/profiles-s-z/update-cracklib
@@ -40,3 +40,5 @@ profile update-cracklib @{exec_path} {
 
   include if exists <local/update-cracklib>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-dlocatedb
+++ b/apparmor.d/profiles-s-z/update-dlocatedb
@@ -62,3 +62,5 @@ profile update-dlocatedb @{exec_path} {
 
   include if exists <local/update-dlocatedb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-initramfs
+++ b/apparmor.d/profiles-s-z/update-initramfs
@@ -53,3 +53,5 @@ profile update-initramfs @{exec_path} {
 
   include if exists <local/update-initramfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-pciids
+++ b/apparmor.d/profiles-s-z/update-pciids
@@ -66,3 +66,5 @@ profile update-pciids @{exec_path} {
 
   include if exists <local/update-pciids>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-secureboot-policy
+++ b/apparmor.d/profiles-s-z/update-secureboot-policy
@@ -34,3 +34,5 @@ profile update-secureboot-policy @{exec_path} {
 
   include if exists <local/update-secureboot-policy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/update-smart-drivedb
+++ b/apparmor.d/profiles-s-z/update-smart-drivedb
@@ -92,3 +92,5 @@ profile update-smart-drivedb @{exec_path} {
 
   include if exists <local/update-smart-drivedb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/updatedb-mlocate
+++ b/apparmor.d/profiles-s-z/updatedb-mlocate
@@ -64,3 +64,5 @@ profile updatedb-mlocate @{exec_path} {
 
   include if exists <local/updatedb-mlocate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/updatedb.plocate
+++ b/apparmor.d/profiles-s-z/updatedb.plocate
@@ -38,3 +38,5 @@ profile updatedb.plocate @{exec_path} {
 
   include if exists <local/updatedb.plocate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uptime
+++ b/apparmor.d/profiles-s-z/uptime
@@ -21,3 +21,5 @@ profile uptime @{exec_path} {
 
   include if exists <local/uptime>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uptimed
+++ b/apparmor.d/profiles-s-z/uptimed
@@ -20,3 +20,5 @@ profile uptimed @{exec_path} {
 
   include if exists <local/uptimed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usb-devices
+++ b/apparmor.d/profiles-s-z/usb-devices
@@ -30,3 +30,5 @@ profile usb-devices @{exec_path} {
 
   include if exists <local/usb-devices>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usbguard
+++ b/apparmor.d/profiles-s-z/usbguard
@@ -37,3 +37,5 @@ profile usbguard @{exec_path} {
 
   include if exists <local/usbguard>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usbguard-applet-qt
+++ b/apparmor.d/profiles-s-z/usbguard-applet-qt
@@ -44,3 +44,5 @@ profile usbguard-applet-qt @{exec_path} {
 
   include if exists <local/usbguard-applet-qt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usbguard-daemon
+++ b/apparmor.d/profiles-s-z/usbguard-daemon
@@ -40,3 +40,5 @@ profile usbguard-daemon @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/usbguard-daemon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usbguard-dbus
+++ b/apparmor.d/profiles-s-z/usbguard-dbus
@@ -23,3 +23,5 @@ profile usbguard-dbus @{exec_path} {
 
   include if exists <local/usbguard-dbus>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usbguard-notifier
+++ b/apparmor.d/profiles-s-z/usbguard-notifier
@@ -20,3 +20,5 @@ profile usbguard-notifier @{exec_path} {
 
   include if exists <local/usbguard-notifier>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/useradd
+++ b/apparmor.d/profiles-s-z/useradd
@@ -73,3 +73,5 @@ profile useradd @{exec_path} {
 
   include if exists <local/useradd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/userdel
+++ b/apparmor.d/profiles-s-z/userdel
@@ -55,3 +55,5 @@ profile userdel @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/userdel>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/usermod
+++ b/apparmor.d/profiles-s-z/usermod
@@ -56,3 +56,5 @@ profile usermod @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/usermod>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/users
+++ b/apparmor.d/profiles-s-z/users
@@ -20,3 +20,5 @@ profile users @{exec_path} {
 
   include if exists <local/users>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/utmpdump
+++ b/apparmor.d/profiles-s-z/utmpdump
@@ -18,3 +18,5 @@ profile utmpdump @{exec_path} {
 
   include if exists <local/utmpdump>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/utox
+++ b/apparmor.d/profiles-s-z/utox
@@ -39,3 +39,5 @@ profile utox @{exec_path} {
 
   include if exists <local/utox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uuidd
+++ b/apparmor.d/profiles-s-z/uuidd
@@ -14,3 +14,5 @@ profile uuidd @{exec_path} {
 
   include if exists <local/uuidd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uuidgen
+++ b/apparmor.d/profiles-s-z/uuidgen
@@ -15,3 +15,5 @@ profile uuidgen @{exec_path} {
 
   include if exists <local/uuidgen>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/uupdate
+++ b/apparmor.d/profiles-s-z/uupdate
@@ -52,3 +52,5 @@ profile uupdate @{exec_path} flags=(complain) {
 
   include if exists <local/uupdates>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vcsi
+++ b/apparmor.d/profiles-s-z/vcsi
@@ -32,3 +32,5 @@ profile vcsi @{exec_path} {
 
   include if exists <local/vcsi>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vidcutter
+++ b/apparmor.d/profiles-s-z/vidcutter
@@ -70,3 +70,5 @@ profile vidcutter @{exec_path} {
 
   include if exists <local/vidcutter>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vipw-vigr
+++ b/apparmor.d/profiles-s-z/vipw-vigr
@@ -49,3 +49,5 @@ profile vipw-vigr @{exec_path} {
 
   include if exists <local/vipw-vigr>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/virt-manager
+++ b/apparmor.d/profiles-s-z/virt-manager
@@ -100,3 +100,5 @@ profile virt-manager @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/virt-manager>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vlc
+++ b/apparmor.d/profiles-s-z/vlc
@@ -85,3 +85,5 @@ profile vlc @{exec_path} {
 
   include if exists <local/vlc>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vlc-cache-gen
+++ b/apparmor.d/profiles-s-z/vlc-cache-gen
@@ -24,3 +24,5 @@ profile vlc-cache-gen @{exec_path} {
 
   include if exists <local/vlc-cache-gen>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vnstat
+++ b/apparmor.d/profiles-s-z/vnstat
@@ -68,3 +68,5 @@ profile vnstat @{exec_path} {
 
   include if exists <local/vnstat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vnstatd
+++ b/apparmor.d/profiles-s-z/vnstatd
@@ -30,3 +30,5 @@ profile vnstatd @{exec_path} {
 
   include if exists <local/vnstatd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/volumeicon
+++ b/apparmor.d/profiles-s-z/volumeicon
@@ -36,3 +36,5 @@ profile volumeicon @{exec_path} {
 
   include if exists <local/volumeicon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/vsftpd
+++ b/apparmor.d/profiles-s-z/vsftpd
@@ -71,3 +71,5 @@ profile vsftpd @{exec_path} {
 
   include if exists <local/vsftpd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/w
+++ b/apparmor.d/profiles-s-z/w
@@ -35,3 +35,5 @@ profile w @{exec_path} {
 
   include if exists <local/w>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/w3m
+++ b/apparmor.d/profiles-s-z/w3m
@@ -31,3 +31,5 @@ profile w3m @{exec_path} {
 
   include if exists <local/w3m>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wavemon
+++ b/apparmor.d/profiles-s-z/wavemon
@@ -30,3 +30,5 @@ profile wavemon @{exec_path} {
 
   include if exists <local/wavemon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whatis
+++ b/apparmor.d/profiles-s-z/whatis
@@ -30,3 +30,5 @@ profile whatis @{exec_path} {
 
   include if exists <local/whatis>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whdd
+++ b/apparmor.d/profiles-s-z/whdd
@@ -34,3 +34,5 @@ profile whdd @{exec_path} {
 
   include if exists <local/whdd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whereis
+++ b/apparmor.d/profiles-s-z/whereis
@@ -40,3 +40,5 @@ profile whereis @{exec_path} {
 
   include if exists <local/whereis>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/which
+++ b/apparmor.d/profiles-s-z/which
@@ -35,3 +35,5 @@ profile which @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/which>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whiptail
+++ b/apparmor.d/profiles-s-z/whiptail
@@ -22,3 +22,5 @@ profile whiptail @{exec_path} flags=(complain) {
 
   include if exists <local/whiptail>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/who
+++ b/apparmor.d/profiles-s-z/who
@@ -22,3 +22,5 @@ profile who @{exec_path} {
 
   include if exists <local/who>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whoami
+++ b/apparmor.d/profiles-s-z/whoami
@@ -17,3 +17,5 @@ profile whoami @{exec_path} {
 
   include if exists <local/whoami>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wireplumber
+++ b/apparmor.d/profiles-s-z/wireplumber
@@ -76,3 +76,5 @@ profile wireplumber @{exec_path} {
 
   include if exists <local/wireplumber>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wireshark
+++ b/apparmor.d/profiles-s-z/wireshark
@@ -63,3 +63,5 @@ profile wireshark @{exec_path} {
 
   include if exists <local/wireshark>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wl-copy
+++ b/apparmor.d/profiles-s-z/wl-copy
@@ -24,3 +24,5 @@ profile wl-copy @{exec_path} {
 
   include if exists <local/wl-copy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wmctrl
+++ b/apparmor.d/profiles-s-z/wmctrl
@@ -17,3 +17,5 @@ profile wmctrl @{exec_path} {
 
   include if exists <local/wmctrl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wpa-action
+++ b/apparmor.d/profiles-s-z/wpa-action
@@ -40,3 +40,5 @@ profile wpa-action @{exec_path} {
 
   include if exists <local/wpa-action>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wpa-cli
+++ b/apparmor.d/profiles-s-z/wpa-cli
@@ -25,3 +25,5 @@ profile wpa-cli @{exec_path} {
 
   include if exists <local/wpa-cli>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wpa-gui
+++ b/apparmor.d/profiles-s-z/wpa-gui
@@ -35,3 +35,5 @@ profile wpa-gui @{exec_path} {
 
   include if exists <local/wpa-gui>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wpa-supplicant
+++ b/apparmor.d/profiles-s-z/wpa-supplicant
@@ -54,3 +54,5 @@ profile wpa-supplicant @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/wpa-supplicant>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wrmsr
+++ b/apparmor.d/profiles-s-z/wrmsr
@@ -20,3 +20,5 @@ profile wrmsr @{exec_path} {
 
   include if exists <local/wrmsr>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wsdd
+++ b/apparmor.d/profiles-s-z/wsdd
@@ -28,3 +28,5 @@ profile wsdd @{exec_path} {
 
   include if exists <local/wsdd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xarchiver
+++ b/apparmor.d/profiles-s-z/xarchiver
@@ -100,3 +100,5 @@ profile xarchiver @{exec_path} {
 
   include if exists <local/xarchiver>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xauth
+++ b/apparmor.d/profiles-s-z/xauth
@@ -42,3 +42,5 @@ profile xauth @{exec_path} {
 
   include if exists <local/xauth>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xautolock
+++ b/apparmor.d/profiles-s-z/xautolock
@@ -30,3 +30,5 @@ profile xautolock @{exec_path} {
 
   include if exists <local/xautolock>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xbacklight
+++ b/apparmor.d/profiles-s-z/xbacklight
@@ -17,3 +17,5 @@ profile xbacklight @{exec_path} {
 
   include if exists <local/xbacklight>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xbrlapi
+++ b/apparmor.d/profiles-s-z/xbrlapi
@@ -19,3 +19,5 @@ profile xbrlapi @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xbrlapi>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xclip
+++ b/apparmor.d/profiles-s-z/xclip
@@ -20,3 +20,5 @@ profile xclip @{exec_path} {
 
   include if exists <local/xclip>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xdpyinfo
+++ b/apparmor.d/profiles-s-z/xdpyinfo
@@ -16,3 +16,5 @@ profile xdpyinfo @{exec_path} {
 
   include if exists <local/xdpyinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xinit
+++ b/apparmor.d/profiles-s-z/xinit
@@ -121,3 +121,5 @@ profile xinit @{exec_path} {
 
   include if exists <local/xinit>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xinput
+++ b/apparmor.d/profiles-s-z/xinput
@@ -18,3 +18,5 @@ profile xinput @{exec_path} {
 
   include if exists <local/xinput>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/xsel
+++ b/apparmor.d/profiles-s-z/xsel
@@ -27,3 +27,5 @@ profile xsel @{exec_path} {
 
   include if exists <local/xsel>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/yadifad
+++ b/apparmor.d/profiles-s-z/yadifad
@@ -32,3 +32,5 @@ profile yadifad @{exec_path} {
 
   include if exists <local/yadifad>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/youtube-dl
+++ b/apparmor.d/profiles-s-z/youtube-dl
@@ -60,3 +60,5 @@ profile youtube-dl @{exec_path} {
 
   include if exists <local/youtube-dl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/youtube-viewer
+++ b/apparmor.d/profiles-s-z/youtube-viewer
@@ -66,3 +66,5 @@ profile youtube-viewer @{exec_path} {
 
   include if exists <local/youtube-viewer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/yt-dlp
+++ b/apparmor.d/profiles-s-z/yt-dlp
@@ -46,3 +46,5 @@ profile yt-dlp @{exec_path} {
 
   include if exists <local/yt-dlp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/ytdl
+++ b/apparmor.d/profiles-s-z/ytdl
@@ -43,3 +43,5 @@ profile ytdl @{exec_path} {
 
   include if exists <local/ytdl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zathura
+++ b/apparmor.d/profiles-s-z/zathura
@@ -29,3 +29,5 @@ profile zathura @{exec_path} {
 
   include if exists <local/zathura>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zed
+++ b/apparmor.d/profiles-s-z/zed
@@ -57,3 +57,5 @@ profile zed @{exec_path} {
 
   include if exists <local/zed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zenmap
+++ b/apparmor.d/profiles-s-z/zenmap
@@ -42,3 +42,5 @@ profile zenmap @{exec_path} {
 
   include if exists <local/zenmap>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zfs
+++ b/apparmor.d/profiles-s-z/zfs
@@ -34,3 +34,5 @@ profile zfs @{exec_path} {
 
   include if exists <local/zfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zpool
+++ b/apparmor.d/profiles-s-z/zpool
@@ -42,3 +42,5 @@ profile zpool @{exec_path} {
 
   include if exists <local/zpool>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zsys-system-autosnapshot
+++ b/apparmor.d/profiles-s-z/zsys-system-autosnapshot
@@ -28,3 +28,5 @@ profile zsys-system-autosnapshot @{exec_path} flags=(complain) {
 
   include if exists <local/zsys-system-autosnapshot>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/zsysd
+++ b/apparmor.d/profiles-s-z/zsysd
@@ -44,3 +44,5 @@ profile zsysd @{exec_path} flags=(complain) {
 
   include if exists <local/zsysd>
 }
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add vim modeline instructing the editor to use the syntax plugin provided by apparmor.

Continuation of #379, #380, #381, #390 to keep the diff list relatively short.