### PR TITLE
feat(groups/{a,b}*): vim syntax support

### DIFF
--- a/apparmor.d/groups/akonadi/akonadi_akonotes_resource
+++ b/apparmor.d/groups/akonadi/akonadi_akonotes_resource
@@ -40,3 +40,5 @@ profile akonadi_akonotes_resource @{exec_path} {
 
   include if exists <local/akonadi_akonotes_resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_archivemail_agent
+++ b/apparmor.d/groups/akonadi/akonadi_archivemail_agent
@@ -46,3 +46,5 @@ profile akonadi_archivemail_agent @{exec_path} {
 
   include if exists <local/akonadi_archivemail_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_birthdays_resource
+++ b/apparmor.d/groups/akonadi/akonadi_birthdays_resource
@@ -39,3 +39,5 @@ profile akonadi_birthdays_resource @{exec_path} {
 
   include if exists <local/akonadi_birthdays_resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_contacts_resource
+++ b/apparmor.d/groups/akonadi/akonadi_contacts_resource
@@ -43,3 +43,5 @@ profile akonadi_contacts_resource @{exec_path} {
 
   include if exists <local/akonadi_contacts_resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_control
+++ b/apparmor.d/groups/akonadi/akonadi_control
@@ -44,3 +44,5 @@ profile akonadi_control @{exec_path} {
 
   include if exists <local/akonadi_control>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_followupreminder_agent
+++ b/apparmor.d/groups/akonadi/akonadi_followupreminder_agent
@@ -42,3 +42,5 @@ profile akonadi_followupreminder_agent @{exec_path} {
 
   include if exists <local/akonadi_followupreminder_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_ical_resource
+++ b/apparmor.d/groups/akonadi/akonadi_ical_resource
@@ -35,3 +35,5 @@ profile akonadi_ical_resource @{exec_path} {
 
   include if exists <local/akonadi_ical_resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_indexing_agent
+++ b/apparmor.d/groups/akonadi/akonadi_indexing_agent
@@ -49,3 +49,5 @@ profile akonadi_indexing_agent @{exec_path} {
 
   include if exists <local/akonadi_indexing_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_maildir_resource
+++ b/apparmor.d/groups/akonadi/akonadi_maildir_resource
@@ -43,3 +43,5 @@ profile akonadi_maildir_resource @{exec_path} {
 
   include if exists <local/akonadi_maildir_resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_maildispatcher_agent
+++ b/apparmor.d/groups/akonadi/akonadi_maildispatcher_agent
@@ -54,3 +54,5 @@ profile akonadi_maildispatcher_agent @{exec_path} {
 
   include if exists <local/akonadi_maildispatcher_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_mailfilter_agent
+++ b/apparmor.d/groups/akonadi/akonadi_mailfilter_agent
@@ -60,3 +60,5 @@ profile akonadi_mailfilter_agent @{exec_path} {
 
   include if exists <local/akonadi_mailfilter_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_mailmerge_agent
+++ b/apparmor.d/groups/akonadi/akonadi_mailmerge_agent
@@ -43,3 +43,5 @@ profile akonadi_mailmerge_agent @{exec_path} {
 
   include if exists <local/akonadi_mailmerge_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_migration_agent
+++ b/apparmor.d/groups/akonadi/akonadi_migration_agent
@@ -40,3 +40,5 @@ profile akonadi_migration_agent @{exec_path} {
 
   include if exists <local/akonadi_migration_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_newmailnotifier_agent
+++ b/apparmor.d/groups/akonadi/akonadi_newmailnotifier_agent
@@ -37,3 +37,5 @@ profile akonadi_newmailnotifier_agent @{exec_path} {
 
   include if exists <local/akonadi_newmailnotifier_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_notes_agent
+++ b/apparmor.d/groups/akonadi/akonadi_notes_agent
@@ -43,3 +43,5 @@ profile akonadi_notes_agent @{exec_path} {
 
   include if exists <local/akonadi_notes_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_sendlater_agent
+++ b/apparmor.d/groups/akonadi/akonadi_sendlater_agent
@@ -44,3 +44,5 @@ profile akonadi_sendlater_agent @{exec_path} {
 
   include if exists <local/akonadi_sendlater_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/akonadi/akonadi_unifiedmailbox_agent
+++ b/apparmor.d/groups/akonadi/akonadi_unifiedmailbox_agent
@@ -38,3 +38,5 @@ profile akonadi_unifiedmailbox_agent @{exec_path} {
 
   include if exists <local/akonadi_unifiedmailbox_agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/calibre
+++ b/apparmor.d/groups/apps/calibre
@@ -119,3 +119,5 @@ profile calibre @{exec_path} {
 
   include if exists <local/calibre>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/discord
+++ b/apparmor.d/groups/apps/discord
@@ -47,3 +47,5 @@ profile discord @{exec_path} {
 
   include if exists <local/discord>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/discord-chrome-sandbox
+++ b/apparmor.d/groups/apps/discord-chrome-sandbox
@@ -31,3 +31,5 @@ profile discord-chrome-sandbox @{exec_path} {
 
   include if exists <local/discord-chrome-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/dropbox
+++ b/apparmor.d/groups/apps/dropbox
@@ -81,3 +81,5 @@ profile dropbox @{exec_path} {
 
   include if exists <local/dropbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/filezilla
+++ b/apparmor.d/groups/apps/filezilla
@@ -59,3 +59,5 @@ profile filezilla @{exec_path} {
 
   include if exists <local/filezilla>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/freetube
+++ b/apparmor.d/groups/apps/freetube
@@ -41,3 +41,5 @@ profile freetube @{exec_path} {
 
   include if exists <local/freetube>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/freetube-chrome-sandbox
+++ b/apparmor.d/groups/apps/freetube-chrome-sandbox
@@ -31,3 +31,5 @@ profile freetube-chrome-sandbox @{exec_path} {
 
   include if exists <local/freetube-chrome-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/signal-desktop
+++ b/apparmor.d/groups/apps/signal-desktop
@@ -47,3 +47,5 @@ profile signal-desktop @{exec_path} {
 
   include if exists <local/signal-desktop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
+++ b/apparmor.d/groups/apps/signal-desktop-chrome-sandbox
@@ -26,3 +26,5 @@ profile signal-desktop-chrome-sandbox @{exec_path} {
   include if exists <local/signal-desktop-chrome-sandbox>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apps/telegram-desktop
+++ b/apparmor.d/groups/apps/telegram-desktop
@@ -54,3 +54,5 @@ profile telegram-desktop @{exec_path} {
 
   include if exists <local/telegram-desktop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt
+++ b/apparmor.d/groups/apt/apt
@@ -232,3 +232,5 @@ profile apt @{exec_path} flags=(attach_disconnected) {
   include if exists <local/apt>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-cache
+++ b/apparmor.d/groups/apt/apt-cache
@@ -30,3 +30,5 @@ profile apt-cache @{exec_path} {
 
   include if exists <local/apt-cache>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-cdrom
+++ b/apparmor.d/groups/apt/apt-cdrom
@@ -88,3 +88,5 @@ profile apt-cdrom @{exec_path} flags=(complain) {
 
   include if exists <local/apt-cdrom>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-config
+++ b/apparmor.d/groups/apt/apt-config
@@ -23,3 +23,5 @@ profile apt-config @{exec_path} {
 
   include if exists <local/apt-config>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-extracttemplates
+++ b/apparmor.d/groups/apt/apt-extracttemplates
@@ -34,3 +34,5 @@ profile apt-extracttemplates @{exec_path} {
 
   include if exists <local/apt-extracttemplates>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-file
+++ b/apparmor.d/groups/apt/apt-file
@@ -36,3 +36,5 @@ profile apt-file @{exec_path} {
 
   include if exists <local/apt-file>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-forktracer
+++ b/apparmor.d/groups/apt/apt-forktracer
@@ -36,3 +36,5 @@ profile apt-forktracer @{exec_path} {
 
   include if exists <local/apt-forktracer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-ftparchive
+++ b/apparmor.d/groups/apt/apt-ftparchive
@@ -21,3 +21,5 @@ profile apt-ftparchive @{exec_path} {
 
   include if exists <local/apt-ftparchive>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-helper
+++ b/apparmor.d/groups/apt/apt-helper
@@ -30,3 +30,5 @@ profile apt-helper @{exec_path} {
 
   include if exists <local/apt-helper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-key
+++ b/apparmor.d/groups/apt/apt-key
@@ -107,3 +107,5 @@ profile apt-key @{exec_path} {
 
   include if exists <local/apt-key>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-listbugs
+++ b/apparmor.d/groups/apt/apt-listbugs
@@ -60,3 +60,5 @@ profile apt-listbugs @{exec_path} {
 
   include if exists <local/apt-listbugs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-listbugs-aptcleanup
+++ b/apparmor.d/groups/apt/apt-listbugs-aptcleanup
@@ -18,3 +18,5 @@ profile apt-listbugs-aptcleanup @{exec_path} {
 
   include if exists <local/apt-listbugs-aptcleanup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-listbugs-migratepins
+++ b/apparmor.d/groups/apt/apt-listbugs-migratepins
@@ -31,3 +31,5 @@ profile apt-listbugs-migratepins @{exec_path} {
 
   include if exists <local/apt-listbugs-migratepins>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-listbugs-prefclean
+++ b/apparmor.d/groups/apt/apt-listbugs-prefclean
@@ -28,3 +28,5 @@ profile apt-listbugs-prefclean @{exec_path} {
 
   include if exists <local/apt-listbugs-prefclean>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-listchanges
+++ b/apparmor.d/groups/apt/apt-listchanges
@@ -102,3 +102,5 @@ profile apt-listchanges @{exec_path} {
 
   include if exists <local/apt-listchanges>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-mark
+++ b/apparmor.d/groups/apt/apt-mark
@@ -29,3 +29,5 @@ profile apt-mark @{exec_path} {
 
   include if exists <local/apt-mark>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-cdrom
+++ b/apparmor.d/groups/apt/apt-methods-cdrom
@@ -43,3 +43,5 @@ profile apt-methods-cdrom @{exec_path} {
 
   include if exists <local/apt-methods-cdrom>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-copy
+++ b/apparmor.d/groups/apt/apt-methods-copy
@@ -54,3 +54,5 @@ profile apt-methods-copy @{exec_path} {
 
   include if exists <local/apt-methods-copy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-file
+++ b/apparmor.d/groups/apt/apt-methods-file
@@ -54,3 +54,5 @@ profile apt-methods-file @{exec_path} {
 
   include if exists <local/apt-methods-file>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-ftp
+++ b/apparmor.d/groups/apt/apt-methods-ftp
@@ -43,3 +43,5 @@ profile apt-methods-ftp @{exec_path} {
 
   include if exists <local/apt-methods-ftp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-gpgv
+++ b/apparmor.d/groups/apt/apt-methods-gpgv
@@ -93,3 +93,5 @@ profile apt-methods-gpgv @{exec_path} {
 
   include if exists <local/apt-methods-gpgv>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-http
+++ b/apparmor.d/groups/apt/apt-methods-http
@@ -78,3 +78,5 @@ profile apt-methods-http @{exec_path} {
 
   include if exists <local/apt-methods-http>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-mirror
+++ b/apparmor.d/groups/apt/apt-methods-mirror
@@ -47,3 +47,5 @@ profile apt-methods-mirror @{exec_path} {
 
   include if exists <local/apt-methods-mirror>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-rred
+++ b/apparmor.d/groups/apt/apt-methods-rred
@@ -55,3 +55,5 @@ profile apt-methods-rred @{exec_path} {
 
   include if exists <local/apt-methods-rred>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-rsh
+++ b/apparmor.d/groups/apt/apt-methods-rsh
@@ -43,3 +43,5 @@ profile apt-methods-rsh @{exec_path} {
 
   include if exists <local/apt-methods-rsh>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-methods-store
+++ b/apparmor.d/groups/apt/apt-methods-store
@@ -61,3 +61,5 @@ profile apt-methods-store @{exec_path} {
 
   include if exists <local/apt-methods-store>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-overlay
+++ b/apparmor.d/groups/apt/apt-overlay
@@ -35,3 +35,5 @@ profile apt-overlay @{exec_path} {
 
   include if exists <local/apt-overlay>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-show-versions
+++ b/apparmor.d/groups/apt/apt-show-versions
@@ -43,3 +43,5 @@ profile apt-show-versions @{exec_path} {
 
   include if exists <local/apt-show-versions>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-sortpkgs
+++ b/apparmor.d/groups/apt/apt-sortpkgs
@@ -21,3 +21,5 @@ profile apt-sortpkgs @{exec_path} {
 
   include if exists <local/apt-sortpkgs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/apt-systemd-daily
+++ b/apparmor.d/groups/apt/apt-systemd-daily
@@ -71,3 +71,5 @@ profile apt-systemd-daily @{exec_path} {
 
   include if exists <local/apt-systemd-daily>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/aptitude
+++ b/apparmor.d/groups/apt/aptitude
@@ -190,3 +190,5 @@ profile aptitude @{exec_path} flags=(complain) {
   include if exists <local/aptitude>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/aptitude-changelog-parser
+++ b/apparmor.d/groups/apt/aptitude-changelog-parser
@@ -21,3 +21,5 @@ profile aptitude-changelog-parser @{exec_path} {
 
   include if exists <local/aptitude-changelog-parser>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/aptitude-create-state-bundle
+++ b/apparmor.d/groups/apt/aptitude-create-state-bundle
@@ -32,3 +32,5 @@ profile aptitude-create-state-bundle @{exec_path} {
 
   include if exists <local/aptitude-create-state-bundle>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/aptitude-run-state-bundle
+++ b/apparmor.d/groups/apt/aptitude-run-state-bundle
@@ -28,3 +28,5 @@ profile aptitude-run-state-bundle @{exec_path} {
 
   include if exists <local/aptitude-run-state-bundle>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/command-not-found
+++ b/apparmor.d/groups/apt/command-not-found
@@ -35,3 +35,5 @@ profile command-not-found @{exec_path} {
 
   include if exists <local/command-not-found>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debconf-apt-progress
+++ b/apparmor.d/groups/apt/debconf-apt-progress
@@ -50,3 +50,5 @@ profile debconf-apt-progress @{exec_path} flags=(complain) {
 
   include if exists <local/debconf-apt-progress>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debconf-show
+++ b/apparmor.d/groups/apt/debconf-show
@@ -26,3 +26,5 @@ profile debconf-show @{exec_path} {
 
   include if exists <local/debconf-show>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/deborphan
+++ b/apparmor.d/groups/apt/deborphan
@@ -28,3 +28,5 @@ profile deborphan @{exec_path} {
 
 
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debsecan
+++ b/apparmor.d/groups/apt/debsecan
@@ -48,3 +48,5 @@ profile debsecan @{exec_path} {
 
   include if exists <local/debsecan>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debsign
+++ b/apparmor.d/groups/apt/debsign
@@ -59,3 +59,5 @@ profile debsign @{exec_path} {
 
   include if exists <local/debsign>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debsums
+++ b/apparmor.d/groups/apt/debsums
@@ -50,3 +50,5 @@ profile debsums @{exec_path} {
 
   include if exists <local/debsums>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/debtags
+++ b/apparmor.d/groups/apt/debtags
@@ -42,3 +42,5 @@ profile debtags @{exec_path} {
 
   include if exists <local/debtags>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg
+++ b/apparmor.d/groups/apt/dpkg
@@ -85,3 +85,5 @@ profile dpkg @{exec_path} {
 
   include if exists <local/dpkg>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-architecture
+++ b/apparmor.d/groups/apt/dpkg-architecture
@@ -49,3 +49,5 @@ profile dpkg-architecture @{exec_path} {
 
   include if exists <local/dpkg-architecture>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-buildflags
+++ b/apparmor.d/groups/apt/dpkg-buildflags
@@ -24,3 +24,5 @@ profile dpkg-buildflags @{exec_path} flags=(complain) {
 
   include if exists <local/dpkg-buildflags>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-checkbuilddeps
+++ b/apparmor.d/groups/apt/dpkg-checkbuilddeps
@@ -27,3 +27,5 @@ profile dpkg-checkbuilddeps @{exec_path} flags=(complain) {
 
   include if exists <local/dpkg-checkbuilddeps>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-deb
+++ b/apparmor.d/groups/apt/dpkg-deb
@@ -35,3 +35,5 @@ profile dpkg-deb @{exec_path} {
 
   include if exists <local/dpkg-deb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-divert
+++ b/apparmor.d/groups/apt/dpkg-divert
@@ -26,3 +26,5 @@ profile dpkg-divert @{exec_path} {
 
   include if exists <local/dpkg-divert>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-genbuildinfo
+++ b/apparmor.d/groups/apt/dpkg-genbuildinfo
@@ -40,3 +40,5 @@ profile dpkg-genbuildinfo @{exec_path} {
 
   include if exists <local/dpkg-genbuildinfo>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-genchanges
+++ b/apparmor.d/groups/apt/dpkg-genchanges
@@ -29,3 +29,5 @@ profile dpkg-genchanges @{exec_path} flags=(complain) {
 
   include if exists <local/dpkg-genchanges>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-preconfigure
+++ b/apparmor.d/groups/apt/dpkg-preconfigure
@@ -72,3 +72,5 @@ profile dpkg-preconfigure @{exec_path} {
 
   include if exists <local/dpkg-preconfigure>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-query
+++ b/apparmor.d/groups/apt/dpkg-query
@@ -28,3 +28,5 @@ profile dpkg-query @{exec_path} {
 
   include if exists <local/dpkg-query>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-split
+++ b/apparmor.d/groups/apt/dpkg-split
@@ -31,3 +31,5 @@ profile dpkg-split @{exec_path} {
 
   include if exists <local/dpkg-split>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-trigger
+++ b/apparmor.d/groups/apt/dpkg-trigger
@@ -21,3 +21,5 @@ profile dpkg-trigger @{exec_path} {
 
   include if exists <local/dpkg-trigger>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/dpkg-vendor
+++ b/apparmor.d/groups/apt/dpkg-vendor
@@ -19,3 +19,5 @@ profile dpkg-vendor @{exec_path} {
 
   include if exists <local/dpkg-vendor>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/querybts
+++ b/apparmor.d/groups/apt/querybts
@@ -84,3 +84,5 @@ profile querybts @{exec_path} {
 
   include if exists <local/querybts>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/reportbug
+++ b/apparmor.d/groups/apt/reportbug
@@ -116,3 +116,5 @@ profile reportbug @{exec_path} {
 
   include if exists <local/reportbug>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/synaptic
+++ b/apparmor.d/groups/apt/synaptic
@@ -182,3 +182,5 @@ profile synaptic @{exec_path} {
 
   include if exists <local/synaptic>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/unattended-upgrade
+++ b/apparmor.d/groups/apt/unattended-upgrade
@@ -115,3 +115,5 @@ profile unattended-upgrade @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/unattended-upgrade>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/unattended-upgrade-shutdown
+++ b/apparmor.d/groups/apt/unattended-upgrade-shutdown
@@ -31,3 +31,5 @@ profile unattended-upgrade-shutdown @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/unattended-upgrade-shutdown>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/apt/update-apt-xapian-index
+++ b/apparmor.d/groups/apt/update-apt-xapian-index
@@ -43,3 +43,5 @@ profile update-apt-xapian-index @{exec_path} {
   include if exists <local/update-apt-xapian-index>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/avahi/avahi-autoipd
+++ b/apparmor.d/groups/avahi/avahi-autoipd
@@ -26,3 +26,5 @@ profile avahi-autoipd @{exec_path} {
   include if exists <local/avahi-autoipd>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/avahi/avahi-browse
+++ b/apparmor.d/groups/avahi/avahi-browse
@@ -25,3 +25,5 @@ profile avahi-browse @{exec_path} {
 
   include if exists <local/avahi-browse>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/avahi/avahi-publish
+++ b/apparmor.d/groups/avahi/avahi-publish
@@ -16,3 +16,5 @@ profile avahi-publish @{exec_path} {
   include if exists <local/avahi-publish>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/avahi/avahi-resolve
+++ b/apparmor.d/groups/avahi/avahi-resolve
@@ -28,3 +28,5 @@ profile avahi-resolve @{exec_path} {
 
   include if exists <local/avahi-resolve>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/avahi/avahi-set-host-name
+++ b/apparmor.d/groups/avahi/avahi-set-host-name
@@ -16,3 +16,5 @@ profile avahi-set-host-name @{exec_path} {
   include if exists <local/avahi-set-host-name>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/brave
+++ b/apparmor.d/groups/browsers/brave
@@ -54,3 +54,5 @@ profile brave @{exec_path} {
 
   include if exists <local/brave>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/brave-crashpad-handler
+++ b/apparmor.d/groups/browsers/brave-crashpad-handler
@@ -38,3 +38,5 @@ profile brave-crashpad-handler @{exec_path} {
 
   include if exists <local/brave-crashpad-handler>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/brave-sandbox
+++ b/apparmor.d/groups/browsers/brave-sandbox
@@ -31,3 +31,5 @@ profile brave-sandbox @{exec_path} {
 
   include if exists <local/brave-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/brave-wrapper
+++ b/apparmor.d/groups/browsers/brave-wrapper
@@ -34,3 +34,5 @@ profile brave-wrapper @{exec_path} {
 
   include if exists <local/brave-wrapper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chrome
+++ b/apparmor.d/groups/browsers/chrome
@@ -38,3 +38,5 @@ profile chrome @{exec_path} {
 
   include if exists <local/chrome>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chrome-crashpad-handler
+++ b/apparmor.d/groups/browsers/chrome-crashpad-handler
@@ -34,3 +34,5 @@ profile chrome-crashpad-handler @{exec_path} {
 
   include if exists <local/chrome-crashpad-handler>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chrome-sandbox
+++ b/apparmor.d/groups/browsers/chrome-sandbox
@@ -31,3 +31,5 @@ profile chrome-sandbox @{exec_path} {
 
   include if exists <local/chrome-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chrome-wrapper
+++ b/apparmor.d/groups/browsers/chrome-wrapper
@@ -38,3 +38,5 @@ profile chrome-wrapper @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/chrome-wrapper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chromium
+++ b/apparmor.d/groups/browsers/chromium
@@ -26,3 +26,5 @@ profile chromium @{exec_path} {
 
   include if exists <local/chromium>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chromium-crashpad-handler
+++ b/apparmor.d/groups/browsers/chromium-crashpad-handler
@@ -33,3 +33,5 @@ profile chromium-crashpad-handler @{exec_path} {
 
   include if exists <local/chromium-crashpad-handler>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chromium-sandbox
+++ b/apparmor.d/groups/browsers/chromium-sandbox
@@ -27,3 +27,5 @@ profile chromium-sandbox @{exec_path} {
 
   include if exists <local/chromium-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/chromium-wrapper
+++ b/apparmor.d/groups/browsers/chromium-wrapper
@@ -50,3 +50,5 @@ profile chromium-wrapper @{exec_path} {
 
   include if exists <local/chromium-wrapper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/ephy-profile-migrator
+++ b/apparmor.d/groups/browsers/ephy-profile-migrator
@@ -20,3 +20,5 @@ profile ephy-profile-migrator @{exec_path} {
 
   include if exists <local/ephy-profile-migrator>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/epiphany
+++ b/apparmor.d/groups/browsers/epiphany
@@ -72,3 +72,5 @@ profile epiphany @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/epiphany>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -71,3 +71,5 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/firefox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-crashreporter
+++ b/apparmor.d/groups/browsers/firefox-crashreporter
@@ -59,3 +59,5 @@ profile firefox-crashreporter @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/firefox-crashreporter>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-glxtest
+++ b/apparmor.d/groups/browsers/firefox-glxtest
@@ -27,3 +27,5 @@ profile firefox-glxtest @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/firefox-glxtest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-kmozillahelper
+++ b/apparmor.d/groups/browsers/firefox-kmozillahelper
@@ -61,3 +61,5 @@ profile firefox-kmozillahelper @{exec_path} {
 
   include if exists <local/firefox-kmozillahelper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-minidump-analyzer
+++ b/apparmor.d/groups/browsers/firefox-minidump-analyzer
@@ -55,3 +55,5 @@ profile firefox-minidump-analyzer @{exec_path} {
 
   include if exists <local/firefox-minidump-analyzer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-pingsender
+++ b/apparmor.d/groups/browsers/firefox-pingsender
@@ -35,3 +35,5 @@ profile firefox-pingsender @{exec_path} {
 
   include if exists <local/firefox-pingsender>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-plugin-container
+++ b/apparmor.d/groups/browsers/firefox-plugin-container
@@ -20,3 +20,5 @@ profile firefox-plugin-container @{exec_path} {
 
   include if exists <local/firefox-plugin-container>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/firefox-vaapitest
+++ b/apparmor.d/groups/browsers/firefox-vaapitest
@@ -28,3 +28,5 @@ profile firefox-vaapitest @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/firefox-vaapitest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/msedge
+++ b/apparmor.d/groups/browsers/msedge
@@ -41,3 +41,5 @@ profile msedge @{exec_path} {
 
   include if exists <local/msedge>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/msedge-crashpad-handler
+++ b/apparmor.d/groups/browsers/msedge-crashpad-handler
@@ -34,3 +34,5 @@ profile msedge-crashpad-handler @{exec_path} {
 
   include if exists <local/msedge-crashpad-handler>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/msedge-sandbox
+++ b/apparmor.d/groups/browsers/msedge-sandbox
@@ -30,3 +30,5 @@ profile msedge-sandbox @{exec_path} {
 
   include if exists <local/msedge-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/msedge-wrapper
+++ b/apparmor.d/groups/browsers/msedge-wrapper
@@ -38,3 +38,5 @@ profile msedge-wrapper @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/msedge-wrapper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/opera
+++ b/apparmor.d/groups/browsers/opera
@@ -31,3 +31,5 @@ profile opera @{exec_path} {
 
   include if exists <local/opera>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/opera-crashreporter
+++ b/apparmor.d/groups/browsers/opera-crashreporter
@@ -34,3 +34,5 @@ profile opera-crashreporter @{exec_path} {
 
   include if exists <local/opera-crashreporter>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/opera-sandbox
+++ b/apparmor.d/groups/browsers/opera-sandbox
@@ -35,3 +35,5 @@ profile opera-sandbox @{exec_path} {
 
   include if exists <local/opera-sandbox>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/at-spi2-registryd
+++ b/apparmor.d/groups/bus/at-spi2-registryd
@@ -47,3 +47,5 @@ profile at-spi2-registryd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/at-spi2-registryd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/dbus-accessibility
+++ b/apparmor.d/groups/bus/dbus-accessibility
@@ -68,3 +68,5 @@ profile dbus-accessibility @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/dbus-accessibility>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/dbus-session
+++ b/apparmor.d/groups/bus/dbus-session
@@ -71,3 +71,5 @@ profile dbus-session flags=(attach_disconnected) {
 
   include if exists <local/dbus-session>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/dbus-system
+++ b/apparmor.d/groups/bus/dbus-system
@@ -77,3 +77,5 @@ profile dbus-system flags=(attach_disconnected) {
 
   include if exists <local/dbus-system>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-daemon
+++ b/apparmor.d/groups/bus/ibus-daemon
@@ -58,3 +58,5 @@ profile ibus-daemon @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-daemon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-dconf
+++ b/apparmor.d/groups/bus/ibus-dconf
@@ -50,3 +50,5 @@ profile ibus-dconf @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-dconf>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-engine-simple
+++ b/apparmor.d/groups/bus/ibus-engine-simple
@@ -32,3 +32,5 @@ profile ibus-engine-simple @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-engine-simple>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-engine-table
+++ b/apparmor.d/groups/bus/ibus-engine-table
@@ -27,3 +27,5 @@ profile ibus-engine-table @{exec_path} {
 
   include if exists <local/ibus-engine-table>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-extension-gtk3
+++ b/apparmor.d/groups/bus/ibus-extension-gtk3
@@ -53,3 +53,5 @@ profile ibus-extension-gtk3 @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-extension-gtk3>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-memconf
+++ b/apparmor.d/groups/bus/ibus-memconf
@@ -29,3 +29,5 @@ profile ibus-memconf @{exec_path} {
 
   include if exists <local/ibus-memconf>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-portal
+++ b/apparmor.d/groups/bus/ibus-portal
@@ -35,3 +35,5 @@ profile ibus-portal @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-portal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/ibus-x11
+++ b/apparmor.d/groups/bus/ibus-x11
@@ -44,3 +44,5 @@ profile ibus-x11 @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/ibus-x11>
 }
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add vim modeline instructing the editor to use syntax plugin provided by apparmor.

Continuation of #391 to keep the diff list relatively short.