### PR TITLE
fix: add vim syntax to remaining files

### DIFF
--- a/apparmor.d/abstractions/common/steam-game
+++ b/apparmor.d/abstractions/common/steam-game
@@ -123,3 +123,5 @@
   /dev/uinput rw,
 
   include if exists <abstractions/common/steam-game.d>
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/elinks
+++ b/apparmor.d/profiles-a-f/elinks
@@ -25,3 +25,5 @@ profile elinks @{exec_path} {
 
   include if exists <local/elinks>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/ffmpegthumbnailer
+++ b/apparmor.d/profiles-a-f/ffmpegthumbnailer
@@ -15,3 +15,5 @@ profile ffmpegthumbnailer @{exec_path} {
 
   include if exists <local/ffmpegthumbnailer>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/img2txt
+++ b/apparmor.d/profiles-g-l/img2txt
@@ -15,3 +15,5 @@ profile img2txt @{exec_path} {
 
   include if exists <local/img2txt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/odt2txt
+++ b/apparmor.d/profiles-m-r/odt2txt
@@ -15,3 +15,5 @@ profile odt2txt @{exec_path} {
 
   include if exists <local/odt2txt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/pdftotext
+++ b/apparmor.d/profiles-m-r/pdftotext
@@ -17,3 +17,5 @@ profile pdftotext @{exec_path} {
 
   include if exists <local/pdftotext>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/protonmail-bridge-core
+++ b/apparmor.d/profiles-m-r/protonmail-bridge-core
@@ -83,3 +83,5 @@ profile protonmail-bridge-core @{exec_path} {
 
   include if exists <local/protonmail-bridge-core>
 }
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add vim syntax modeline to files which didn't have it for some reason.
Continuation of #396.