### PR TITLE
Update firewalld

### DIFF
--- a/apparmor.d/profiles-a-f/firewalld
+++ b/apparmor.d/profiles-a-f/firewalld
@@ -14,6 +14,7 @@ profile firewalld @{exec_path} flags=(attach_disconnected) {
   include <abstractions/bus/org.freedesktop.PolicyKit1>
   include <abstractions/bus/org.freedesktop.NetworkManager>
   include <abstractions/nameservice-strict>
+  include <abstractions/app/kmod>
 
   capability dac_read_search,
   capability mknod,
@@ -51,12 +52,12 @@ profile firewalld @{exec_path} flags=(attach_disconnected) {
   @{bin}/ebtables-legacy-restore  rix,
   @{bin}/false                    rix,
   @{bin}/ipset                    rix,
-  @{bin}/kmod                     rPx,
+  @{bin}/kmod                     rix,
   @{bin}/modprobe                 rPx,
   @{bin}/xtables-legacy-multi     rix,
   @{bin}/xtables-nft-multi        rix,
 
-  /usr/local/lib/python*/dist-packages/ r,
+  /usr/local/lib/python3.@{int}/dist-packages/ r,
 
   /usr/share/libalternatives/ r,
   /usr/share/libalternatives/ebtables*/{,*} r,
@@ -65,37 +66,27 @@ profile firewalld @{exec_path} flags=(attach_disconnected) {
   /etc/firewalld/{,**} rw,
   /etc/iproute2/group r,
   /etc/iproute2/rt_realms r,
-  # Maybe change to as in kmod,lspci,...?
-  # /etc/modprobe.d/{,*.conf} r,
-  /etc/modprobe.d/ r,
-  /etc/modprobe.d/firewalld-sysctls.conf r,
 
   /var/lib/ebtables/lock rwk,
 
   /var/log/firewalld rw,
 
   @{run}/firewalld/{,*} rw,
-  @{run}/modprobe.d/ r, # Maybe change to as in kmod,lspci?
-                        # @{run}/modprobe.d/{,*.conf} r,
+  @{run}/modprobe.d/{,*.conf} r,
   @{run}/xtables.lock rwk,
 
-        @{PROC}/cmdline r,
+  @{sys}/module/compression r,
+  @{sys}/module/crc32c_{generic,intel}/initstate r,
+  @{sys}/module/libcrc32c/initstate r,
+  @{sys}/module/nf_conntrack{,_tftp}/initstate r,
+  @{sys}/module/nf_defrag_ipv{4,6}/initstate r,
+  @{sys}/module/nf_nat/initstate r,
+
         @{PROC}/sys/kernel/modprobe r,
         @{PROC}/sys/net/ipv{4,6}/ip_forward rw,
   owner @{PROC}/@{pid}/fd/ r,
   owner @{PROC}/@{pid}/mounts r,
   owner @{PROC}/@{pids}/net/ip_tables_names r,
-
-  @{sys}/module/compression r,
-  # Maybe change to as in systemd-modules-load?
-  # @{sys}/module/*/initstate r,
-  @{sys}/module/crc32c_generic/initstate r,
-  @{sys}/module/crc32c_intel/initstate r,
-  @{sys}/module/libcrc32c/initstate r,
-  @{sys}/module/nf_conntrack/initstate r,
-  @{sys}/module/nf_conntrack_tftp/initstate r,
-  @{sys}/module/nf_defrag_ipv{4,6}/initstate r,
-  @{sys}/module/nf_nat/initstate r,
 
   include if exists <local/firewalld>
 }

--- a/apparmor.d/profiles-a-f/firewalld
+++ b/apparmor.d/profiles-a-f/firewalld
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/firewalld
-profile firewalld @{exec_path} {
+profile firewalld @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/bus-session>
   include <abstractions/bus-system>
@@ -15,10 +15,12 @@ profile firewalld @{exec_path} {
   include <abstractions/bus/org.freedesktop.NetworkManager>
   include <abstractions/nameservice-strict>
 
+  capability dac_read_search,
   capability mknod,
   capability net_admin,
   capability net_raw,
   capability setpcap,
+  capability sys_module,
 
   network inet raw,
   network inet6 raw,
@@ -50,10 +52,11 @@ profile firewalld @{exec_path} {
   @{bin}/false                    rix,
   @{bin}/ipset                    rix,
   @{bin}/kmod                     rPx,
+  @{bin}/modprobe                 rPx,
   @{bin}/xtables-legacy-multi     rix,
   @{bin}/xtables-nft-multi        rix,
 
-  /usr/local/lib/python3.10/dist-packages/ r,
+  /usr/local/lib/python*/dist-packages/ r,
 
   /usr/share/libalternatives/ r,
   /usr/share/libalternatives/ebtables*/{,*} r,
@@ -62,19 +65,37 @@ profile firewalld @{exec_path} {
   /etc/firewalld/{,**} rw,
   /etc/iproute2/group r,
   /etc/iproute2/rt_realms r,
+  # Maybe change to as in kmod,lspci,...?
+  # /etc/modprobe.d/{,*.conf} r,
+  /etc/modprobe.d/ r,
+  /etc/modprobe.d/firewalld-sysctls.conf r,
 
   /var/lib/ebtables/lock rwk,
 
   /var/log/firewalld rw,
 
   @{run}/firewalld/{,*} rw,
+  @{run}/modprobe.d/ r, # Maybe change to as in kmod,lspci?
+                        # @{run}/modprobe.d/{,*.conf} r,
   @{run}/xtables.lock rwk,
 
+        @{PROC}/cmdline r,
         @{PROC}/sys/kernel/modprobe r,
         @{PROC}/sys/net/ipv{4,6}/ip_forward rw,
   owner @{PROC}/@{pid}/fd/ r,
   owner @{PROC}/@{pid}/mounts r,
   owner @{PROC}/@{pids}/net/ip_tables_names r,
+
+  @{sys}/module/compression r,
+  # Maybe change to as in systemd-modules-load?
+  # @{sys}/module/*/initstate r,
+  @{sys}/module/crc32c_generic/initstate r,
+  @{sys}/module/crc32c_intel/initstate r,
+  @{sys}/module/libcrc32c/initstate r,
+  @{sys}/module/nf_conntrack/initstate r,
+  @{sys}/module/nf_conntrack_tftp/initstate r,
+  @{sys}/module/nf_defrag_ipv{4,6}/initstate r,
+  @{sys}/module/nf_nat/initstate r,
 
   include if exists <local/firewalld>
 }

--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -106,6 +106,7 @@ fail2ban-server attach_disconnected,complain
 fdisk complain
 firewall-applet attach_disconnected,complain
 firewall-config complain
+firewalld attach_disconnected,complain
 flameshot complain
 flatpak attach_disconnected,mediate_deleted,complain
 flatpak-app attach_disconnected,mediate_deleted,complain


### PR DESCRIPTION
Add attach_disconnected.
Add profile to main.flags, it was missing there for some reason. There's some uncertainty about some lines, see comments.

Fixes
```
$ aa-log firewalld
ALLOWED firewalld getattr owner dev/null info="Failed name lookup - disconnected path" comm=firewalld requested_mask=r denied_mask=r error=-13
ALLOWED firewalld capable comm=firewalld capability=2 capname=dac_read_search
ALLOWED firewalld exec owner @{bin}/modprobe -> kmod info="no new privs" comm=firewalld requested_mask=x denied_mask=x error=-1
ALLOWED firewalld open owner @{sys}/module/compression comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner /etc/modprobe.d/ comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{run}/modprobe.d/ comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner /etc/modprobe.d/firewalld-sysctls.conf comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{PROC}/cmdline comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/crc32c_intel/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/crc32c_generic/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/libcrc32c/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/nf_defrag_ipv4/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/nf_defrag_ipv6/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/nf_conntrack/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/nf_nat/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld open owner @{sys}/module/nf_conntrack_tftp/initstate comm=modprobe requested_mask=r denied_mask=r
ALLOWED firewalld capable comm=modprobe capability=16 capname=sys_module
$ aa-log -r firewalld
profile firewalld flags=(attach_disconnected) {
  capability dac_read_search,
  capability sys_module,

  @{bin}/modprobe ix -> kmod, # no new privs no new privs

  /etc/modprobe.d/ r,
  /etc/modprobe.d/firewalld-sysctls.conf r,

  @{run}/modprobe.d/ r,

  @{sys}/module/compression r,
  @{sys}/module/crc32c_generic/initstate r,
  @{sys}/module/crc32c_intel/initstate r,
  @{sys}/module/libcrc32c/initstate r,
  @{sys}/module/nf_conntrack/initstate r,
  @{sys}/module/nf_conntrack_tftp/initstate r,
  @{sys}/module/nf_defrag_ipv4/initstate r,
  @{sys}/module/nf_defrag_ipv6/initstate r,
  @{sys}/module/nf_nat/initstate r,

  @{PROC}/cmdline r,

  dev/null r, # Failed name lookup - disconnected path
}

```