### PR TITLE
Fix hyprlock

### DIFF
--- a/apparmor.d/groups/hyprland/hyprlock
+++ b/apparmor.d/groups/hyprland/hyprlock
@@ -27,6 +27,8 @@ profile hyprlock @{exec_path} {
   owner @{user_config_dirs}/hypr/hyprlock.conf r,
 
   owner @{run}/faillock/@{user} rwk,
+  owner /dev/shm/@{uuid} r,
+  owner /dev/shm/wlroots-@{rand6} r,
 
   owner /dev/tty@{int} rw,
 


### PR DESCRIPTION
Small fix. I'd like to take this opportunity to ask whether it's fine to include this rule:

` owner /dev/shm/@{uuid} r,` 

in other profiles, as this seems to be required for many profiles to work with the currently WIP Hyprland profile. Currently, other than hyprlock, the profiles that I needed to add this are: keepassxc, mullvad-gui, pavucontrol, strawberry, xwayland.