### PR TITLE
Fix mpv (ao=alsa)

### DIFF
--- a/apparmor.d/profiles-m-r/mpv
+++ b/apparmor.d/profiles-m-r/mpv
@@ -79,6 +79,8 @@ profile mpv @{exec_path} {
   @{sys}/devices/**/sound/**/uevent r,
 
         /dev/input/event@{int} r,
+        /dev/snd/controlC@{int} w,
+        /dev/snd/pcmC* w,
   owner /dev/tty@{int} rw,
 
   profile xdg-screensaver {


### PR DESCRIPTION
mpv needs access to /dev/snd files for the alsa audio backend to work