### PR TITLE
allow read access to atool config files

### DIFF
--- a/apparmor.d/profiles-a-f/atool
+++ b/apparmor.d/profiles-a-f/atool
@@ -38,6 +38,7 @@ profile atool @{exec_path} {
   @{bin}/lzma rix,
   @{bin}/lzop rix,
   @{bin}/lzop rix,
+  @{lib}/p7zip/7z rix,
   @{bin}/rar rix,
   @{bin}/tar rix,
   @{bin}/unace rix,
@@ -46,6 +47,9 @@ profile atool @{exec_path} {
   @{bin}/unzip rix,
   @{bin}/xz rix,
   @{bin}/zip rix,
+
+  /etc/atool.conf r,
+  owner @{HOME}/.atoolrc r,
 
   include if exists <local/atool>
 }


### PR DESCRIPTION
Fixes complains about missing read permissions