### PR TITLE
mesa: Add a Fallback for newest mesa3d

### DIFF
--- a/apparmor.d/abstractions/mesa.d/complete
+++ b/apparmor.d/abstractions/mesa.d/complete
@@ -10,7 +10,10 @@
   owner @{desktop_cache_dirs}/mesa_shader_cache/@{hex2}/@{hex38}.tmp rwk,
   owner @{desktop_cache_dirs}/mesa_shader_cache/index rw,
   owner @{desktop_cache_dirs}/mesa_shader_cache/marker rw,
-
+  
   owner @{user_cache_dirs}/mesa_shader_cache/marker rw,
+
+  # Add a simple fallback for newest mesa shader cache that can't be detected
+  owner @{user_cache_dirs}/mesa_shader_cache_db/* rwk,
 
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/mesa.d/complete
+++ b/apparmor.d/abstractions/mesa.d/complete
@@ -15,5 +15,11 @@
 
   # Add a simple fallback for newest mesa shader cache that can't be detected
   owner @{user_cache_dirs}/mesa_shader_cache_db/* rwk,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/ rw,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/@{hex2}/ rw,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/@{hex2}/@{hex38} rw,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/@{hex2}/@{hex38}.tmp rwk,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/index rw,
+  owner @{desktop_cache_dirs}/mesa_shader_cache_db/marker rw,
 
 # vim:syntax=apparmor


### PR DESCRIPTION
Newest Mesa3D releases uses a new directory "mesa_shader_cache_db"