### PR TITLE
Draft: Graphics changes

### DIFF
--- a/apparmor.d/abstractions/mesa.d/complete
+++ b/apparmor.d/abstractions/mesa.d/complete
@@ -13,4 +13,11 @@
 
   owner @{user_cache_dirs}/mesa_shader_cache/marker rw,
 
+  # Fallback to mesa_shader_cache_db
+  owner @{user_cache_dirs}/mesa_shader_cache_db/marker rw,
+  owner @{user_cache_dirs}/mesa_shader_cache_db/index rw,
+  owner @{user_cache_dirs}/mesa_shader_cache_db/*/mesa_cache.idx rwk,
+  owner @{user_cache_dirs}/mesa_shader_cache_db/*/mesa_cache.db rwk,
+
+
 # vim:syntax=apparmor

--- a/apparmor.d/groups/gnome/gnome-shell
+++ b/apparmor.d/groups/gnome/gnome-shell
@@ -248,6 +248,12 @@ profile gnome-shell @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{gdm_share_dirs}/icc/ rw,
   owner @{gdm_share_dirs}/icc/edid-@{hex32}.icc rw,
   owner @{gdm_share_dirs}/icc/.goutputstream-@{rand6} rw,
+  
+  # GDM shader cache
+  owner /var/lib/gdm/.cache/mesa_shader_cache_db/marker rw,
+  owner /var/lib/gdm/.cache/mesa_shader_cache_db/index rw,
+  owner /var/lib/gdm/.cache/mesa_shader_cache_db/*/mesa_cache.idx rwk,
+  owner /var/lib/gdm/.cache/mesa_shader_cache_db/*/mesa_cache.db rwk,
 
   owner @{HOME}/.face r,
   owner @{HOME}/.mozilla/firefox/firefox-mpris/{,*} r,

--- a/apparmor.d/profiles-a-f/flatpak
+++ b/apparmor.d/profiles-a-f/flatpak
@@ -17,6 +17,7 @@ profile flatpak @{exec_path} flags=(attach_disconnected,mediate_deleted,complain
   include <abstractions/desktop>
   include <abstractions/nameservice-strict>
   include <abstractions/ssl_certs>
+  include <abstractions/graphics>
 
   # userns,
 


### PR DESCRIPTION
This includes new graphics changes

1: Fallback to mesa_shader_cache_db in abstractions/mesa.d/complete
2: Include abstractions/graphics to flatpak
3: Draft: Including gdm var shader cache

I'm very newbie, but i'm welcome to suggestions and changes.
 (i'm not a native speaker, sorry if looks strange)

Which is the best way to enable  owner @{user_cache_dirs}/gtk-4.0/vulkan-pipeline-cache to all gtk4.0 applications, gtk-4.0 abstractions? 
or graphics?

generated aa-log -r kgx
```
owner @{user_cache_dirs}/gtk-4.0/vulkan-pipeline-cache/@{uuid}.@{int8}8 w,

```