### PR TITLE
socat: add apparmor profile

### DIFF
--- a/apparmor.d/groups/network/socat
+++ b/apparmor.d/groups/network/socat
@@ -1,20 +1,18 @@
-#------------------------------------------------------------------
-#    Author: Nishit Majithia (nishitm)
-#
-#    This program is free software; you can redistribute it and/or
-#    modify it under the terms of version 2 of the GNU General Public
-#    License published by the Free Software Foundation.
-#    SPDX-License-Identifier: GPL-2.0-only
-#------------------------------------------------------------------
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2024 Nishit Majithia (nishitm)
+# SPDX-License-Identifier: GPL-2.0-only
 # vim: ft=apparmor
 
-abi <abi/4.0>,
+abi <abi/3.0>,
 
 include <tunables/global>
 
-profile socat /usr/bin/socat {
+@{exec_path} = /usr/bin/socat
+profile socat @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
+  include <abstractions/ssl_certs>
+  include <abstractions/consoles>
 
   capability dac_read_search,
   capability dac_override,
@@ -32,27 +30,17 @@ profile socat /usr/bin/socat {
   network,
 
   # Enale /dev/ptmx access for testsuite
-  # file rw /dev/ptmx,
-  # file rw /dev/pts/*,
+  # /dev/ptmx rw,
 
   # TUN/TAP device
-  file rw /dev/net/tun,
+  /dev/net/tun rw,
 
   # Process-specific access
-  file rw @{PROC}/@{pid}/fd/*,
-  file r @{PROC}/@{pid}/stat,
+  @{PROC}/@{pid}/fdinfo/@{int} rw,
+  @{PROC}/@{pid}/stat           r,
 
-  # Allow reading from /dev/tty
-  file rw /dev/tty,
-
-  # Allow reading /dev/vsock
-  file r /dev/vsock,
-
-  # certs/keys can be are stored in:
-  #     - /etc/ssl/certs/*.{key,crt}
-  #     - $HOME/.cert/**/*.pem
-  file r /etc/ssl/certs/{,*.{key,crt}},
-  file r @{HOME}/.certs/{,**},
+  # For bi-directional communication between vms and host/hypervisor
+  /dev/vsock r,
 
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/socat>

--- a/apparmor.d/groups/network/socat
+++ b/apparmor.d/groups/network/socat
@@ -7,7 +7,7 @@ abi <abi/3.0>,
 
 include <tunables/global>
 
-@{exec_path} = /usr/bin/socat
+@{exec_path} = @{bin}/socat
 profile socat @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
@@ -28,6 +28,8 @@ profile socat @{exec_path} {
   # Allow creation of network sockets and `socat` uses dccp for some
   # fuctionalities that is why it is necessary to allow whole `network`
   network,
+
+  @{exec_path} mr,
 
   # Enale /dev/ptmx access for testsuite
   # /dev/ptmx rw,

--- a/apparmor.d/groups/network/socat
+++ b/apparmor.d/groups/network/socat
@@ -1,0 +1,59 @@
+#------------------------------------------------------------------
+#    Author: Nishit Majithia (nishitm)
+#
+#    This program is free software; you can redistribute it and/or
+#    modify it under the terms of version 2 of the GNU General Public
+#    License published by the Free Software Foundation.
+#    SPDX-License-Identifier: GPL-2.0-only
+#------------------------------------------------------------------
+# vim: ft=apparmor
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+profile socat /usr/bin/socat {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  capability dac_read_search,
+  capability dac_override,
+  capability net_raw,
+  capability net_admin,
+  capability sys_module,
+  capability sys_admin,
+  capability fsetid,
+  capability chown,
+  capability net_bind_service,
+  capability sys_resource,
+
+  # Allow creation of network sockets and `socat` uses dccp for some
+  # fuctionalities that is why it is necessary to allow whole `network`
+  network,
+
+  # Enale /dev/ptmx access for testsuite
+  # file rw /dev/ptmx,
+  # file rw /dev/pts/*,
+
+  # TUN/TAP device
+  file rw /dev/net/tun,
+
+  # Process-specific access
+  file rw @{PROC}/@{pid}/fd/*,
+  file r @{PROC}/@{pid}/stat,
+
+  # Allow reading from /dev/tty
+  file rw /dev/tty,
+
+  # Allow reading /dev/vsock
+  file r /dev/vsock,
+
+  # certs/keys can be are stored in:
+  #     - /etc/ssl/certs/*.{key,crt}
+  #     - $HOME/.cert/**/*.pem
+  file r /etc/ssl/certs/{,*.{key,crt}},
+  file r @{HOME}/.certs/{,**},
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/socat>
+}


### PR DESCRIPTION
Creating a profile for "socat". I have tested this profile on "socat" latest upstream version: 1.8.0.1 with its test suite on kernel `6.8.0-31`. I have written this profile with the latest abi 4.0 support. 

Let me know if it fails any tests or needs more modifications. Thanks