### PR TITLE
Update profile for sbctl

### DIFF
--- a/apparmor.d/profiles-s-z/sbctl
+++ b/apparmor.d/profiles-s-z/sbctl
@@ -18,6 +18,7 @@ profile sbctl @{exec_path} {
   @{bin}/lsblk  rPx,
 
   /usr/share/secureboot/{,**} rw,
+  /var/lib/sbctl/{,**} rw,
 
   /{boot,efi}/{,**} r,
   /{boot,efi}/EFI/{,**} rw,


### PR DESCRIPTION
Secure Boot keys have been moved to /var/lib/sbctl/ since version 0.15