### PR TITLE
add ssh-sk-helper

### DIFF
--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -25,7 +25,7 @@ profile ssh @{exec_path} {
 
   @{bin}/@{shells}     rUx,
 
-  @{lib}/ssh/ssh-sk-helper rix -> ssh//null-@{lib}/ssh/ssh-sk-helper,
+  @{lib}/ssh/ssh-sk-helper rix -> ssh-sk-helper,
 
   @{etc_ro}/ssh/ssh_config r,
   @{etc_ro}/ssh/ssh_config.d/{,*} r,

--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -25,6 +25,8 @@ profile ssh @{exec_path} {
 
   @{bin}/@{shells}     rUx,
 
+  @{lib}/ssh/ssh-sk-helper rix -> ssh//null-@{lib}/ssh/ssh-sk-helper,
+
   @{etc_ro}/ssh/ssh_config r,
   @{etc_ro}/ssh/ssh_config.d/{,*} r,
   @{etc_ro}/ssh/sshd_config r,

--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -25,7 +25,7 @@ profile ssh @{exec_path} {
 
   @{bin}/@{shells}     rUx,
 
-  @{lib}/ssh/ssh-sk-helper rix -> ssh-sk-helper,
+  @{lib}/ssh/ssh-sk-helper rPx -> ssh-sk-helper,
 
   @{etc_ro}/ssh/ssh_config r,
   @{etc_ro}/ssh/ssh_config.d/{,*} r,

--- a/apparmor.d/groups/ssh/ssh-sk-helper
+++ b/apparmor.d/groups/ssh/ssh-sk-helper
@@ -1,0 +1,26 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2024 valoq <valoq@mailbox.org>
+# SPDX-License-Identifier: GPL-2.0-only
+
+profile ssh//null-@{lib}/ssh/ssh-sk-helper {
+  / r,
+
+  @{lib}/ssh/ssh-sk-helper r,
+
+  /etc/ssl/openssl.cnf r,
+
+  @{sys}/ r,
+  @{sys}/bus/ r,
+  @{sys}/class/ r,
+  @{sys}/class/hidraw/ r,
+  @{sys}/class/hidraw/hidraw@{int} r,
+  @{sys}/devices/ r,
+  @{sys}/devices/@{pci_bus}/ r,
+  @{sys}/devices/@{pci_bus}/{,**} r,
+
+  /dev/hidraw@{int} rwk,
+
+  include if exists <local/ssh-sk-helper>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/ssh-sk-helper
+++ b/apparmor.d/groups/ssh/ssh-sk-helper
@@ -2,8 +2,9 @@
 # Copyright (C) 2024 valoq <valoq@mailbox.org>
 # SPDX-License-Identifier: GPL-2.0-only
 
-profile ssh//null-@{lib}/ssh/ssh-sk-helper {
-  / r,
+include <tunables/global>
+
+profile ssh-sk-helper flags=(complain) {
 
   @{lib}/ssh/ssh-sk-helper r,
 

--- a/apparmor.d/groups/ssh/ssh-sk-helper
+++ b/apparmor.d/groups/ssh/ssh-sk-helper
@@ -4,20 +4,17 @@
 
 include <tunables/global>
 
+@{exec_path} = @{lib}/ssh/ssh-sk-helper
 profile ssh-sk-helper flags=(complain) {
+  include <abstractions/base>
 
-  @{lib}/ssh/ssh-sk-helper r,
-
-  /etc/ssl/openssl.cnf r,
+  @{exec_path} mr,
 
   @{sys}/ r,
   @{sys}/bus/ r,
   @{sys}/class/ r,
   @{sys}/class/hidraw/ r,
   @{sys}/class/hidraw/hidraw@{int} r,
-  @{sys}/devices/ r,
-  @{sys}/devices/@{pci_bus}/ r,
-  @{sys}/devices/@{pci_bus}/{,**} r,
 
   /dev/hidraw@{int} rwk,
 


### PR DESCRIPTION
Required for use of ssh with security keys like fido devices