### PR TITLE
A Fix for xdg-permission-store

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-permission-store
+++ b/apparmor.d/groups/freedesktop/xdg-permission-store
@@ -41,7 +41,7 @@ profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
   owner @{user_share_dirs}/flatpak/db/ rw,
   owner @{user_share_dirs}/flatpak/db/.goutputstream-@{rand6} rw,
   owner @{user_share_dirs}/flatpak/db/background rw,
-  owner @{user_share_dirs}/flatpak/db/devices r,
+  owner @{user_share_dirs}/flatpak/db/devices rw,
   owner @{user_share_dirs}/flatpak/db/documents rw,
   owner @{user_share_dirs}/flatpak/db/notifications rw,
 


### PR DESCRIPTION
Due to Gnome 47 changes, this dictionary needs write permission to allow Gnome giving camera assess to apps