### PR TITLE
A fix for fwupdmgr

### DIFF
--- a/apparmor.d/profiles-a-f/fwupdmgr
+++ b/apparmor.d/profiles-a-f/fwupdmgr
@@ -50,6 +50,7 @@ profile fwupdmgr @{exec_path} flags=(attach_disconnected) {
 
   /dev/i2c-@{int} rw,
   /dev/tty rw,
+  /dev/pts/@{int} rw,
 
   profile bus flags=(attach_disconnected) {
     include <abstractions/base>


### PR DESCRIPTION
Fix no output issue when running fwupdmgr, here is the log: 
`apparmor="DENIED" operation="file_inherit" class="file" profile="fwupdmgr" name="/dev/pts/1"  comm="fwupdmgr" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0 FSUID="root" OUID="root"`