### PR TITLE
YubiKey support for sudo

### DIFF
--- a/apparmor.d/abstractions/app/sudo
+++ b/apparmor.d/abstractions/app/sudo
@@ -12,6 +12,7 @@
   include <abstractions/consoles>
   include <abstractions/nameservice-strict>
   include <abstractions/wutmp>
+  include <abstractions/devices-usb>
 
   capability audit_write,
   capability dac_override,
@@ -50,6 +51,10 @@
   owner /var/log/sudo.log wk,
 
   owner @{HOME}/.sudo_as_admin_successful rw,
+
+  # yubikey support
+  owner @{HOME}/.yubico/challenge-* rw,
+        @{HOME}/.yubico/ r,
 
         @{run}/faillock/ rw,
         @{run}/faillock/@{user} rwk,


### PR DESCRIPTION
This PR is an attempt to support YubiKeys for sudo authentication. Tested on the highly experimental NixOS concoction, but works well there. Logs are clean and the widening allowed here is minimal.

- the yubikey is a u2f usb device, so usb abstraction is required
- the authentication with yubikey against sudo happens as challenge response, which is why rw on the challenge file is required
- the elevator first checks whether a .yubico folder exists, which is why reading the folder (but not the files within) is required