### PR TITLE
Update to ABI4.0 for Arch Linux

### DIFF
--- a/cmd/prebuild/main.go
+++ b/cmd/prebuild/main.go
@@ -38,7 +38,6 @@ func init() {
 	// Compatibility with AppArmor 3
 	switch prebuild.Distribution {
 	case "arch":
-		prebuild.ABI = 3
 
 	case "ubuntu":
 		if !slices.Contains([]string{"noble"}, prebuild.Release["VERSION_CODENAME"]) {


### PR DESCRIPTION
The apparmor-4.0.3-1 package from Arch Linux had been moved out of the testing repository, See [here](https://archlinux.org/packages/extra/x86_64/apparmor/)