### PR TITLE
DRAFT: Split the profiles in multiple packages.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,19 +3,23 @@
 
 # Warning: for development only, use https://aur.archlinux.org/packages/apparmor.d-git for production use.
 
-pkgname=apparmor.d
-pkgver=0.001
+pkgbase=apparmor.d
+pkgname=(
+  apparmor.d apparmor.d.base
+  apparmor.d.other
+)
+pkgver=0.0001
 pkgrel=1
-pkgdesc="Full set of apparmor profiles"
-arch=("x86_64")
-url="https://github.com/roddhjav/$pkgname"
+pkgdesc="Full set of apparmor profiles (base)"
+arch=("any")
+url="https://github.com/roddhjav/apparmor.d"
 license=('GPL2')
 depends=('apparmor')
 makedepends=('go' 'git' 'rsync')
-conflicts=("$pkgname-git")
+conflicts=("$pkgbase-git" "$pkgbase")
 
 pkgver() {
-  cd "$srcdir/$pkgname"
+  cd "$srcdir/$pkgbase"
   echo "0.$(git rev-list --count HEAD)"
 }
 
@@ -24,16 +28,33 @@ prepare() {
 }
 
 build() {
-  cd "$srcdir/$pkgname"
+  cd "$srcdir/$pkgbase"
   export CGO_CPPFLAGS="${CPPFLAGS}"
   export CGO_CFLAGS="${CFLAGS}"
   export CGO_CXXFLAGS="${CXXFLAGS}"
   export CGO_LDFLAGS="${LDFLAGS}"
   export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
-  make DISTRIBUTION=arch
+  make BUILD=.buid.all DISTRIBUTION=arch
+  make packages DISTRIBUTION=arch
 }
 
-package() {
-  cd "$srcdir/$pkgname"
-  make install DESTDIR="$pkgdir"
+package_apparmor.d() {
+  pkgdesc="Full set of apparmor profiles"
+  arch=("$CARCH")
+  conflicts=("${pkgname[@]:1}")
+  cd "$srcdir/$pkgbase"
+  make install BUILD=.buid.all DESTDIR="$pkgdir"
+}
+
+package_apparmor.d.base() {
+  arch=("$CARCH")
+  cd "$srcdir/$pkgbase"
+  make install-base DESTDIR="$pkgdir"
+}
+
+package_apparmor.d.other() {
+  pkgdesc="Full set of apparmor profiles (other)"
+  depends=(apparmor.d.base)
+  cd "$srcdir/$pkgbase"
+  make profiles-other DESTDIR="$pkgdir"
 }

--- a/cmd/prebuild/main.go
+++ b/cmd/prebuild/main.go
@@ -37,8 +37,6 @@ func init() {
 
 	// Compatibility with AppArmor 3
 	switch prebuild.Distribution {
-	case "arch":
-
 	case "ubuntu":
 		if !slices.Contains([]string{"noble"}, prebuild.Release["VERSION_CODENAME"]) {
 			prebuild.ABI = 3

--- a/dists/ignore/arch.ignore
+++ b/dists/ignore/arch.ignore
@@ -4,9 +4,6 @@ apparmor.d/groups/apt
 # Ubuntu specific definition 
 apparmor.d/groups/ubuntu
 
-# OpenSUSE specific definition
-apparmor.d/groups/suse
-
 # Whonix specific definition
 apparmor.d/groups/whonix
 apparmor.d/tunables/home.d/whonix

--- a/dists/ignore/debian.ignore
+++ b/dists/ignore/debian.ignore
@@ -5,9 +5,6 @@ share/libalpm
 # Ubuntu specific definition 
 apparmor.d/groups/ubuntu
 
-# OpenSUSE specific definition
-apparmor.d/groups/suse
-
 # Whonix specific definition
 apparmor.d/groups/whonix
 apparmor.d/abstractions/base.anondist

--- a/dists/ignore/ubuntu.ignore
+++ b/dists/ignore/ubuntu.ignore
@@ -2,9 +2,6 @@
 apparmor.d/groups/pacman
 share/libalpm
 
-# OpenSUSE specific definition
-apparmor.d/groups/suse
-
 # Whonix specific definition
 apparmor.d/groups/whonix
 apparmor.d/tunables/home.d/whonix

--- a/dists/ignore/whonix.ignore
+++ b/dists/ignore/whonix.ignore
@@ -2,9 +2,6 @@
 apparmor.d/groups/pacman
 share/libalpm
 
-# OpenSUSE specific definition
-apparmor.d/groups/suse
-
 # Whonix does not have them
 apparmor.d/groups/pacman
 apparmor.d/groups/ubuntu

--- a/dists/packages/base.conf
+++ b/dists/packages/base.conf
@@ -1,0 +1,22 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Minimal core with tunables, abstractions, and dependencies of other profiles 
+
+mode=enforce
+
+tunables
+
+abstractions
+!abstractions/app/chromium
+!abstractions/app/firefox
+
+groups/children
+!groups/children/user_confined
+!groups/children/user_default
+!groups/children/user_unconfined
+
+groups/bus
+profiles-s-z/unix-chkpwd
+profiles-m-r/pam-tmpdir-helper

--- a/pkg/prebuild/builder/core.go
+++ b/pkg/prebuild/builder/core.go
@@ -6,6 +6,8 @@ package builder
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/roddhjav/apparmor.d/pkg/paths"
 	"github.com/roddhjav/apparmor.d/pkg/prebuild"
@@ -33,7 +35,7 @@ type Option struct {
 
 func NewOption(file *paths.Path) *Option {
 	return &Option{
-		Name: file.Base(),
+		Name: strings.TrimSuffix(file.Base(), ".apparmor.d"),
 		File: file,
 	}
 }
@@ -41,9 +43,22 @@ func NewOption(file *paths.Path) *Option {
 func Register(names ...string) {
 	for _, name := range names {
 		if b, present := Builders[name]; present {
-			Builds = append(Builds, b)
+			if !slices.Contains(Builds, b) {
+				Builds = append(Builds, b)
+			}
 		} else {
 			panic(fmt.Sprintf("Unknown builder: %s", name))
+		}
+	}
+}
+
+func Unregister(names ...string) {
+	for _, name := range names {
+		for i, b := range Builds {
+			if b.Name() == name {
+				Builds = slices.Delete(Builds, i, i+1)
+				break
+			}
 		}
 	}
 }

--- a/pkg/prebuild/cli/cli.go
+++ b/pkg/prebuild/cli/cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/roddhjav/apparmor.d/pkg/prebuild/builder"
 	"github.com/roddhjav/apparmor.d/pkg/prebuild/directive"
 	"github.com/roddhjav/apparmor.d/pkg/prebuild/prepare"
+	"github.com/roddhjav/apparmor.d/pkg/util"
 )
 
 const (

--- a/pkg/prebuild/directories.go
+++ b/pkg/prebuild/directories.go
@@ -4,17 +4,28 @@
 
 package prebuild
 
-import "github.com/roddhjav/apparmor.d/pkg/paths"
+import (
+	"os"
+	"strings"
+
+	"github.com/roddhjav/apparmor.d/pkg/paths"
+)
 
 var (
 	// AppArmor ABI version
 	ABI uint = 0
 
-	// Root is the root directory for the build (default: .build)
-	Root *paths.Path = paths.New(".build")
+	// Root is the root directory for the build (default: ./.build)
+	Root *paths.Path = getRootBuild()
 
 	// RootApparmord is the final built apparmor.d directory (default: .build/apparmor.d)
-	RootApparmord *paths.Path = Root.Join("apparmor.d")
+	RootApparmord *paths.Path = Root.Join(Src)
+
+	// src is the basename of the source directory (default: apparmor.d)
+	Src = "apparmor.d"
+
+	// SrcApparmord is the source apparmor.d directory (default: ./apparmor.d)
+	SrcApparmord *paths.Path = paths.New(Src)
 
 	// DistDir is the directory where the distribution specific files are stored
 	DistDir *paths.Path = paths.New("dists")
@@ -25,6 +36,9 @@ var (
 	// IgnoreDir is the directory where the ignore files are stored
 	IgnoreDir *paths.Path = DistDir.Join("ignore")
 
+	// PkgDir is the directory where the packages files are stored
+	PkgDir *paths.Path = DistDir.Join("packages")
+
 	// SystemdDir is the directory where the systemd drop-in files are stored
 	SystemdDir *paths.Path = paths.New("systemd")
 
@@ -34,6 +48,29 @@ var (
 	// DebianHide is the path to the debian/apparmor.d.hide file
 	DebianHide = DebianHider{path: DebianDir.Join("apparmor.d.hide")}
 
+	// Packages are the packages to build
+	Packages = getPackages()
+
 	Ignore = Ignorer{}
 	Flags  = Flagger{}
 )
+
+func getRootBuild() *paths.Path {
+	root, present := os.LookupEnv("BUILD")
+	if !present {
+		root = ".build"
+	}
+	return paths.New(root)
+}
+
+func getPackages() []string {
+	files, err := PkgDir.ReadDirRecursiveFiltered(nil, paths.FilterOutDirectories())
+	if err != nil {
+		panic(err)
+	}
+	packages := make([]string, 0, len(files))
+	for _, file := range files {
+		packages = append(packages, strings.TrimSuffix(file.Base(), ".conf"))
+	}
+	return packages
+}

--- a/pkg/prebuild/directories.go
+++ b/pkg/prebuild/directories.go
@@ -66,7 +66,7 @@ func getRootBuild() *paths.Path {
 func getPackages() []string {
 	files, err := PkgDir.ReadDirRecursiveFiltered(nil, paths.FilterOutDirectories())
 	if err != nil {
-		panic(err)
+		return []string{}
 	}
 	packages := make([]string, 0, len(files))
 	for _, file := range files {

--- a/pkg/prebuild/packages.go
+++ b/pkg/prebuild/packages.go
@@ -1,0 +1,231 @@
+// apparmor.d - Full set of apparmor profiles
+// Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+// SPDX-License-Identifier: GPL-2.0-only
+
+package prebuild
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/roddhjav/apparmor.d/pkg/paths"
+)
+
+type Package struct {
+	Name     string
+	Mode     string
+	Required []string
+	Profiles []string
+	Ignores  []string
+	Ignored  []string
+	builddir *paths.Path
+}
+
+func NewPackage(name string) *Package {
+	path := PkgDir.Join(name + ".conf")
+	if !path.Exist() {
+		panic(fmt.Sprintf("Unknown package: %s", name))
+	}
+	lines := path.MustReadFilteredFileAsLines()
+	mode := ""
+	profiles := make([]string, 0, len(lines))
+	ignores := []string{}
+	dependencies := []string{}
+	ignored := getFilesIgnoredByDistribution()
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "mode="):
+			mode = strings.TrimPrefix(line, "mode=")
+		case strings.HasPrefix(line, "require="):
+			dependencies = strings.Split(strings.TrimPrefix(line, "require="), ",")
+		case strings.HasPrefix(line, "!"):
+			ignores = append(ignores, strings.TrimPrefix(line, "!"))
+		default:
+			profiles = append(profiles, line)
+		}
+	}
+	return &Package{
+		Name:     name,
+		Mode:     mode,
+		Required: dependencies,
+		Profiles: profiles,
+		Ignores:  ignores,
+		Ignored:  ignored,
+		builddir: Root.Join(name),
+	}
+}
+
+func getFilesIgnoredByDistribution() []string {
+	res := []string{}
+	for _, iname := range []string{"main", Distribution} {
+		for _, ignore := range Ignore.Read(iname) {
+			if !strings.HasPrefix(ignore, Src) {
+				continue
+			}
+			profile := strings.TrimPrefix(ignore, Src+"/")
+			path := SrcApparmord.Join(profile)
+			if path.IsDir() {
+				files, err := path.ReadDirRecursiveFiltered(nil, paths.FilterOutDirectories())
+				if err != nil {
+					panic(err)
+				}
+				for _, file := range files {
+					res = append(res, file.Base())
+				}
+			} else if path.Exist() {
+				res = append(res, path.Base())
+			} else {
+				panic(fmt.Errorf("%s.ignore: no files found for '%s'", iname, profile))
+			}
+		}
+	}
+	return res
+}
+
+func (p *Package) Generate() ([]string, error) {
+	var res []string
+
+	if err := p.builddir.RemoveAll(); err != nil {
+		return res, err
+	}
+	if err := p.builddir.MkdirAll(); err != nil {
+		return res, err
+	}
+
+	explode := paths.PathList{
+		paths.New("groups"), paths.New("profiles-a-f"),
+		paths.New("profiles-m-r"), paths.New("profiles-s-z"),
+	}
+	for _, name := range p.Profiles {
+		originalPath := SrcApparmord.Join(name)
+
+		if originalPath.IsDir() {
+			originFiles, err := originalPath.ReadDirRecursiveFiltered(nil, paths.FilterOutDirectories())
+			if err != nil {
+				return res, err
+			}
+			for _, originFile := range originFiles {
+				file, err := originFile.RelFrom(SrcApparmord)
+				if err != nil {
+					return res, err
+				}
+
+				if slices.Contains(p.Ignores, file.String()) {
+					continue
+				}
+
+				done := false
+				for _, e := range explode {
+					if ok, _ := file.IsInsideDir(e); ok {
+						base := file.Base()
+						msg, err := p.move(base)
+						if err != nil {
+							return res, err
+						}
+						res = append(res, msg)
+						done = true
+						break
+					}
+				}
+
+				if !done {
+					msg, err := p.move(file)
+					if err != nil {
+						return res, err
+					}
+					res = append(res, msg)
+				}
+			}
+
+		} else if originalPath.Exist() {
+			base := originalPath.Base()
+			if slices.Contains(p.Ignores, base) {
+				continue
+			}
+			msg, err := p.move(base)
+			if err != nil {
+				return res, err
+			}
+			res = append(res, msg)
+
+		} else {
+			return res, fmt.Errorf("No %s", originalPath)
+		}
+	}
+	return res, nil
+}
+
+func (p *Package) move(origin any) (string, error) {
+	var src *paths.Path
+	var dst *paths.Path
+	var srcOverridden *paths.Path
+	var dstOverridden *paths.Path
+	var srcSymlink *paths.Path
+	var dstSymlink *paths.Path
+	const ext = ".apparmor.d"
+
+	switch value := any(origin).(type) {
+	case string:
+		src = RootApparmord.Join(value)
+		dst = p.builddir.Join(value)
+		srcOverridden = RootApparmord.Join(value + ext)
+		dstOverridden = p.builddir.Join(value + ext)
+		srcSymlink = RootApparmord.Join("disable", value)
+		dstSymlink = p.builddir.Join("disable", value)
+
+	case *paths.Path:
+		src = RootApparmord.JoinPath(value)
+		dst = p.builddir.JoinPath(value)
+		srcOverridden = RootApparmord.JoinPath(value.Parent()).Join(value.Base() + ext)
+		dstOverridden = p.builddir.JoinPath(value.Parent()).Join(value.Base() + ext)
+		srcSymlink = RootApparmord.Join("disable").JoinPath(value)
+		dstSymlink = p.builddir.Join("disable").JoinPath(value)
+
+	default:
+		panic("Package.move: unsupported type")
+	}
+
+	if src.Exist() {
+		if err := dst.Parent().MkdirAll(); err != nil {
+			return "", nil
+		}
+		if err := src.Rename(dst); err != nil {
+			return "", nil
+		}
+		// fmt.Printf("%s -> %s\n", src, dst)
+
+	} else if srcOverridden.Exist() {
+		if err := dstOverridden.Parent().MkdirAll(); err != nil {
+			return "", nil
+		}
+		if err := dstSymlink.Parent().MkdirAll(); err != nil {
+			return "", nil
+		}
+		if err := srcOverridden.Rename(dstOverridden); err != nil {
+			return "", nil
+		}
+		if err := srcSymlink.Rename(dstSymlink); err != nil {
+			return "", nil
+		}
+		// fmt.Printf("%s -> %s\n", srcOverridden, dstOverridden)
+
+	} else {
+		srcRltv, err := src.RelFrom(RootApparmord)
+		if err != nil {
+			return "", nil
+		}
+		if !slices.Contains(p.Ignored, srcRltv.String()) {
+			fmt.Printf("Warning: No %s\n", src)
+			// return "", fmt.Errorf("No %s", src)
+		}
+
+	}
+	return "", nil
+}
+
+// Validate ensures a package has its required dependencies
+func (p *Package) Validate() error {
+	return nil
+}
+

--- a/pkg/prebuild/prepare/merge.go
+++ b/pkg/prebuild/prepare/merge.go
@@ -48,7 +48,7 @@ func (p Merge) Apply() ([]string, error) {
 
 		files, err = filepath.Glob(prebuild.RootApparmord.Join(dirRemoved).String())
 		if err != nil {
-			return []string{}, err
+			return res, err
 		}
 		for _, file := range files {
 			if err := paths.New(file).RemoveAll(); err != nil {

--- a/pkg/prebuild/prepare/overwrite.go
+++ b/pkg/prebuild/prepare/overwrite.go
@@ -50,7 +50,6 @@ func (p Overwrite) Apply() ([]string, error) {
 			continue
 		}
 		if err := origin.Rename(dest); err != nil {
-
 			return res, err
 		}
 		originRel, err := origin.RelFrom(dest)

--- a/pkg/prebuild/prepare/synchronise.go
+++ b/pkg/prebuild/prepare/synchronise.go
@@ -33,14 +33,15 @@ func (p Synchronise) Apply() ([]string, error) {
 		}
 	}
 	if p.Path == "" {
-		for _, name := range []string{"apparmor.d", "share"} {
-			if err := paths.CopyTo(paths.New(name), prebuild.Root.Join(name)); err != nil {
-				return res, err
-			}
+		if err := paths.CopyTo(paths.New("share"), prebuild.Root.Join("share")); err != nil {
+			return res, err
+		}
+		if err := paths.CopyTo(prebuild.SrcApparmord, prebuild.RootApparmord); err != nil {
+			return res, err
 		}
 	} else {
 		file := paths.New(p.Path)
-		destination, err := file.RelFrom(paths.New("apparmor.d"))
+		destination, err := file.RelFrom(prebuild.SrcApparmord)
 		if err != nil {
 			return res, err
 		}


### PR DESCRIPTION
This PR provide early support for multiple packages `apparmor.d.*`. See #464 for more context.

Example of packages generated:
- `apparmor.d` The same than usual, no change.
- `apparmor.d.base` 
- `apparmor.d.other` All other profiles that are part of this project and not installed by other `apparmor.d.*`
