### PR TITLE
Added files in /tmp (nscopy.tmp and others) to the ThunderBird profile

### DIFF
--- a/apparmor.d/profiles-s-z/thunderbird
+++ b/apparmor.d/profiles-s-z/thunderbird
@@ -52,7 +52,8 @@ profile thunderbird @{exec_path} {
 
   owner @{tmp}/MozillaMailnews/ rw,
   owner @{tmp}/MozillaMailnews/*.msf rw,
-  owner @{tmp}/nsemail.eml rw,
+  owner @{tmp}/nscopy.tmp rw,
+  owner @{tmp}/nsemail{,-@{int}}.eml rw,
   owner @{tmp}/nsma rw,
   owner @{tmp}/pid-@{pid}/{,**} w,
 


### PR DESCRIPTION
ThunderBird complains that it cannot save a draft. Log:

```
apparmor="DENIED" operation="mknod" class="file" profile="thunderbird" name="/tmp/nscopy.tmp"  comm="thunderbird" requested_mask="c" denied_mask="c" fsuid=1001 ouid=1001 FSUID="user" OUID="user"
apparmor="DENIED" operation="mknod" class="file" profile="thunderbird" name="/tmp/nsemail-1.eml"  comm="thunderbird" requested_mask="c" denied_mask="c" fsuid=1001 ouid=1001 FSUID="user" OUID="user"
```