### PR TITLE
/boot/EFI

### DIFF
--- a/apparmor.d/groups/pacman/mkinitcpio
+++ b/apparmor.d/groups/pacman/mkinitcpio
@@ -83,9 +83,10 @@ profile mkinitcpio @{exec_path} flags=(attach_disconnected) {
 
   # Manage /boot
   / r,
-  /boot/ r,
-  /boot/initramfs-*.img* rw,
-  /boot/vmlinuz-* r,
+  /{boot,efi}/ r,
+  /{boot,efi}/EFI/{,**} rw,
+  /{boot,efi}/initramfs-*.img* rw,
+  /{boot,efi}/vmlinuz-* r,
 
   /usr/share/systemd/bootctl/** r,
 


### PR DESCRIPTION
When running `mkinitcpio -p linux`, I get the following log messages:

```
apparmor="ALLOWED" operation="open" class="file" profile="mkinitcpio" name="/etc/apparmor.d/"  comm="find" requested_mask="r" denied_mask="r" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="ALLOWED" operation="unlink" class="file" profile="mkinitcpio" name="/boot/EFI/boot/bootx64.efi"  comm="objcopy" requested_mask="d" denied_mask="d" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="ALLOWED" operation="mknod" class="file" profile="mkinitcpio" name="/boot/EFI/boot/bootx64.efi"  comm="objcopy" requested_mask="c" denied_mask="c" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="ALLOWED" operation="open" class="file" profile="mkinitcpio" name="/boot/EFI/boot/bootx64.efi"  comm="objcopy" requested_mask="wrc" denied_mask="wrc" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="ALLOWED" operation="chmod" class="file" profile="mkinitcpio" name="/boot/EFI/boot/bootx64.efi"  comm="objcopy" requested_mask="w" denied_mask="w" fsuid=0 ouid=0 FSUID="root" OUID="root"
```

I changed the paths similar to the `sbctl` profile.