### PR TITLE
Writing locale.conf

### DIFF
--- a/apparmor.d/groups/systemd/systemd-localed
+++ b/apparmor.d/groups/systemd/systemd-localed
@@ -24,11 +24,12 @@ profile systemd-localed @{exec_path} flags=(attach_disconnected) {
   /usr/share/systemd/*-map r,
   /usr/share/X11/xkb/{,**} r,
 
+  /etc/.#locale.conf@{hex16} rw,
   /etc/.#vconsole.conf* rw,
   /etc/default/.#locale* rw,
   /etc/default/keyboard r,
   /etc/default/locale rw,
-  /etc/locale.conf r,
+  /etc/locale.conf rw,
   /etc/vconsole.conf rw,
   /etc/X11/xorg.conf.d/ r,
   /etc/X11/xorg.conf.d/.#*.confd* rw,


### PR DESCRIPTION
When executing `localectl set-locale LANG=en_US.UTF-8`, I get the following log messages:

```
apparmor="DENIED" operation="mknod" class="file" profile="systemd-localed" name="/etc/.#locale.conffbda0356a1df5f8b"  comm="systemd-localed" requested_mask="c" denied_mask="c" fsuid=0 ouid=0 FSUID="root" OUID="root"
```

After adding the corresponding rule, I get:

```
apparmor="DENIED" operation="rename_dest" class="file" profile="systemd-localed" name="/etc/locale.conf"  comm="systemd-localed" requested_mask="wc" denied_mask="wc" fsuid=0 ouid=0 FSUID="root" OUID="root"
```