### PR TITLE
/boot/EFI 2

### DIFF
--- a/apparmor.d/groups/pacman/mkinitcpio
+++ b/apparmor.d/groups/pacman/mkinitcpio
@@ -83,10 +83,10 @@ profile mkinitcpio @{exec_path} flags=(attach_disconnected) {
 
   # Manage /boot
   / r,
-  /{boot,efi}/ r,
+  /boot/ r,
   /{boot,efi}/EFI/{,**} rw,
-  /{boot,efi}/initramfs-*.img* rw,
-  /{boot,efi}/vmlinuz-* r,
+  /boot/initramfs-*.img* rw,
+  /boot/vmlinuz-* r,
 
   /usr/share/systemd/bootctl/** r,
 

--- a/apparmor.d/groups/pacman/pacman-hook-mkinitcpio
+++ b/apparmor.d/groups/pacman/pacman-hook-mkinitcpio
@@ -37,7 +37,7 @@ profile pacman-hook-mkinitcpio @{exec_path} flags=(attach_disconnected) {
 
   / r,
   /boot/ r,
-  /boot/efi/boot/boot*.efi rw,
+  /{boot,efi}/EFI/boot/boot*.efi rw,
   /boot/initramfs-*-fallback.img rw,
   /boot/initramfs-*.img rw,
   /boot/vmlinuz-* rw,


### PR DESCRIPTION
When executing `pacman -Syu`, I get the following log messages:

```
apparmor="DENIED" operation="unlink" class="file" profile="pacman-hook-mkinitcpio" name="/boot/EFI/boot/bootx64.efi"  comm="rm" requested_mask="d" denied_mask="d" fsuid=0 ouid=0 FSUID="root" OUID="root"
```

In some profiles, the `EFI` directory in `/{boot,efi}/` is also called `efi`. Nested directories are also written in upper or lower case. Probably because this mount point has the FAT32 file system. This problem is present in the `fwupd`, `sbctl`, `grub-install`, `bootctl`, and `fstrim` profiles.

I also reverted some changes I made in the previous pull request.