### PR TITLE
non-owner accesses authorized_keys

### DIFF
--- a/apparmor.d/groups/ssh/sshd
+++ b/apparmor.d/groups/ssh/sshd
@@ -94,7 +94,7 @@ profile sshd @{exec_path} flags=(attach_disconnected) {
   owner @{user_download_dirs}/{,**} rwl,
   owner @{user_sync_dirs}/{,**} rwl,
 
-  owner @{HOME}/@{XDG_SSH_DIR}/authorized_keys{,.*} r,
+  @{HOME}/@{XDG_SSH_DIR}/authorized_keys{,.*} r,
   owner @{user_cache_dirs}/{,motd*} rw,
 
   @{att}/@{run}/systemd/sessions/@{int}.ref rw,


### PR DESCRIPTION
When I try to log into a local SSH server, I get the following log messages:

```
apparmor="DENIED" operation="open" class="file" profile="sshd" name="/home/remote/.ssh/authorized_keys"  comm="sshd-session" requested_mask="r" denied_mask="r" fsuid=1005 ouid=0 FSUID="remote" OUID="root"
apparmor="DENIED" operation="exec" class="file" profile="sshd" name="/usr/bin/userdbctl"  comm="sshd-session" requested_mask="x" denied_mask="x" fsuid=0 ouid=0 FSUID="root" OUID="root"
```

After removing `owner` in

```
  owner @{HOME}/@{XDG_SSH_DIR}/authorized_keys{,.*} r,
```

no log messages.