### PR TITLE
Various fixes: man, nvidia-strict, iwd, lynx

### DIFF
--- a/apparmor.d/abstractions/nvidia-strict
+++ b/apparmor.d/abstractions/nvidia-strict
@@ -26,7 +26,8 @@
         @{PROC}/sys/vm/max_map_count r,
         @{PROC}/sys/vm/mmap_min_addr r,
         @{PROC}/modules r,
-  owner @{PROC}/@{pid}/comm r,
+  owner @{PROC}/@{pid}/{,task/*/}comm r,
+  owner @{PROC}/@{pid}/cmdline r,
 
   /dev/char/195:@{int} w,  # Nvidia graphics devices
   /dev/nvidia-modeset rw,

--- a/apparmor.d/groups/network/iwd
+++ b/apparmor.d/groups/network/iwd
@@ -21,8 +21,10 @@ profile iwd @{exec_path} {
   network netlink raw,
   network netlink dgram,
   network alg seqpacket,
+  network packet dgram,
 
   @{exec_path} mr,
+  @{bin}/resolvconf rPx,
 
   /etc/iwd/{,**} r,
   /var/lib/iwd/{,**} rw,
@@ -33,9 +35,13 @@ profile iwd @{exec_path} {
   @{PROC}/sys/net/ipv{4,6}/conf/wlan@{int}/arp_* rw,
   @{PROC}/sys/net/ipv{4,6}/conf/wlan@{int}/drop_* rw,
   @{PROC}/sys/net/ipv{4,6}/conf/wlan@{int}/ndisc_* rw,
+  @{PROC}/sys/net/ipv{4,6}/conf/wlan@{int}/accept_ra rw,
+  @{PROC}/sys/net/ipv{4,6}/conf/wlan@{int}/optimistic_dad rw,
   @{PROC}/sys/net/ipv{4,6}/conf/wlp*/arp_* rw,
   @{PROC}/sys/net/ipv{4,6}/conf/wlp*/drop_* rw,
   @{PROC}/sys/net/ipv{4,6}/conf/wlp*/ndisc_* rw,
+  @{PROC}/sys/net/ipv{4,6}/conf/wlp*/accept_ra rw,
+  @{PROC}/sys/net/ipv{4,6}/conf/wlp*/optimistic_dad rw,
 
   /dev/rfkill rw,
 

--- a/apparmor.d/profiles-g-l/lynx
+++ b/apparmor.d/profiles-g-l/lynx
@@ -33,8 +33,7 @@ profile lynx @{exec_path} {
   /etc/mailcap r,
   /etc/mime.types r,
 
-  owner @{tmp}/lynxXXXX*/ rw,
-  owner @{tmp}/lynxXXXX*/*TMP.html{,.gz} rw,
+  owner @{tmp}/lynxXXXX*/{,**} rw,
 
   include if exists <local/lynx>
 }


### PR DESCRIPTION
* man:
  * more flexible index db path and specific manpath
  * allow calling groff and friends with inherited permissions
  * proper subprofiles
* nvidia-strict: nvidia libraries get argv from /proc/self
* iwd:
  * sends lots of UDP on packet sockets
  * writes to accept_ra and optimistic_dad
  * DNS daemons other than systemd-resolvd may require iwd to use resolvconf
* lynx: now handles brotli'd HTML as well as gzipped

I didn't want to open a whole pull request for each profile given that each change is just a few lines, but let me know if I should