### PR TITLE
Update systemd-tmpfiles

### DIFF
--- a/apparmor.d/groups/systemd/systemd-tmpfiles
+++ b/apparmor.d/groups/systemd/systemd-tmpfiles
@@ -51,7 +51,10 @@ profile systemd-tmpfiles @{exec_path} flags=(attach_disconnected) {
   @{sys}/kernel/security/{,**} rw,
 
   @{sys}/class/net/ r,
+  @{sys}/devices/system/cpu/cpufreq/ r,
+  @{sys}/devices/system/cpu/cpufreq/policy@{int}/scaling_governor w,
   @{sys}/devices/system/cpu/microcode/reload w,
+  @{sys}/module/pcie_aspm/parameters/policy w,
 
   @{PROC}/@{pid}/net/unix r,
   @{PROC}/1/cmdline r,


### PR DESCRIPTION
profile systemd-tmpfiles {
  @{sys}/devices/system/cpu/cpufreq/ r,
  @{sys}/devices/system/cpu/cpufreq/policy0/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy1/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy2/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy3/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy4/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy5/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy6/scaling_governor w,
  @{sys}/devices/system/cpu/cpufreq/policy7/scaling_governor w,
  @{sys}/module/pcie_aspm/parameters/policy w,
}