### PR TITLE
Add support for different Wechat variants

### DIFF
--- a/apparmor.d/profiles-s-z/wechat
+++ b/apparmor.d/profiles-s-z/wechat
@@ -1,0 +1,47 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 EricLin
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{name} = wechat
+@{lib_dirs} = /opt/wechat/
+@{config_dirs} = @{user_config_dirs}/@{name}
+@{cache_dirs} = @{user_cache_dirs}/@{name}
+
+@{exec_path} = @{lib_dirs}/wechat
+profile wechat @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/attached/consoles>
+  include <abstractions/audio-client>
+  include <abstractions/common/electron>
+  include <abstractions/fontconfig-cache-read>
+  include <abstractions/app/bus>
+
+  network netlink raw,
+  network netlink dgram,
+  network inet stream,
+  network inet dgram,
+  network inet6 dgram,
+  network inet6 stream,
+
+  @{exec_path} mr,
+
+  @{sh_path}  rix,
+  @{lib_dirs}/crashpad_handler ix,
+  @{bin}/mkdir ix,
+  @{bin}/gawk  rix,
+  @{bin}/lsblk rix,
+  @{bin}/ip rix,
+  @{bin}/xdg-user-dir rix,
+  @{open_path} rpx -> child-open-strict,
+
+  owner @{HOME}/.xwechat/{,**} rwk,
+  owner @{user_documents_dirs}/xwechat_files/{,**} rwk,
+
+  include if exists <local/wechat>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wechat
+++ b/apparmor.d/profiles-s-z/wechat
@@ -18,7 +18,6 @@ profile wechat @{exec_path} flags=(attach_disconnected) {
   include <abstractions/audio-client>
   include <abstractions/common/electron>
   include <abstractions/fontconfig-cache-read>
-  include <abstractions/app/bus>
 
   network netlink raw,
   network netlink dgram,
@@ -33,7 +32,7 @@ profile wechat @{exec_path} flags=(attach_disconnected) {
   @{lib_dirs}/crashpad_handler ix,
   @{bin}/mkdir ix,
   @{bin}/gawk  rix,
-  @{bin}/lsblk rix,
+  @{bin}/lsblk rPx,
   @{bin}/ip rix,
   @{bin}/xdg-user-dir rix,
   @{open_path} rpx -> child-open-strict,

--- a/apparmor.d/profiles-s-z/wechat-appimage
+++ b/apparmor.d/profiles-s-z/wechat-appimage
@@ -1,0 +1,95 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 EricLin
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{name} = wechat-appimage
+@{lib_dirs} = /opt/wechat-appimage/
+@{config_dirs} = @{user_config_dirs}/@{name}
+@{cache_dirs} = @{user_cache_dirs}/@{name}
+
+@{exec_path} = @{bin}/wechat @{lib_dirs}/wechat-appimage.Appimage /tmp/.mount_wechat??????/user/bin/wechat
+profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/attached/consoles>
+  include <abstractions/audio-client>
+  include <abstractions/common/electron>
+  include <abstractions/fontconfig-cache-read>
+  include <abstractions/app/bus>
+
+  capability dac_override,
+  capability dac_read_search,
+
+  network netlink raw,
+  network netlink dgram,
+  network inet stream,
+  network inet dgram,
+  network inet6 dgram,
+  network inet6 stream,
+
+  @{exec_path} r,
+
+  @{sh_path}  rix,
+  @{lib_dirs}/wechat-appimage.AppImage ix,
+  /tmp/.mount_wechat??????/AppRun ix,
+  @{bin}/mkdir ix,
+  @{bin}/gawk  rix,
+  @{bin}/lsblk rix,
+  @{bin}/ip rix,
+  @{bin}/xdg-user-dir rix,
+  @{tmp}/.mount_wechat??????/opt/wechat/{,**} ix,
+  @{tmp}/.mount_wechat??????/usr/bin/wechat ix,
+  @{open_path} rpx -> child-open-strict,
+
+  mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat??????/,
+
+  umount @{tmp}/.mount_wechat??????/,
+
+  @{bin}/fusermount{,3} ix -> fusermount,
+  @{bin}/dirname  rix -> fusermount,
+  @{bin}/readlink rix -> fusermount,
+
+  @{bin}/ r,
+  @{bin}/core_perl/ r,
+  @{bin}/site_perl/ r,
+  @{bin}/vendor_perl/ r,
+
+  /usr/local/bin/ r,
+  /usr/local/sbin/ r,
+
+  /etc/machine-id r,
+  /etc/fuse.conf r,
+
+  @{tmp}/.mount_wechat??????/AppRun r,
+  @{tmp}/.mount_wechat??????/ rw,
+  @{tmp}/.mount_wechat??????/opt/wechat/{,**} mr,
+
+  owner /var/tmp/etilqs_* rw,
+
+  @{HOME}/.xwechat/{,**} rwk,
+  owner @{user_documents_dirs}/xwechat_files/{,**} rwk,
+
+  /dev/fuse rw,
+  /dev/tty rw,
+
+  profile fusermount {
+    include <abstractions/base>
+    include <abstractions/consoles>
+    include <abstractions/nameservice-strict>
+    @{bin}/fusermount{,3} mr,
+
+    @{lib_dirs}/wechat-appimage.AppImage r,
+
+    @{PROC}/@{pid}/mounts r,
+
+    /dev/fuse rw,
+    include if exists <local/wechat-appimage_fusermount>
+  }
+
+  include if exists <local/wechat-appimage>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/wechat-appimage
+++ b/apparmor.d/profiles-s-z/wechat-appimage
@@ -11,17 +11,15 @@ include <tunables/global>
 @{config_dirs} = @{user_config_dirs}/@{name}
 @{cache_dirs} = @{user_cache_dirs}/@{name}
 
-@{exec_path} = @{bin}/wechat @{lib_dirs}/wechat-appimage.Appimage /tmp/.mount_wechat??????/user/bin/wechat
+@{exec_path} = @{bin}/wechat
+@{exec_path} += @{lib_dirs}/wechat-appimage.Appimage
+@{exec_path} += /tmp/.mount_wechat??????/user/bin/wechat
 profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/attached/consoles>
   include <abstractions/audio-client>
   include <abstractions/common/electron>
   include <abstractions/fontconfig-cache-read>
-  include <abstractions/app/bus>
-
-  capability dac_override,
-  capability dac_read_search,
 
   network netlink raw,
   network netlink dgram,
@@ -29,6 +27,10 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   network inet dgram,
   network inet6 dgram,
   network inet6 stream,
+
+  mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat??????/,
+
+  umount @{tmp}/.mount_wechat??????/,
 
   @{exec_path} r,
 
@@ -44,13 +46,9 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   @{tmp}/.mount_wechat??????/usr/bin/wechat ix,
   @{open_path} rpx -> child-open-strict,
 
-  mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat??????/,
-
-  umount @{tmp}/.mount_wechat??????/,
-
-  @{bin}/fusermount{,3} ix -> fusermount,
-  @{bin}/dirname  rix -> fusermount,
-  @{bin}/readlink rix -> fusermount,
+  @{bin}/fusermount{,3} Cx -> fusermount,
+  @{bin}/dirname  rix,
+  @{bin}/readlink rix,
 
   @{bin}/ r,
   @{bin}/core_perl/ r,
@@ -61,7 +59,6 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   /usr/local/sbin/ r,
 
   /etc/machine-id r,
-  /etc/fuse.conf r,
 
   @{tmp}/.mount_wechat??????/AppRun r,
   @{tmp}/.mount_wechat??????/ rw,
@@ -79,11 +76,22 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
     include <abstractions/base>
     include <abstractions/consoles>
     include <abstractions/nameservice-strict>
+
+    capability dac_override,
+    capability dac_read_search,
+    capability sys_admin,
+
+    mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat??????/,
+
+    umount @{tmp}/.mount_wechat??????/,
+
     @{bin}/fusermount{,3} mr,
 
     @{lib_dirs}/wechat-appimage.AppImage r,
 
     @{PROC}/@{pid}/mounts r,
+
+    /etc/fuse.conf r,
 
     /dev/fuse rw,
     include if exists <local/wechat-appimage_fusermount>

--- a/apparmor.d/profiles-s-z/wechat-appimage
+++ b/apparmor.d/profiles-s-z/wechat-appimage
@@ -11,9 +11,7 @@ include <tunables/global>
 @{config_dirs} = @{user_config_dirs}/@{name}
 @{cache_dirs} = @{user_cache_dirs}/@{name}
 
-@{exec_path} = @{bin}/wechat
-@{exec_path} += @{lib_dirs}/wechat-appimage.Appimage
-@{exec_path} += /tmp/.mount_wechat??????/user/bin/wechat
+@{exec_path} = @{bin}/wechat @{lib_dirs}/wechat-appimage.Appimage /tmp/.mount_wechat??????/user/bin/wechat
 profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/attached/consoles>

--- a/apparmor.d/profiles-s-z/wechat-universal
+++ b/apparmor.d/profiles-s-z/wechat-universal
@@ -19,7 +19,6 @@ profile wechat-universal @{exec_path} flags=(attach_disconnected) {
   include <abstractions/common/electron>
   include <abstractions/common/bwrap>
   include <abstractions/fontconfig-cache-read>
-  include <abstractions/app/bus>
 
   network netlink raw,
   network netlink dgram,

--- a/apparmor.d/profiles-s-z/wechat-universal
+++ b/apparmor.d/profiles-s-z/wechat-universal
@@ -42,6 +42,7 @@ profile wechat-universal @{exec_path} flags=(attach_disconnected) {
   @{open_path} rPx -> child-open-strict,
 
   /etc/lsb-release r,
+  /etc/machine-id r,
 
   owner @{HOME}/@{XDG_DOCUMENTS_DIR}/WeChat_Data/{,**} rwk,
   owner @{HOME}/.xwechat/{,**} rwk,


### PR DESCRIPTION
wechat-universal: the old version, now only capable with this [AUR](https://aur.archlinux.org/packages/wechat-universal-bwrap) package

wechat-appimage: appimage package version

wechat: the normal version (packed with DEB format)