### PR TITLE
Fix broken regex in mkinitcpio profile

### DIFF
--- a/apparmor.d/groups/pacman/mkinitcpio
+++ b/apparmor.d/groups/pacman/mkinitcpio
@@ -62,7 +62,7 @@ profile mkinitcpio @{exec_path} flags=(attach_disconnected) {
   /etc/mkinitcpio.conf r,
   /etc/mkinitcpio.conf.d/{,**} r,
   /etc/mkinitcpio.d/{,**} r,
-  /etc/modprobe.d/{,*} r,
+  /etc/modprobe.d/{,**} r,
   /etc/os-release r,
   /etc/plymouth/plymouthd.conf r,
   /etc/vconsole.conf r,


### PR DESCRIPTION
This PR adds one extra star in the [mkinitcpio profile on line 65](https://github.com/roddhjav/apparmor.d/blob/main/apparmor.d/groups/pacman/mkinitcpio#L65), fixing the broken regex.

The broken regex causes the AppArmor service to fail to start and the mkinitcpio profile to be unavailable.  Detected while doing a fresh install on Arch Linux on the 22.02.2025.