### PR TITLE
gnome-shell: allows acess XDG_PICTURES_DIR

### DIFF
--- a/apparmor.d/groups/gnome/gnome-shell
+++ b/apparmor.d/groups/gnome/gnome-shell
@@ -249,6 +249,7 @@ profile gnome-shell @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{HOME}/.var/app/**.{png,jpg,svg} r,
   owner @{HOME}/.var/app/**/ r,
   owner @{HOME}/@{XDG_SCREENSHOTS_DIR}/{,**} rw,
+  owner @{HOME}/@{XDG_PICTURES_DIR}/{,**} rw,
   owner @{HOME}/@{XDG_WALLPAPERS_DIR}/{,**} rw,
 
   owner @{user_games_dirs}/**.{png,jpg,svg} r,


### PR DESCRIPTION
i need to test it, but i think this is not good
