### PR TITLE
gnome-shell: Allow acess to flatpak

### DIFF
--- a/apparmor.d/groups/gnome/gnome-shell
+++ b/apparmor.d/groups/gnome/gnome-shell
@@ -174,6 +174,7 @@ profile gnome-shell @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   @{bin}/ibus-daemon            rPx,
   @{bin}/Xwayland               rPx,
   @{bin}/tecla                  rPx,
+  @{bin}/flatpak rPx,
   @{lib}/{,NetworkManager/}nm-openvpn-auth-dialog rPx,
   @{lib}/mutter-x11-frames      rPx,
   #aa:exec polkit-agent-helper


### PR DESCRIPTION
can allow to gnome-shell background apps to kill
background apps