### PR TITLE
bwrap(abstractions): Allow read to actions_avail

### DIFF
--- a/apparmor.d/abstractions/common/bwrap
+++ b/apparmor.d/abstractions/common/bwrap
@@ -47,6 +47,7 @@
         @{PROC}/sys/kernel/overflowgid r,
         @{PROC}/sys/kernel/overflowuid r,
         @{PROC}/sys/user/max_user_namespaces r,
+        @{PROC}/sys/kernel/seccomp/actions_avail r,
   owner @{PROC}/@{pid}/fd/ r,
 
         @{att}/@{PROC}/sys/user/max_user_namespaces rw,


### PR DESCRIPTION
according to kernel doc
actions_avail:
```
    A read-only ordered list of seccomp return values (refer to the SECCOMP_RET_* macros above) in string form. The ordering, from left-to-right, is the least permissive return value to the most permissive return value.

    The list represents the set of seccomp return values supported by the kernel. A userspace program may use this list to determine if the actions found in the seccomp.h, when the program was built, differs from the set of actions actually supported in the current running kernel.
```