### PR TITLE
fix(profile): allow speech-dispatcher to read user config

### DIFF
--- a/apparmor.d/profiles-s-z/speech-dispatcher
+++ b/apparmor.d/profiles-s-z/speech-dispatcher
@@ -29,6 +29,8 @@ profile speech-dispatcher @{exec_path} {
   owner @{run}/user/@{uid}/speech-dispatcher/ rw,
   owner @{run}/user/@{uid}/speech-dispatcher/** rwk,
 
+  owner @{user_config_dirs}/speech-dispatcher/{,**} r,
+
   include if exists <local/speech-dispatcher>
 }
 


### PR DESCRIPTION
E.g., see https://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html#Configuration

> Speech Dispatcher can be configured on several different levels. You can configure the global settings through the server configuration file, which can be placed either in the Speech Dispatcher default configuration system path like /etc/speech-dispatcher/ or in your home directory in ~/.config/speech-dispatcher/. There is also support for per-client configuration, this is, specifying different default values for different client applications. 