### PR TITLE
wirepumbler: Allow access to /dev/udmabuf

### DIFF
--- a/apparmor.d/groups/freedesktop/wireplumber
+++ b/apparmor.d/groups/freedesktop/wireplumber
@@ -73,6 +73,7 @@ profile wireplumber @{exec_path} {
   owner @{PROC}/@{pid}/task/@{tid}/comm rw,
 
   /dev/media@{int} rw,
+  /dev/udmabuf rw,
 
   include if exists <local/wireplumber>
 }


### PR DESCRIPTION
I think this is used to pipewire dma-buf share

```
DENIED  wireplumber open /dev/udmabuf comm=wireplumber requested_mask=wr denied_mask=wr
```