### PR TITLE
Fix can't parse mount rule error

### DIFF
--- a/apparmor.d/profiles-s-z/wechat-appimage
+++ b/apparmor.d/profiles-s-z/wechat-appimage
@@ -26,7 +26,7 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
   network inet6 dgram,
   network inet6 stream,
 
-  mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat@{word6}/,
+  mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) -> @{tmp}/.mount_wechat@{word6}/,
 
   umount @{tmp}/.mount_wechat@{word6}/,
 
@@ -76,7 +76,7 @@ profile wechat-appimage @{exec_path} flags=(attach_disconnected) {
     capability dac_read_search,
     capability sys_admin,
 
-    mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat@{word6}/,
+    mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) -> @{tmp}/.mount_wechat@{word6}/,
 
     umount @{tmp}/.mount_wechat@{word6}/,
 


### PR DESCRIPTION
Fix error when running apparmor-utils

```
ERROR: Can't parse mount rule mount fstype=fuse.wechat-appimage.AppImage options=(ro nodev nosuid) wechat-appimage.AppImage -> @{tmp}/.mount_wechat@{word6}/,
```