### PR TITLE
read access to the hwmon directory

### DIFF
--- a/apparmor.d/profiles-s-z/sensors
+++ b/apparmor.d/profiles-s-z/sensors
@@ -23,7 +23,7 @@ profile sensors @{exec_path} {
   @{sys}/class/i2c-adapter/ r,
   @{sys}/devices/{,platform/*.{i2c,hdmi}/}i2c-@{int}/name r,
   @{sys}/devices/@{pci}/name r,
-  @{sys}/devices/**/hwmon*/** r,
+  @{sys}/devices/**/hwmon*/{,**} r,
 
   # file_inherit
   deny @{PROC}/@{pid}/net/dev r,


### PR DESCRIPTION
Without this patch, I get
```
sensors_init: Kernel interface error
```