### PR TITLE
loginctl-linger

### DIFF
--- a/apparmor.d/groups/systemd/loginctl
+++ b/apparmor.d/groups/systemd/loginctl
@@ -12,6 +12,7 @@ profile loginctl @{exec_path} flags=(attach_disconnected) {
   include <abstractions/consoles>
   include <abstractions/bus-system>
   include <abstractions/common/systemd>
+  include <abstractions/nameservice-strict>
 
   capability net_admin,
   capability sys_resource,

--- a/apparmor.d/groups/systemd/systemd-logind
+++ b/apparmor.d/groups/systemd/systemd-logind
@@ -56,7 +56,7 @@ profile systemd-logind @{exec_path} flags=(attach_disconnected) {
   /swap/swapfile r,
   /swapfile r,
 
-  /var/lib/systemd/linger/ r,
+  /var/lib/systemd/linger/{,@{user}} rw,
 
   @{run}/.#nologin* rw,
   @{run}/credentials/getty@tty@{int}.service/ r,


### PR DESCRIPTION
Executing
```
loginctl disable-linger pulse
```
yields the following AppArmor log:
```
apparmor="ALLOWED" operation="open" class="file" profile="loginctl" name="/etc/nsswitch.conf"  comm="loginctl" requested_mask="r" denied_mask="r" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="ALLOWED" operation="open" class="file" profile="loginctl" name="/etc/passwd"  comm="loginctl" requested_mask="r" denied_mask="r" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="DENIED" operation="unlink" class="file" profile="systemd-logind" name="/var/lib/systemd/linger/pulse"  comm="systemd-logind" requested_mask="d" denied_mask="d" fsuid=0 ouid=0 FSUID="root" OUID="root"
```