### PR TITLE
feat(profile): git//ssh: allow execution of ksshaskpass

### DIFF
--- a/apparmor.d/profiles-g-l/git
+++ b/apparmor.d/profiles-g-l/git
@@ -132,6 +132,7 @@ profile git @{exec_path} flags=(attach_disconnected) {
     network netlink raw,
 
     @{bin}/ssh mr,
+    @{bin}/ksshaskpass ix,
 
     @{etc_ro}/ssh/ssh_config.d/{,*} r,
     @{etc_ro}/ssh/ssh_config r,


### PR DESCRIPTION
I am using the KDE Wallet to store ssh key passphrases.

Syncing changes (git pull/push) raises the following log:
`apparmor="DENIED" operation="exec" class="file" profile="git//ssh" name="/usr/bin/ksshaskpass"  comm="ssh" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0 FSUID="my_user" OUID="root"`

The proposed change worked and I'm now able to sync changes.

Please let me know if this OK or there's a better way of handling it.

Thank you!