### PR TITLE
Fix hyprland profile.

### DIFF
--- a/apparmor.d/groups/hyprland/hyprland
+++ b/apparmor.d/groups/hyprland/hyprland
@@ -31,6 +31,7 @@ profile hyprland @{exec_path} flags=(attach_disconnected) {
   owner @{user_cache_dirs}/hyprland/{,**} rw,
   owner @{user_config_dirs}/hypr/** r,
   owner @{user_share_dirs}/hyprpm/** mr,
+  owner @{user_share_dirs}/hyprland/** rw,
 
   owner @{run}/user/@{uid}/gamescope-* rw,
   owner @{run}/user/@{uid}/.hyprpaper_* rw,


### PR DESCRIPTION
Hyprland now needs access to `~/.local/share/hyprland/`, where it stores its last version used for notifying user when it was updated. Without `rw` permissions to this directory, Hyprland displays a "Hyprland was just updated!" notification on every startup. This PR resolves that issue.