### PR TITLE
Broken login: Update systemd-logind

### DIFF
--- a/apparmor.d/groups/systemd/systemd-logind
+++ b/apparmor.d/groups/systemd/systemd-logind
@@ -139,6 +139,7 @@ profile systemd-logind @{exec_path} flags=(attach_disconnected) {
         /dev/dri/card@{int} rw,
         /dev/input/event@{int} rw,  # Input devices (keyboard, mouse, etc)
         /dev/mqueue/ r,
+        /dev/tty@{int} rw,
   owner /dev/shm/{,**/} rw,
 
   include if exists <local/systemd-logind>


### PR DESCRIPTION
Today I was not able to log into my Arch Linux system. After chrooting into the system, performing aa-log and adding the rule to systemd-logind the problem was fixed.