### PR TITLE
ouch: allow listing archive contents

### DIFF
--- a/apparmor.d/profiles-m-r/ouch
+++ b/apparmor.d/profiles-m-r/ouch
@@ -17,11 +17,16 @@ profile ouch @{exec_path} {
   owner @{HOME}/.tmp@{rand6}/{,**} rw,
   owner @{HOME}/.tmp-ouch@{rand6}/{,**} rw,
 
+  owner /tmp/ w,
+  owner /tmp/.tmp@{rand6}/{,**} rw,
+  owner /tmp/.tmp-ouch@{rand6}/{,**} rw,
+
   @{sys}/fs/cgroup/user.slice/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{word}.scope/cpu.max r,
 
   owner @{PROC}/@{pid}/cgroup r,
+  owner @{PROC}/@{pid}/mountinfo r,
 
   include if exists <local/ouch>
 }


### PR DESCRIPTION
The list function requires the creation of new directories in /tmp for some archive formats