### PR TITLE
Add profile for `tgpt`.

### DIFF
--- a/apparmor.d/profiles-s-z/tgpt
+++ b/apparmor.d/profiles-s-z/tgpt
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/tgpt
-profile tgpt @{exec_path} flags=(unconfined) {
+profile tgpt @{exec_path} flags=(complain) {
   include <abstractions/base>
   include <abstractions/nameservice>
 


### PR DESCRIPTION
## New profile for [tgpt](https://github.com/aandrew-me/tgpt)

The profile is set to unconfined at this time since it's very experimental and *will* break some functionality.

While set to enforce mode, with the unconfined flag removed:
- [x] Basic LLM chat works
- [x] Image generation works, as long as the output path is in `XDG_DOWNLOAD_DIR`
- [ ] Shell commands can be generated, but can't be executed as allowing the program to run a shell in unconfined mode would be to defeat the purpose of having an AppArmor profile for it in the first place