### PR TITLE
Add profile for texstudio

### DIFF
--- a/apparmor.d/profiles-s-z/texstudio
+++ b/apparmor.d/profiles-s-z/texstudio
@@ -41,7 +41,7 @@ profile texstudio @{exec_path} {
 
   ## silencer
   deny owner /usr/share/hunspell/en_US-large.ign w,
-  
+
   include if exists <local/texstudio>
 }
 


### PR DESCRIPTION
Add a profile for the latex editor texstudio

The applications tries to open some file under /usr/share/ with write permissions for some reason.
I assume this is a bug since it will never have those permissions anyway, therefore I silenced the request in the profile.
