### PR TITLE
Add support for MD RAID devices to the disk-read/write abstractions

### DIFF
--- a/apparmor.d/abstractions/disks-read
+++ b/apparmor.d/abstractions/disks-read
@@ -80,6 +80,11 @@
 
   # CD-ROM
   /dev/sr@{int} rk,
+  
+  # MD RAID devices
+  /dev/md@{int} rk,
+  @{sys}/devices/virtual/block/md@{int}/ r,
+  @{sys}/devices/virtual/block/md@{int}/** r,
 
   # Lookup block device by major:minor numbers
   # See: https://apparmor.pujol.io/development/internal/#udev-rules
@@ -91,6 +96,7 @@
   @{run}/udev/data/b2:@{int} r,       # for /dev/fd*
   @{run}/udev/data/b7:@{int} r,       # for /dev/loop*
   @{run}/udev/data/b8:@{int} r,       # for /dev/sd*
+  @{run}/udev/data/b9:@{int} r,       # for /dev/md*
   @{run}/udev/data/b11:@{int} r,      # for /dev/sr*
   @{run}/udev/data/b43:@{int} r,      # for /dev/nbd*
   @{run}/udev/data/b179:@{int} r,     # for /dev/mmcblk*

--- a/apparmor.d/abstractions/disks-read
+++ b/apparmor.d/abstractions/disks-read
@@ -80,7 +80,7 @@
 
   # CD-ROM
   /dev/sr@{int} rk,
-  
+
   # MD RAID devices
   /dev/md@{int} rk,
   @{sys}/devices/virtual/block/md@{int}/ r,

--- a/apparmor.d/abstractions/disks-write
+++ b/apparmor.d/abstractions/disks-write
@@ -40,6 +40,9 @@
 
   # CD-ROM
   /dev/sr@{int} w,
+  
+  # MD RAID devices
+  /dev/md@{int} w,
 
   include if exists <abstractions/disks-write.d>
 

--- a/apparmor.d/abstractions/disks-write
+++ b/apparmor.d/abstractions/disks-write
@@ -40,7 +40,7 @@
 
   # CD-ROM
   /dev/sr@{int} w,
-  
+
   # MD RAID devices
   /dev/md@{int} w,
 


### PR DESCRIPTION
I noticed that 'lsblk' wasn't showing my MD RAID arrays.