### PR TITLE
Allow sbctl to parse DMI data

### DIFF
--- a/apparmor.d/profiles-s-z/sbctl
+++ b/apparmor.d/profiles-s-z/sbctl
@@ -26,6 +26,8 @@ profile sbctl @{exec_path} {
   @{lib}/fwupd/efi/{,**} rw,
   @{lib}/systemd/boot/efi/systemd-boot*.efi.signed rw,
 
+  @{sys}/devices/virtual/dmi/id/* r,
+
   @{sys}/firmware/efi/efivars/db-@{uuid} rw,
   @{sys}/firmware/efi/efivars/KEK-@{uuid} rw,
   @{sys}/firmware/efi/efivars/PK-@{uuid} rw,


### PR DESCRIPTION
This path is hard coded in "dmi/dmi.go".