### PR TITLE
Add Pacman Hook Profile for Paccache

### DIFF
--- a/apparmor.d/groups/pacman/pacman-hook-paccache
+++ b/apparmor.d/groups/pacman/pacman-hook-paccache
@@ -1,5 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2025 valoq <valoq@mailbox.org>
+# Copyright (C) 2025 RayJW <29835902+RayJW@users.noreply.github.com>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/4.0>,

--- a/apparmor.d/groups/pacman/pacman-hook-paccache
+++ b/apparmor.d/groups/pacman/pacman-hook-paccache
@@ -1,0 +1,149 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 valoq <valoq@mailbox.org>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/date {
+  @{bin}/date r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/find {
+  @{bin}/find r,
+  @{lib}/gconv/gconv-modules.cache r,
+
+  /var/cache/pacman/pkg/ r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacman-conf {
+  @{bin}/pacman-conf r,
+
+  /etc/pacman.conf r,
+  /etc/pacman.d/ r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacsort {
+  @{bin}/pacsort r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/gawk {
+  @{bin}/gawk r,
+  @{lib}/gconv/gconv-modules.cache r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpgconf {
+  @{bin}/gpgconf r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+# vim:syntax=apparmor
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpg {
+  @{bin}/gpg r,
+
+  /etc/pacman.d/ r,
+  /etc/pacman.d/gnupg/ r,
+  /etc/pacman.d/gnupg/gpg.conf r,
+  /etc/pacman.d/gnupg/pubring.gpg r,
+  /etc/pacman.d/gnupg/trustdb.gpg rw,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman {
+  @{bin}/paccache ix -> pacman//null-@{bin}/paccache,
+}
+
+profile pacman//null-@{bin}/paccache {
+  @{sh_path}         r,
+  @{bin}/date        ix -> pacman//null-@{bin}/paccache//null-@{bin}/date,
+  @{bin}/date        r,
+  @{bin}/find        ix -> pacman//null-@{bin}/paccache//null-@{bin}/find,
+  @{bin}/find        r,
+  @{bin}/gawk        ix -> pacman//null-@{bin}/paccache//null-@{bin}/gawk,
+  @{bin}/gawk        r,
+  @{bin}/paccache    r,
+  @{bin}/pacman      ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacman,
+  @{bin}/pacman      r,
+  @{bin}/pacman-conf ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacman-conf,
+  @{bin}/pacman-conf r,
+  @{bin}/pacsort     ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacsort,
+  @{bin}/pacsort     r,
+  @{lib}/gconv/gconv-modules.cache r,
+
+  / r,
+
+  /usr/share/makepkg/util/message.sh r,
+  /usr/share/makepkg/util/parseopts.sh r,
+
+  /var/ r,
+  /var/cache/ r,
+  /var/cache/pacman/ r,
+  /var/cache/pacman/pkg/ r,
+
+  /dev/pts/2 rw, # file_inherit
+  /dev/tty rw,
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacman {
+  @{bin}/gpg     ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpg,
+  @{bin}/gpgconf ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpgconf,
+  @{bin}/gpgsm   ix -> pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpgsm,
+  @{bin}/pacman  r,
+  @{lib}/gconv/gconv-modules.cache r,
+
+  / r,
+
+  /etc/pacman.conf r,
+  /etc/pacman.d/ r,
+  /etc/ssl/openssl.cnf r,
+
+  /var/lib/pacman/local/ r,
+  /var/lib/pacman/local/ r,
+  /var/lib/pacman/sync/ r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile pacman//null-@{bin}/paccache//null-@{bin}/pacman//null-@{bin}/gpgsm {
+  @{bin}/gpgsm r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile paccache//null-@{bin}/find {
+  @{bin}/find r,
+  @{lib}/gconv/gconv-modules.cache r,
+
+  /var/cache/pacman/pkg/ r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile paccache {
+  @{bin}/date ix -> paccache//null-@{bin}/date,
+  @{bin}/find ix -> paccache//null-@{bin}/find,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+profile paccache//null-@{bin}/date {
+  @{bin}/date r,
+
+  /dev/pts/2 rw, # file_inherit
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
This adds a profile for the [paccache-hook](https://aur.archlinux.org/packages/paccache-hook) and the tool `paccache` it's using, which is part of [pacman-contrib](https://archlinux.org/packages/extra/x86_64/pacman-contrib).

The initial profile created by `aa-log -r pacman` contained a lot of specific paths to packages and specific pacman config files. I think I've cleaned all of that up. It seems like a pretty big profile, but testing went fine on my end. This is my first time creating a profile from scratch though, so maybe this is way off, but I tried following the guide.