### PR TITLE
Host: allow netlink raw

### DIFF
--- a/apparmor.d/profiles-g-l/host
+++ b/apparmor.d/profiles-g-l/host
@@ -18,6 +18,7 @@ profile host @{exec_path} {
   network inet6 dgram,
   network inet stream,
   network inet6 stream,
+  network netlink raw,
 
   @{exec_path} mr,
 


### PR DESCRIPTION
Querying a DNS server using it's hostname results in an apparmor denial: `host google.com dns.google.com`

`apparmor="DENIED" operation="create" class="net" profile="host" pid=00000 comm="host" family="netlink" sock_type="raw" protocol=0 requested_mask="create" denied_mask="create"`