### PR TITLE
add search tools

### DIFF
--- a/apparmor.d/profiles-a-f/fd
+++ b/apparmor.d/profiles-a-f/fd
@@ -1,0 +1,21 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 valoq <valoq@mailbox.ofd>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/fd
+profile fd @{exec_path}  {
+  include <abstractions/base>
+
+  @{exec_path} mr,
+
+  ## Allow reading the entire filesystem to search for filenames
+  /{,**} r,
+
+  include if exists <local/fd>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/rg
+++ b/apparmor.d/profiles-m-r/rg
@@ -1,0 +1,21 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 valoq <valoq@mailbox.org>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/rg
+profile rg @{exec_path}  {
+  include <abstractions/base>
+
+  @{exec_path} mr,
+
+  ## Allow reading the entire filesystem to search for strings
+  /{,**} r,
+
+  include if exists <local/rg>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/rga
+++ b/apparmor.d/profiles-m-r/rga
@@ -1,0 +1,36 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2025 valoq <valoq@mailbox.org>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/rga
+profile rga /{,usr/}bin/rga {
+  include <abstractions/base-strict>
+
+  @{exec_path} mr,
+
+  @{bin}/rg          ix,
+  @{bin}/ffmpeg      ix,
+  @{bin}/ffprobe     ix,
+  @{bin}/pandoc      ix,
+  @{bin}/pdftotext   ix,
+  @{bin}/rga-preproc ix,
+
+  /usr/share/poppler/** r,
+
+  owner @{user_cache_dirs}/ripgrep-all/cache.sqlite3 rwk,
+  owner @{user_cache_dirs}/ripgrep-all/cache.sqlite3-shm rwk,
+  owner @{user_cache_dirs}/ripgrep-all/cache.sqlite3-wal rwk,
+
+  ## Allow reading the entire filesystem to search for strings
+  /{,**} r,
+ 
+  owner @{PROC}/@{pid}/task/@{tid}/comm w,
+
+  include if exists <local/rga>
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Adds file (fd) and string (rg) search tools

This is a bit special:
These tools need access tot he entire file system for common usage, but since they parse a lot of data they should also be restricted. Since there are no permissions needed that could allow data extraction (like network access) this still provides significant benefits.  