### PR TITLE
Update mdadm

### DIFF
--- a/apparmor.d/profiles-m-r/mdadm
+++ b/apparmor.d/profiles-m-r/mdadm
@@ -27,7 +27,8 @@ profile mdadm @{exec_path} flags=(attach_disconnected) {
   @{sh_path}       rix,
   @{sbin}/sendmail rPUx,
 
-  /etc/mdadm.conf r,
+  /etc/{,mdadm/}mdadm.conf     r,
+  /etc/{,mdadm/}mdadm.conf.d/* r,
 
   @{run}/initctl r,
   @{run}/mdadm/* rwk,


### PR DESCRIPTION
There were lots of missing components of mdadm.

I have a few scripts that create and tear down MD RAID arrays.  I've ran them all and added the missing entries.

Note that mdadm has the ability to run in daemon mode and send mail when an array fails. That's why it requires all the network entries.