### PR TITLE
ssh: allow ssh to authenticate to remote hosts using kerberos tickets

### DIFF
--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -44,6 +44,8 @@ profile ssh @{exec_path} {
   owner @{user_projects_dirs}/**/ssh/{,*} r,
   owner @{user_projects_dirs}/**/config r,
 
+  owner @{tmp}/krb5cc_* rwk,
+
   audit owner @{tmp}/ssh-*/{,agent.@{int}} rwkl,
 
   owner @{run}/user/@{uid}/gvfsd-sftp/@{hex} rwl -> @{run}/user/@{uid}/gvfsd-sftp/@{hex}.@{rand},


### PR DESCRIPTION
This allows the SSH client to function with kerberos auth.

Note that if the kerberos config specifies a file like `/tmp/krb5cc*` for the credential cache, then this will still fail because write access is required, whereas the abstraction only permits read access. But this should probably be fixed in a separate patch to the upstream `kerberosclient` abstraction.