### PR TITLE
ssh-keygen: allow execution of ssh-sk-helper

### DIFF
--- a/apparmor.d/groups/ssh/ssh-keygen
+++ b/apparmor.d/groups/ssh/ssh-keygen
@@ -15,6 +15,8 @@ profile ssh-keygen @{exec_path} {
 
   @{exec_path} mr,
 
+  @{lib}/{,ssh/}ssh-sk-helper rPx -> ssh-sk-helper,
+
   /etc/ssh/moduli rw,
   /etc/ssh/ssh_host_*_key* rw,
 


### PR DESCRIPTION
The ssh-sk-helper  profile was added last year but never hooked into the ssh-keygen profile.

This is needed for generating SSH keys that live on a yubikey.