### PR TITLE
Update sddm-greeter: add mediate_deleted

### DIFF
--- a/apparmor.d/groups/kde/sddm-greeter
+++ b/apparmor.d/groups/kde/sddm-greeter
@@ -8,7 +8,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/sddm-greeter{,-qt6}
-profile sddm-greeter @{exec_path} flags=(attach_disconnected) {
+profile sddm-greeter @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/bus-session>
   include <abstractions/bus-system>
@@ -48,8 +48,11 @@ profile sddm-greeter @{exec_path} flags=(attach_disconnected) {
   /etc/sddm.conf r,
   /etc/sddm.conf.d/{,*} r,
   /etc/xdg/plasmarc r,
-  /var/lib/AccountsService/icons/* r,
-  /var/lib/dbus/machine-id r,
+  
+        /var/lib/AccountsService/icons/* r,
+        /var/lib/dbus/machine-id r,
+  owner /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/#@{int8} rw,
+  owner /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/qqpc_opengl.@{rand6} l -> /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/#@{int8},
 
         @{SDDM_HOME}/state.conf r,
   owner @{SDDM_HOME}/** rw,

--- a/apparmor.d/groups/kde/sddm-greeter
+++ b/apparmor.d/groups/kde/sddm-greeter
@@ -49,11 +49,9 @@ profile sddm-greeter @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   /etc/sddm.conf.d/{,*} r,
   /etc/xdg/plasmarc r,
   
-        /var/lib/AccountsService/icons/* r,
-        /var/lib/dbus/machine-id r,
-  owner /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/#@{int8} rw,
-  owner /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/qqpc_opengl.@{rand6} l -> /var/lib/sddm/.cache/sddm-greeter/qtshadercache-x86_64-little_endian-lp64/#@{int8},
-
+  /var/lib/AccountsService/icons/* r,
+  /var/lib/dbus/machine-id r,
+  
         @{SDDM_HOME}/state.conf r,
   owner @{SDDM_HOME}/** rw,
   owner @{SDDM_HOME}/#@{int} mrw,

--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -278,7 +278,7 @@ run-parts complain
 runuser complain
 sdcv complain
 sddm attach_disconnected,mediate_deleted,complain
-sddm-greeter attach_disconnected,complain
+sddm-greeter attach_disconnected,mediate_deleted,complain
 secure-time-sync attach_disconnected,complain
 sftp-server complain
 sing-box complain


### PR DESCRIPTION
profile sddm-greeter flags=(mediate_deleted) {
 owner link /var/lib/sddm/.cache/sddm-greeter-qt6/qtpipelinecache-@{arch}-little_endian-lp64/#@{int8} ,           # Failed name lookup - deleted entry
 owner link /var/lib/sddm/.cache/sddm-greeter-qt6/qtpipelinecache-@{arch}-little_endian-lp64/qqpc_opengl.BalADW -> /var/lib/sddm/.cache/sddm-greeter-qt6/qtpipelinecache-@{arch}-little_endian-lp64/#@{int8},
owner link /var/lib/sddm/.cache/sddm-greeter-qt6/qtpipelinecache-@{arch}-little_endian-lp64/qqpc_opengl.cgulsP -> /var/lib/sddm/.cache/sddm-greeter-qt6/qtpipelinecache-@{arch}-little_endian-lp64/#@{int8},