### PR TITLE
fix zpool again

### DIFF
--- a/apparmor.d/profiles-s-z/zpool
+++ b/apparmor.d/profiles-s-z/zpool
@@ -13,7 +13,7 @@ profile zpool @{exec_path} {
 
   capability sys_admin,
 
-  mount fstype=zfs options=(rw noatime) * -> @{MOUNTS}/,
+  mount fstype=zfs options=(rw noatime) ** -> @{MOUNTS}/,
 
   @{exec_path} mr,
 

--- a/apparmor.d/profiles-s-z/zpool
+++ b/apparmor.d/profiles-s-z/zpool
@@ -13,7 +13,7 @@ profile zpool @{exec_path} {
 
   capability sys_admin,
 
-  mount fstype=zfs options=(rw noatime) ** -> @{MOUNTS}/,
+  mount fstype=zfs options=(rw noatime) -> @{MOUNTS}/,
 
   @{exec_path} mr,
 


### PR DESCRIPTION
Previous fix has this error which slipped past me and apparmor_parser.

```
ERROR: Can't parse mount rule mount fstype=zfs options=(rw noatime) * -> @{MOUNTS}/,
```