### PR TITLE
Add allowed paths for correct generation of swap target

### DIFF
--- a/apparmor.d/groups/systemd-generators/systemd-generator-gpt-auto
+++ b/apparmor.d/groups/systemd-generators/systemd-generator-gpt-auto
@@ -25,7 +25,9 @@ profile systemd-generator-gpt-auto @{exec_path} flags=(attach_disconnected)  {
   /home/ r,
 
   @{run}/systemd/generator.late/**.{,auto}mount w,
+  @{run}/systemd/generator.late/**.swap w,
   @{run}/systemd/generator.late/home.mount.wants/ w,
+  @{run}/systemd/generator.late/swap.target.wants/ w,
   @{run}/systemd/generator.late/local-fs.target.d/ w,
   @{run}/systemd/generator.late/local-fs.target.d/*.conf w,
   @{run}/systemd/generator.late/local-fs.target.requires/ w,


### PR DESCRIPTION
The generator for GPT mounts also creates a swap target, when a swap partition is available. Write access to paths relating to this target was missing. They were added in this commit.