### PR TITLE
Update xdg-desktop-portal-kde

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -42,7 +42,7 @@ profile xdg-desktop-portal-kde @{exec_path} {
 
   owner @{desktop_config_dirs}/user-dirs.dirs r,
 
-  owner @{user_cache_dirs}/xdg-desktop-portal-kde/{,**} rw,
+  owner @{user_cache_dirs}/xdg-desktop-portal-kde/{,**} rwl,
 
   owner @{user_config_dirs}/autostart/org.kde.*.desktop r,
   owner @{user_config_dirs}/breezerc r,


### PR DESCRIPTION
DENIED  xdg-desktop-portal-kde link owner @{user_cache_dirs}/xdg-desktop-portal-kde/qmlcache/@{hex38}49.qmlc.HaAhtu -> @{user_cache_dirs}/xdg-desktop-portal-kde/qmlcache/#@{int8} comm=QQmlThread requested_mask=l denied_mask=l