### PR TITLE
Correct Tor Browser temp file name pattern

### DIFF
--- a/apparmor.d/groups/browsers/torbrowser
+++ b/apparmor.d/groups/browsers/torbrowser
@@ -42,7 +42,7 @@ profile torbrowser @{exec_path} flags=(attach_disconnected) {
   owner "@{tmp}/Tor Project*" rwk,
   owner "@{tmp}/Tor Project*/" rw,
   owner "@{tmp}/Tor Project*/**" rwk,
-  owner @{tmp}/@{rand8}.* rw,
+  owner @{tmp}/@{word8} rw,
   owner @{tmp}/mozilla_pc@{int}/ rw,
   owner @{tmp}/mozilla_pc@{int}/* rwk,
 


### PR DESCRIPTION
Tor Browser, as of v14.5.8, creates temporary files during downloads with 8-character names including underscore (_) so the pattern @{rand8}.* does not match and allow them. This has been changed to @{word8} in this commit.