### PR TITLE
Minor profile fix

### DIFF
--- a/apparmor.d/profiles-s-z/zathura
+++ b/apparmor.d/profiles-s-z/zathura
@@ -22,6 +22,8 @@ profile zathura @{exec_path} {
   /etc/xdg/{,**} r,
   /etc/zathurarc r,
 
+  /var/empty/ r,
+
   owner @{user_config_dirs}/zathura/** r,
   owner @{user_share_dirs}/zathura/ r,
   owner @{user_share_dirs}/zathura/** rwk,


### PR DESCRIPTION
Allow /var/empy which is used in a zathura to avoid dconf writes https://github.com/pwmt/zathura/commit/4cb24239b688b08bab72534edb4759097891c63b