### PR TITLE
Libreoffice: missing flag in main.flags

### DIFF
--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -213,7 +213,7 @@ landscape-sysinfo.wrapper complain
 language-validate attach_disconnected,complain
 last complain
 lastlog complain
-libreoffice attach_disconnected,complain
+libreoffice attach_disconnected,complain,mediate_deleted
 libvirt-dbus complain
 libvirtd attach_disconnected,complain
 lightdm attach_disconnected,complain


### PR DESCRIPTION
The libreoffice profile contains the `mediate_deleted` flag but it is missing in `main.flags`.