### PR TITLE
Update fwupd

### DIFF
--- a/apparmor.d/profiles-a-f/fwupd
+++ b/apparmor.d/profiles-a-f/fwupd
@@ -99,6 +99,7 @@ profile fwupd @{exec_path} flags=(attach_disconnected) {
   @{sys}/firmware/efi/efivars/Boot@{hex}-@{uuid} rw,
   @{sys}/firmware/efi/efivars/BootNext-@{uuid} rw,
   @{sys}/firmware/efi/efivars/dbx-@{uuid} rw,
+  @{sys}/firmware/efi/efivars/db-@{uuid} rw,
   @{sys}/firmware/efi/efivars/fwupd-* rw,
   @{sys}/firmware/efi/efivars/KEK-@{uuid} rw,
   @{sys}/kernel/security/lockdown r,


### PR DESCRIPTION
I was unable to update UEFI db
`DENIED  fwupd open @{sys}/firmware@{efi}/efivars/db-@{uuid} comm=fwupd requested_mask=a denied_mask=a`

I'm not sure if `@{efi}` var should be used here, also I don't know if it will work fine with append permission only, or just gran write since I personally just added `rw` to make it work