### PR TITLE
fix(profile): discord: add video

### DIFF
--- a/apparmor.d/profiles-a-f/discord
+++ b/apparmor.d/profiles-a-f/discord
@@ -21,6 +21,7 @@ profile discord @{exec_path} flags=(attach_disconnected) {
   include <abstractions/screensaver>
   include <abstractions/thumbnails-cache-read>
   include <abstractions/user-download-strict>
+  include <abstractions/camera>
 
   network inet dgram,
   network inet6 dgram,


### PR DESCRIPTION
Discord has a video call feature, so it should be allowed to read `/dev/video` files for the webcam. When this is disallowed in a default installation this is logged every three seconds:
```
Dec 04 20:45:56 framework kernel: audit: type=1400 audit(1764881156.931:6474): apparmor="ALLOWED" operation="open" class="file" profile="discord" name="/dev/video0" pid=4656 comm="VideoDevicePoll" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
Dec 04 20:45:56 framework kernel: audit: type=1400 audit(1764881156.931:6475): apparmor="ALLOWED" operation="open" class="file" profile="discord" name="/dev/video1" pid=4656 comm="VideoDevicePoll" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
Dec 04 20:45:56 framework kernel: audit: type=1400 audit(1764881156.931:6476): apparmor="ALLOWED" operation="open" class="file" profile="discord" name="/dev/video0" pid=4656 comm="VideoDevicePoll" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
Dec 04 20:45:56 framework kernel: audit: type=1400 audit(1764881156.931:6477): apparmor="ALLOWED" operation="open" class="file" profile="discord" name="/dev/video1" pid=4656 comm="VideoDevicePoll" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
Dec 04 20:45:56 framework kernel: audit: type=1400 audit(1764881156.931:6478): apparmor="ALLOWED" operation="open" class="file" profile="discord" name="/dev/video0" pid=4656 comm="VideoDevicePoll" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```
I could not tell whether `abstractions/camera` or `abstractions/video` was the correct file to include. `video` seems finer grained. When applied the audit log is no longer spammed and the webcam preview functions in the application