### PR TITLE
fix(profile): plasma: browser integration artwork

### DIFF
--- a/apparmor.d/groups/kde/plasma-browser-integration-host
+++ b/apparmor.d/groups/kde/plasma-browser-integration-host
@@ -31,6 +31,9 @@ profile plasma-browser-integration-host @{exec_path} {
   owner @{PROC}/@{pid}/cmdline r,
   owner @{PROC}/@{pid}/stat r,
 
+  owner /tmp/#@{int} rw,
+  owner @{tmp}/plasma-browser-integration_artwork_@{rand6}.jpg rwl -> /tmp/#@{int},
+
   include if exists <local/plasma-browser-integration-host>
 }
 

--- a/apparmor.d/groups/kde/plasmashell
+++ b/apparmor.d/groups/kde/plasmashell
@@ -204,6 +204,7 @@ profile plasmashell @{exec_path} flags=(mediate_deleted) {
 
         /tmp/.mount_nextcl@{rand6}/{,*} r,
   owner @{tmp}/#@{int} rw,
+  owner @{tmp}/plasma-browser-integration_artwork_@{rand6}.jpg r,
 
         @{run}/mount/utab r,
         @{run}/user/@{uid}/gvfs/ r,


### PR DESCRIPTION
The `plasma-browser-integration` native messaging host writes the current browser's stream's artwork to a tmpfile (`O_TMPFILE` by way of `QTemporaryFile`) which is then read by `plasmashell`. At present in `main` neither ends of the communication succeed. These rules grant read/write/link on the tmpfile path format to `plasma-browser-integration-host` and read on it to `plasmashell`.