### PR TITLE
umu-run: allow mapping from proton runner

### DIFF
--- a/apparmor.d/groups/umu/umu-run
+++ b/apparmor.d/groups/umu/umu-run
@@ -64,7 +64,7 @@ profile umu-run @{exec_path} flags=(attach_disconnected) {
   owner @{wineprefix_dirs}/** w,
 
   owner @{steam_lib_dirs}/{,*} rw,
-  owner @{steam_share_dirs}/compatibilitytools.d/{,**} rw,
+  owner @{steam_share_dirs}/compatibilitytools.d/{,**} rwm,
 
   owner @{cache_dirs}/ rw,
   owner @{cache_dirs}/** rwlk -> @{share_dirs}/**,


### PR DESCRIPTION
`ALLOWED umu-run file_mmap owner @{user_share_dirs}/Steam/compatibilitytools.d/proton-EM-10.0-32/files/lib/wine/@{arch}-windows/ia2comproxy.dll comm=ModManager.exe requested_mask=m denied_mask=m
ALLOWED umu-run file_mmap owner @{user_share_dirs}/Steam/compatibilitytools.d/proton-EM-10.0-32/files/lib/wine/@{arch}-windows/msimg32.dll comm=ModManager.exe requested_mask=m denied_mask=m`