### PR TITLE
app-open: allow mpv launch

### DIFF
--- a/apparmor.d/abstractions/app-open
+++ b/apparmor.d/abstractions/app-open
@@ -48,6 +48,7 @@
   @{bin}/gnome-software         Px,
   @{bin}/gwenview               PUx,
   @{bin}/keepassxc              Px,
+  @{bin}/mpv                    Px,
   @{bin}/qbittorrent            Px,
   @{bin}/qpdfview               Px,
   @{bin}/smplayer               Px,


### PR DESCRIPTION
`DENIED  child-open exec @{bin}/mpv comm=gio-launch-desk requested_mask=x denied_mask=x`

mpv should be allowed as it also can be the default media player, log caused by opening a downloaded video from firefox.