### PR TITLE
Added kde-open for KDE Plasma 6.5.5

### DIFF
--- a/apparmor.d/abstractions/app/open
+++ b/apparmor.d/abstractions/app/open
@@ -42,6 +42,7 @@
 
     owner @{run}/user/@{uid}/#@{int} rw,
     owner @{run}/user/@{uid}/kioclient@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
+    owner @{run}/user/@{uid}/kde-open@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
 
     @{PROC}/sys/kernel/random/boot_id r,
 


### PR DESCRIPTION
KDE Plasma 6.5.5 seems to have changed a few things. 

"Unable to create KIO worker. Can not create a socket for launching a KIO worker for protocol 'file'."
kde-open requested_mask=l denied_mask=l