### PR TITLE
Kioworker allowed access to /etc

### DIFF
--- a/apparmor.d/groups/kde/kioworker
+++ b/apparmor.d/groups/kde/kioworker
@@ -75,7 +75,7 @@ profile kioworker @{exec_path} {
 
   # Silence non user's data
   deny @{efi}/{,**} r,
-  deny /etc/{,**} r,
+  #deny /etc/{,**} r,
   deny /opt/{,**} r,
   deny /root/{,**} r,
   deny /tmp/.* rw,


### PR DESCRIPTION
Resolves a problem with KDE Plasma Addons in which internet applets fail to fetch data from their providers.