### PR TITLE
Firefox: Add new XDG config path

### DIFF
--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -10,6 +10,7 @@ include <tunables/global>
 @{name} = firefox{,-esr,-bin}
 @{lib_dirs} = @{lib}/firefox{,-esr,-beta,-devedition,-nightly} /opt/@{name}
 @{config_dirs} = @{HOME}/.mozilla/
+@{config_dirs} += @{user_config_dirs}/mozilla/
 @{cache_dirs} = @{user_cache_dirs}/mozilla/
 
 @{exec_path} = @{bin}/@{name} @{lib_dirs}/@{name}


### PR DESCRIPTION
Firefox 147 added support for configuration path following the XDG specification. 
When firefox >=147 is started for the first time and ~/.mozilla does not exist, it attempts to create ~/.config/mozilla by default