### PR TITLE
Complains that the profile is missing otherwise.

### DIFF
--- a/apparmor.d/profiles-s-z/thunderbird
+++ b/apparmor.d/profiles-s-z/thunderbird
@@ -52,6 +52,8 @@ profile thunderbird @{exec_path} flags=(attach_disconnected) {
 
   owner /var/mail/** rwk,
 
+  owner @{HOME}/Thunderbird/{,**} rw,
+
   owner @{user_mail_dirs}/ rw,
   owner @{user_mail_dirs}/** rwl -> @{user_mail_dirs}/**,
 


### PR DESCRIPTION
Executing
```
thunderbird
```
produces the following AppArmor log:
```
apparmor="DENIED" operation="file_inherit" class="file" profile="thunderbird" name="/dev/pts/4"  comm="thunderbird" requested_mask="wr" denied_mask="wr" fsuid=1001 ouid=1001 FSUID="user" OUID="user"
apparmor="DENIED" operation="mkdir" class="file" profile="thunderbird" name="/home/user/Thunderbird/"  comm="thunderbird" requested_mask="c" denied_mask="c" fsuid=1001 ouid=1001 FSUID="user" OUID="user"
apparmor="DENIED" operation="file_inherit" class="file" info="Failed name lookup - disconnected path" error=-13 profile="local-read" name="apparmor/.null"  comm="file" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0 FSUID="root" OUID="root"
apparmor="DENIED" operation="open" class="file" info="Failed name lookup - disconnected path" error=-13 profile="local-read" name="apparmor/.null"  comm="file" requested_mask="wr" denied_mask="wr" fsuid=0 ouid=0 FSUID="root" OUID="root"
```
and a message window “Your Thunderbird profile cannot be loaded. It may be missing or inaccessible.”
