### PR TITLE
Add AppArmor profile start-hyprland

### DIFF
--- a/apparmor.d/profiles-s-z/start-hyprland
+++ b/apparmor.d/profiles-s-z/start-hyprland
@@ -12,7 +12,7 @@ profile start-hyprland @{exec_path} {
 
   signal receive set=term peer=sddm,
   signal send    set=term peer=hyprland,
-  
+
   @{bin}/Hyprland rPx,
 
   @{exec_path} mr,


### PR DESCRIPTION
Adds a new AppArmor profile at apparmor.d/profiles-s-z/start-hyprland to provide basic confinement for start-hyprland. The profile is based on abstractions/base-strict, runs in complain mode, and grants execution and necessary read/write access for the Hyprland startup; it also includes an optional local override. Please don't judge my first try — happy to revise based on feedback and suggestions to tighten or correct any rules.