### PR TITLE
discord: allow autostart .desktop creation

### DIFF
--- a/apparmor.d/profiles-a-f/discord
+++ b/apparmor.d/profiles-a-f/discord
@@ -44,6 +44,7 @@ profile discord @{exec_path} flags=(attach_disconnected) {
   owner @{user_pictures_dirs}/{,**} rwl,
 
   owner @{config_dirs}/@{version}/modules/** m,
+  owner @{user_config_dirs}/autostart/discord.desktop rw,
 
   owner "@{tmp}/Discord Crashes/" rw,
   owner @{tmp}/discord.sock rw,


### PR DESCRIPTION
Discord app can enable autostart in "Linux settings"