### PR TITLE
Fix for #1033

### DIFF
--- a/apparmor.d/groups/kde/kioworker
+++ b/apparmor.d/groups/kde/kioworker
@@ -75,7 +75,7 @@ profile kioworker @{exec_path} {
 
   # Silence non user's data
   deny @{efi}/{,**} r,
-  deny /etc/{,**} r,
+  deny /etc/{,**} w,
   deny /opt/{,**} r,
   deny /root/{,**} r,
   deny /tmp/.* rw,


### PR DESCRIPTION
Fixed KIO HTTPS failures in kioworker AppArmor profile by changing the blanket /etc deny from read to write. The profile previously blocked reads under /etc (including /etc/ssl and OpenSSL configs) which caused 0-byte downloads; updating
deny /etc/{,} r,
to
deny /etc/{,} w,
preserves required reads (certs/config) while still preventing writes, restoring remote-content (APOD/Bing POTD) downloads.