### PR TITLE
ssh-keyscan: initial profile

### DIFF
--- a/apparmor.d/groups/ssh/ssh-keyscan
+++ b/apparmor.d/groups/ssh/ssh-keyscan
@@ -1,0 +1,26 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Zane Zakraisek <zz@eng.utah.edu>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/ssh-keyscan
+profile ssh-keyscan @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+
+  owner /{,**} r,
+
+  include if exists <local/ssh-keyscan>
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add an AppArmor profile for ssh-keyscan.

ssh-keyscan has the ability to read a list of IPs, hostnames, and networks from a file. I wasn't sure how restrictive the file location should be. That's what the `owner /{,**} r,`  rule is for. Other than taking input from a file, no other direct filesystem access is needed.

For example:
```
echo 'ssh.example.com' > /tmp/hosts
ssh-keyscan -f /tmp/hosts
```

Let me know if this should be restricted.