### PR TITLE
pipewire: fix profile for 1.6.0

### DIFF
--- a/apparmor.d/groups/freedesktop/pipewire
+++ b/apparmor.d/groups/freedesktop/pipewire
@@ -50,6 +50,7 @@ profile pipewire @{exec_path} flags=(attach_disconnected) {
 
         @{run}/snapd.socket rw,
   owner @{run}/user/@{uid}/pipewire-@{int} rw,
+  owner @{run}/user/@{uid}/pipewire-@{int}-manager rw,
   owner @{run}/user/@{uid}/pipewire-@{int}-manager.lock rwk,
   owner @{run}/user/@{uid}/pipewire-@{int}.lock rwk,
   owner @{run}/user/@{uid}/pulse/pid rw,


### PR DESCRIPTION
`DENIED  pipewire unlink owner @{run}/user/@{uid}/pipewire-0-manager comm=pipewire requested_mask=d denied_mask=d`
it completely fails to start