### PR TITLE
systemsettings: fix portal

### DIFF
--- a/apparmor.d/groups/kde/systemsettings
+++ b/apparmor.d/groups/kde/systemsettings
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/systemsettings
-profile systemsettings @{exec_path} flags=(attach_disconnected) {
+profile systemsettings @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/audio-client>
   include <abstractions/bus-session>


### PR DESCRIPTION
similar situation than #1052
`DENIED  systemsettings link owner @{run}/user/@{uid}/#418 info="Failed name lookup - deleted entry" comm=systemsettings requested_mask=l denied_mask=l error=-2`