### PR TITLE
plasma-login-greeter: add user icon

### DIFF
--- a/apparmor.d/groups/kde/plasma-login-greeter
+++ b/apparmor.d/groups/kde/plasma-login-greeter
@@ -32,6 +32,8 @@ profile plasma-login-greeter @{exec_path} flags=(attach_disconnected,mediate_del
   @{etc_ro}/login.defs.d/{,*} r,
   /etc/fstab r,
 
+  /var/lib/AccountsService/icons/@{user} r,
+
   / r,
 
   owner @{SDDM_HOME}/** rw,


### PR DESCRIPTION
it seems user icon is stored there without an extension