### PR TITLE
remove unconfined fallbacks

### DIFF
--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -85,7 +85,7 @@
   @{bin}/xdg-email          Px,
   @{bin}/xdg-icon-resource  ix,
   @{bin}/xdg-mime          rix,
-  @{bin}/xdg-open           Px -> child-open-any,
+  @{bin}/xdg-open          rPx -> child-open,
   @{bin}/xdg-settings      rix,
 
   # Installing/removing extensions, applications, and stacked xdg menus

--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -63,7 +63,7 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   @{bin}/update-mime-database                        rPx,
   @{lib}/gvfsd-metadata                              rPx,
   @{lib}/mozilla/kmozillahelper                     rPUx,
-  @{open_path}                                       rPx -> child-open-any,
+  @{open_path}                                       rPx -> child-open,
 
   # Common extensions
   @{bin}/browserpass                                           rPx,


### PR DESCRIPTION
Many cases of unconfined execute can be removed.
Especially problematic is the use of child-open-any in browsers, which effectively allows unconfined shells. If I see this correctly that alone means automatic sandbox escape