### PR TITLE
fix(abstraction): Avoid conflicting exec rules.

### DIFF
--- a/apparmor.d/abstractions/tests
+++ b/apparmor.d/abstractions/tests
@@ -40,9 +40,9 @@
   /tmp/shunit.@{rand6}/** rwlk,
 
   /tmp/test*/ rw,
-  /tmp/test*/** rwlkmix,
+  priority=-1 /tmp/test*/** rwlkmix,
   /tmp/*test*/ rw,
-  /tmp/*test*/** rwlkmix,
+  priority=-1 /tmp/*test*/** rwlkmix,
 
   owner /tmp/dbusmock_data_*/{,**} rwlk,
 


### PR DESCRIPTION
Test abstraction allows executing /tmp/*test*/** to support test suites. However, some profiles, like do-release-upgrade also perform explicit Cx transitions.

If the executed file matches the regex, it will fail with profile xxx has merged rule xxx with conflicting x modifiers.

Fixed by adding priority=-1 in the abstraction to allow smooth overrides.