### PR TITLE
Update cups-notifier-dbus and ippfind flags

### DIFF
--- a/apparmor.d/groups/cups/cups-notifier-dbus
+++ b/apparmor.d/groups/cups/cups-notifier-dbus
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{lib}/cups/notifier/dbus
-profile cups-notifier-dbus @{exec_path} {
+profile cups-notifier-dbus @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/bus-session>
   include <abstractions/bus-system>

--- a/apparmor.d/groups/cups/ippfind
+++ b/apparmor.d/groups/cups/ippfind
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/ippfind
-profile ippfind @{exec_path} {
+profile ippfind @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/bus-system>
   include <abstractions/bus/system/org.freedesktop.Avahi.Server>

--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -66,7 +66,7 @@ cups-backend-snmp complain
 cups-backend-socket complain
 cups-backend-usb complain
 cups-browsed complain
-cups-notifier-dbus complain
+cups-notifier-dbus attach_disconnected,complain
 cups-notifier-mailto complain
 cups-notifier-rss complain
 cups-pk-helper-mechanism complain
@@ -155,6 +155,7 @@ hyprpm complain
 ibus-engine-table complain
 ibus-memconf complain
 im-launch complain
+ippfind attach_disconnected
 iwctl complain
 iwd complain
 kaccess complain

--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -66,7 +66,7 @@ cups-backend-snmp complain
 cups-backend-socket complain
 cups-backend-usb complain
 cups-browsed complain
-cups-notifier-dbus attach_disconnected,complain
+cups-notifier-dbus complain
 cups-notifier-mailto complain
 cups-notifier-rss complain
 cups-pk-helper-mechanism complain
@@ -155,7 +155,6 @@ hyprpm complain
 ibus-engine-table complain
 ibus-memconf complain
 im-launch complain
-ippfind attach_disconnected
 iwctl complain
 iwd complain
 kaccess complain


### PR DESCRIPTION
profile cups-notifier-dbus flags=(attach_disconnected) { run/dbus/system_bus_socket r, # Failed name lookup - disconnected path

profile cups-notifier-dbus flags=(attach_disconnected) { run/dbus/system_bus_socket r, # Failed name lookup - disconnected path

/run/dbus/system_bus_socket is already covered by the `bus-system` abstraction.