### PR TITLE
fix(profile): missing ansible abstraction for ssh

### DIFF
--- a/apparmor.d/abstractions/ansible
+++ b/apparmor.d/abstractions/ansible
@@ -5,6 +5,7 @@
   abi <abi/4.0>,
 
   owner @{HOME}/.ansible/tmp/ansible-tmp-*/* rw,
+  owner @{HOME}/.ansible/cp/** rwl,
 
   include if exists <abstractions/ansible.d>
 

--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -9,6 +9,7 @@ include <tunables/global>
 
 @{exec_path} = @{bin}/ssh
 profile ssh @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/ansible>
   include <abstractions/base>
   include <abstractions/consoles>
   include <abstractions/devices-u2f>


### PR DESCRIPTION
A slightly better solution than the one I suggested in #1111 : the abstraction existed but needed: 
- access to `@{HOME}/.ansible/cp`
- to be included in the `ssh` profile

close #1111 