### PR TITLE
fix(profile): gnome-desktop-thumbnailers: fix glycin/bwrap exec transitions

### DIFF
--- a/apparmor.d/groups/gnome/gnome-desktop-thumbnailers
+++ b/apparmor.d/groups/gnome/gnome-desktop-thumbnailers
@@ -21,9 +21,12 @@ profile gnome-desktop-thumbnailers flags=(attach_disconnected) {
   @{bin}/*-thumbnailer                 Cx -> &gnome-desktop-thumbnailers//thumbnailer,
 
   #aa:only apparmor<5.0
-  @{lib}/glycin-loaders/@{d}+/glycin-* Cx -> gnome-desktop-thumbnailers//&glycin//loaders,
+  # glycin-loaders sandboxed profile stack
+  @{bin}/bwrap                         Px -> gnome-desktop-thumbnailers//&glycin,
+  @{lib}/glycin-loaders/@{d}+/glycin-* Px -> gnome-desktop-thumbnailers//&glycin//&glycin//loaders,
 
   #aa:only apparmor>=5.0
+  @{bin}/bwrap                         Px -> :glycin:bwrap,
   @{lib}/glycin-loaders/@{d}+/glycin-* Px -> gnome-desktop-thumbnailers//&:glycin:loaders,
 
   /usr/share/poppler/{,**} r,
@@ -42,6 +45,7 @@ profile gnome-desktop-thumbnailers flags=(attach_disconnected) {
 
   profile thumbnailer flags=(attach_disconnected) {
     include <abstractions/base>
+    include <abstractions/app/bwrap-glycin>
     include <abstractions/fonts>
     include <abstractions/gstreamer>
     include <abstractions/mime>
@@ -51,7 +55,15 @@ profile gnome-desktop-thumbnailers flags=(attach_disconnected) {
     unix type=stream peer=(label=gnome-desktop-thumbnailers),
 
     @{bin}/*-thumbnailer mr,
-    @{lib}/glycin-loaders/@{d}+/glycin-* ix,
+
+    #aa:only apparmor<5.0
+    # glycin-loaders sandboxed profile stack
+    @{bin}/bwrap                         Px -> gnome-desktop-thumbnailers//thumbnailer//&glycin,
+    @{lib}/glycin-loaders/@{d}+/glycin-* Px -> gnome-desktop-thumbnailers//thumbnailer//&glycin//&glycin//loaders,
+
+    #aa:only apparmor>=5.0
+    @{bin}/bwrap                         Px -> :glycin:bwrap,
+    @{lib}/glycin-loaders/@{d}+/glycin-* Px -> gnome-desktop-thumbnailers//thumbnailer//&:glycin:loaders,
 
     /usr/share/poppler/{,**} r,
 


### PR DESCRIPTION
## Summary

The current glycin exec transitions in `gnome-desktop-thumbnailers` do not resolve. The kernel logs (in complain mode):

```
apparmor="ALLOWED" operation="exec" class="file" info="profile transition not found" error=-13 \
  profile="gnome-desktop-thumbnailers" \
  name="/usr/lib/glycin-loaders/2+/glycin-image-rs" \
  requested_mask="x" \
  target="gnome-desktop-thumbnailers//null-/usr/lib/glycin-loaders/2+/glycin-image-rs"
```

The same chain fires from the `//thumbnailer` child when it execs `/usr/bin/bwrap` (the child has `glycin-* ix,` and no bwrap rule at all):

```
target="gnome-desktop-thumbnailers//thumbnailer//null-/usr/bin/bwrap"
```

In complain mode this is just noise on every thumbnail. In enforce mode it would block glycin thumbnailing.

## Fix

Apply the namespace-stacking pattern already used by `firefox` / `thunderbird` (introduced in #918, refined in #966): stack the glycin profile via bwrap first, then re-stack it to enter the loaders subprofile (`&glycin//&glycin//loaders` — note the **double** `&glycin`; the single-`&glycin//loaders` form does not resolve).

The `//thumbnailer` child needs the same treatment (it also execs glycin loaders + bwrap), plus the `bwrap-glycin` abstraction include.

Also add a bwrap transition for the `apparmor>=5.0` namespace path (`Px -> :glycin:bwrap`) so the namespace flow is complete on both sides.

Closes #1115. Related: #881, #918, #966.

## Test plan

- [x] `apparmor_parser -QKT` parses the patched profile cleanly (and so do firefox, thunderbird, foliate, epiphany, xdg-desktop-portal-validate-icon, `:glycin:bwrap`, `:glycin:loaders`).
- [ ] On a system with apparmor 4.x: confirm "profile transition not found" stops appearing in dmesg/journal when generating a thumbnail of an image format handled by glycin (e.g. AVIF, SVG, JXL, HEIF) via nautilus.
- [ ] On a system with apparmor 5.x: confirm the `:glycin:*` namespace path works (bwrap transitions to `:glycin:bwrap`, loaders to `:glycin:loaders`).