### PR TITLE
feat(profile): update gpu-screen-recorder

### DIFF
--- a/apparmor.d/profiles-g-l/gpu-screen-recorder
+++ b/apparmor.d/profiles-g-l/gpu-screen-recorder
@@ -19,7 +19,8 @@ profile gpu-screen-recorder @{exec_path} {
 
   @{exec_path} r,
 
-  @{bin}/gsr-kms-server rPx,
+  @{bin}/gsr-kms-server rPx, #should be removed after version 5.13.9
+  @{bin}/pkexec          cx -> pkexec,
 
   owner @{HOME}/.nv/nvidia-application-profiles-rc.d/ rw,
   owner @{HOME}/.nv/nvidia-application-profiles-rc.d/10-gsr-cuda-no-stable-perf-limit rw,
@@ -40,6 +41,17 @@ profile gpu-screen-recorder @{exec_path} {
   /usr/share/gsr-ui/fonts/{,**} r,
 
   #silencer deny /etc/machine-id r,
+
+  profile pkexec {
+    include <abstractions/base>
+    include <abstractions/app/pkexec>
+
+    ptrace (read) peer=gpu-screen-recorder,
+
+    @{bin}/gsr-kms-server rPx,
+
+    include if exists <local/gpu-screen-recorder_pkexec>
+  }
 
   include if exists <local/gpu-screen-recorder>
 }


### PR DESCRIPTION
Recent update (5.13.9) introduces pkexec to launch gsr-kms-server as root

```
DENIED  gpu-screen-recorder exec @{bin}/pkexec comm=gpu-screen-reco requested_mask=x denied_mask=x
ALLOWED gpu-screen-recorder//pkexec file_inherit /dev/dri/card1 comm=pkexec requested_mask=r denied_mask=r
ALLOWED gpu-screen-recorder//pkexec ptrace comm=pkexec requested_mask=read denied_mask=read peer=gpu-screen-recorder
ALLOWED gpu-screen-recorder//pkexec exec @{bin}/gsr-kms-server -> gpu-screen-recorder//pkexec//null-@{bin}/gsr-kms-server comm=pkexec requested_mask=x denied_mask=x
```
