### PR TITLE
feat(profile): gsr-ui shell subprofile, file_inherit denials

### DIFF
--- a/apparmor.d/profiles-g-l/gpu-screen-recorder
+++ b/apparmor.d/profiles-g-l/gpu-screen-recorder
@@ -45,7 +45,7 @@ profile gpu-screen-recorder @{exec_path} {
 
   /usr/share/gsr-ui/fonts/{,**} r,
 
-  #silencer deny /etc/machine-id r,
+  /etc/machine-id r,
 
   include if exists <local/gpu-screen-recorder>
 }

--- a/apparmor.d/profiles-g-l/gsr-game-tracker
+++ b/apparmor.d/profiles-g-l/gsr-game-tracker
@@ -24,6 +24,8 @@ profile gsr-game-tracker @{exec_path} {
         @{PROC}/@{pid}/cmdline r,
   owner @{PROC}/@{pid}/environ r,
 
+  deny /dev/dri/card@{int} r, # file_inherit
+
   include if exists <local/gsr-game-tracker>
 }
 

--- a/apparmor.d/profiles-g-l/gsr-global-hotkeys
+++ b/apparmor.d/profiles-g-l/gsr-global-hotkeys
@@ -20,6 +20,8 @@ profile gsr-global-hotkeys @{exec_path} {
 
   @{PROC}/bus/input/devices r,
 
+  @{sys}/devices/@{pci}/usb@{int}/**/input/input@{int}/input@{int}::{numlock,capslock,scrolllock}/brightness r,
+
   include if exists <local/gsr-global-hotkeys>
 }
 

--- a/apparmor.d/profiles-g-l/gsr-ui
+++ b/apparmor.d/profiles-g-l/gsr-ui
@@ -21,8 +21,7 @@ profile gsr-ui @{exec_path} {
   signal (send) set=(kill) peer=gsr-kwin-helper,
   signal (send) set=(int) peer=gsr-game-tracker,
 
-  @{sh_path}                 rix,
-  #TODO? @{sh_path}           Px -> gsr-ui-shell,
+  @{sh_path}                  cx -> shell,
   @{bin}/cat                 rix,
   @{bin}/gsr-game-tracker    rPx,
   @{bin}/gsr-global-hotkeys  rPx,
@@ -30,8 +29,6 @@ profile gsr-ui @{exec_path} {
   @{bin}/gsr-notify          rix,
   @{bin}/gpu-screen-recorder rPx,
   @{bin}/systemctl           rPx -> child-systemctl,
-
-  /dev/tty rw,
 
   owner @{user_config_dirs}/gpu-screen-recorder/{,**} rw,
 
@@ -42,6 +39,23 @@ profile gsr-ui @{exec_path} {
   owner @{run}/user/@{uid}/xauth_@{rand6} r,
 
   @{PROC}/ r,
+
+  profile shell flags=(complain) {
+    include <abstractions/base>
+
+    @{sh_path}      r,
+    @{bin}/cat     ix,
+    @{bin}/mkdir   ix,
+    @{bin}/dirname ix,
+
+    /dev/tty rw,
+
+    owner @{user_config_dirs}/autostart/gpu-screen-recorder-ui.desktop rw,
+
+    deny /dev/dri/card@{int} r, # file_inherit
+
+    include if exists <local/gsr-ui_shell>
+  }
 
   include if exists <local/gsr-ui>
 }


### PR DESCRIPTION
I'm still unsure about /etc/machine-id, it doesn't seem to break normal usage yet what I can gather from #24 is that we probably should just allow it and privacy aware users should handle it by their own