### PR TITLE
Add brave-browser-stable to list of disabled profiles

### DIFF
--- a/dists/overwrite
+++ b/dists/overwrite
@@ -4,6 +4,7 @@
 
 # Overwrite unconfined upstream profiles that only allow userns
 brave
+brave-browser-stable
 chrome
 chromium
 cockpit-desktop


### PR DESCRIPTION
Add brave-browser-stable to list of disabled profiles. Needed for Kubuntu 26.04, to avoid ambiguous attachment for brave. Fixes https://github.com/roddhjav/apparmor.d/issues/1132