### PR TITLE
fix(profile): update xdg-permission-store

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-permission-store
+++ b/apparmor.d/groups/freedesktop/xdg-permission-store
@@ -47,7 +47,8 @@ profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
   owner @{user_share_dirs}/flatpak/db/devices rw,
   owner @{user_share_dirs}/flatpak/db/documents rw,
   owner @{user_share_dirs}/flatpak/db/notifications rw,
-  owner @{user_share_dirs}/flatpak/db/screencast r,
+  owner @{user_share_dirs}/flatpak/db/screencast rw,
+  owner @{user_share_dirs}/flatpak/db/screenshot rw,
   owner @{user_share_dirs}/flatpak/db/webextensions rw,
 
   include if exists <local/xdg-permission-store>


### PR DESCRIPTION
`DENIED  xdg-permission-store mknod owner @{user_share_dirs}/flatpak/db/screenshot comm=pool-1 requested_mask=c denied_mask=c`

Triggered by allowing flameshot to take captures, I had the write rule for screencast in my local since long time, I don't remember which app triggered it but why should it be read-only ?