### PR TITLE
fix(profile): xdg-mime allow reading the MIME database via abstractions/mime

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-mime
+++ b/apparmor.d/groups/freedesktop/xdg-mime
@@ -11,6 +11,7 @@ include <tunables/global>
 profile xdg-mime @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/common/xdg>
+  include <abstractions/mime>
 
   @{exec_path} r,
 


### PR DESCRIPTION
Include `abstractions/mime`, which grants read access to both the system (`@{system_share_dirs}/mime/{,**}`) and per-user (`@{user_share_dirs}/mime/{,**}`) MIME databases plus the `mimeapps.list` variants. This is the same abstraction already used by other MIME-consuming profiles (`evince-thumbnailer`, `fwupd`, `syncthing`, `appstreamcli`).

Verified on Arch/CachyOS with `apparmor.d.enforced`: after adding the include, `xdg-mime query default text/plain` returns the correct handler with no denials.
