### PR TITLE
fix(profile): kioworker allow the gs child fonts and paperspecs

### DIFF
--- a/apparmor.d/groups/kde/kioworker
+++ b/apparmor.d/groups/kde/kioworker
@@ -127,12 +127,15 @@ profile kioworker @{exec_path} {
 
   profile gs {
     include <abstractions/base>
+    include <abstractions/fonts>
 
     @{bin}/gs{,.bin} mr,
     @{lib}/ghostscript/**  mr,
 
     /usr/share/ghostscript/{,**} r,
     /usr/share/org.kde.syntax-highlighting/{,**} r,
+
+    /etc/paperspecs r,
 
     #aa:lint ignore=too-wide
     @{MOUNTS}/** r,


### PR DESCRIPTION
The `gs` child profile inside `groups/kde/kioworker` (ghostscript, used to render
PostScript/PDF thumbnails) only pulls in `abstractions/base`. Child profiles do
not inherit the parent's includes, so it lacks the fonts, dconf and paper-size
access the parent profile gets via `abstractions/kde-strict`.

Under enforce mode this produces denials when kioworker spawns `gs` to render a
PS/PDF thumbnail:

- reading fonts under `/usr/share/fonts/**` (needed to rasterize text) —
  `abstractions/fonts`
- dconf lookups — `abstractions/dconf`
- reading `/etc/paperspecs` (ghostscript paper-size definitions)

## Fix

Add to the `profile gs { ... }` child:

```
    include <abstractions/fonts>
    include <abstractions/dconf>

    /etc/paperspecs r,
```

## Testing

Verified on Arch/CachyOS with `apparmor.d.enforced`: after switching kioworker to
enforce, PS/PDF thumbnail rendering triggered the denials above; adding the three
includes/rule resolves them with no further gs denials.
