### PR TITLE
fix(profile): firefox allow launching the GNOME browser connector host

### DIFF
--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -56,6 +56,7 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   @{lib}/mozilla/plugins/*.so mr,
 
   # Desktop integration
+  @{bin}/gnome-browser-connector-host                rPx,
   @{bin}/gnome-software                              rPx,
   @{bin}/kreadconfig{,5}                             rPx,
   @{bin}/plasma-browser-integration-host             rPx,


### PR DESCRIPTION
## What

The `gs` child profile inside `groups/kde/kioworker` (ghostscript, used to render
PostScript/PDF thumbnails) only pulls in `abstractions/base`. Child profiles do
not inherit the parent's includes, so it lacks the fonts, dconf and paper-size
access the parent profile gets via `abstractions/kde-strict`.

Under enforce mode this produces denials when kioworker spawns `gs` to render a
PS/PDF thumbnail:

- reading fonts under `/usr/share/fonts/**` (needed to rasterize text) —
  `abstractions/fonts`
- dconf lookups — `abstractions/dconf`
- reading `/etc/paperspecs` (ghostscript paper-size definitions)

## Fix

Add to the `profile gs { ... }` child:

```
    include <abstractions/fonts>
    include <abstractions/dconf>

    /etc/paperspecs r,
```

## Testing

Verified on Arch/CachyOS with `apparmor.d.enforced`: after switching kioworker to
enforce, PS/PDF thumbnail rendering triggered the denials above; adding the three
includes/rule resolves them with no further gs denials.
