### PR TITLE
fix(profile): gnome-extension-gsconnect attach the browser nativeMessagingHost entrypoint

### DIFF
--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -100,6 +100,8 @@
   # Gnome shell integration
   @{bin}/chrome-gnome-shell            Px,
   @{bin}/gnome-browser-connector-host  Px,
+  @{user_share_dirs}/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/nativeMessagingHost.js  Px -> gnome-extension-gsconnect-native,
+  /usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/nativeMessagingHost.js           Px -> gnome-extension-gsconnect-native,
 
   # Plasma integration
   @{bin}/plasma-browser-integration-host Px,

--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -57,6 +57,8 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
 
   # Desktop integration
   @{bin}/gnome-browser-connector-host                rPx,
+        @{user_share_dirs}/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/nativeMessagingHost.js  rPx -> gnome-extension-gsconnect-native,
+        /usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/nativeMessagingHost.js           rPx -> gnome-extension-gsconnect-native,
   @{bin}/gnome-software                              rPx,
   @{bin}/kreadconfig{,5}                             rPx,
   @{bin}/plasma-browser-integration-host             rPx,

--- a/apparmor.d/groups/gnome/gnome-extension-gsconnect-native
+++ b/apparmor.d/groups/gnome/gnome-extension-gsconnect-native
@@ -1,0 +1,43 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{share_dirs}  = /usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io
+@{share_dirs} += @{user_share_dirs}/gnome-shell/extensions/gsconnect@andyholmes.github.io
+
+@{exec_path} = @{share_dirs}/service/nativeMessagingHost.js
+profile gnome-extension-gsconnect-native @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  # Bridge the browser's stdio native-messaging pipe to the running GSConnect
+  # daemon over the session bus.
+  #aa:dbus talk bus=session name=org.gnome.Shell.Extensions.GSConnect label=gnome-extension-gsconnect
+
+  @{exec_path} r,
+
+  @{sh_path}          rix,
+  @{bin}/env          rix,
+  @{bin}/gjs-console  rix,
+
+  @{lib}/gio/modules/*.so* rm,
+  @{lib}/girepository-1.0/* r,
+
+  @{share_dirs}/{,**} r,
+
+  owner @{user_config_dirs}/gsconnect/{,**} r,
+
+  owner @{run}/user/@{uid}/gsconnect/{,**} rw,
+
+  owner @{PROC}/@{pid}/cgroup r,
+  owner @{PROC}/@{pid}/stat r,
+  owner @{PROC}/@{pid}/statm r,
+
+  include if exists <local/gnome-extension-gsconnect-native>
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
The `gnome-extension-gsconnect` profile's `@{exec_path}` only lists `service/daemon.js` and `gsconnect-preferences`. It does not include `service/nativeMessagingHost.js`, the entrypoint a browser launches to speak the GSConnect native-messaging protocol.

Because that path isn't in the attach path, when a browser (via a `Px` transition) launches the native-messaging host, it doesn't attach to this profile — under enforce mode it falls to a null/denied child profile, breaking the browser <-> GSConnect integration.

This adds `@{share_dirs}/service/nativeMessagingHost.js` to `@{exec_path}` (same variable/style as the existing entries) so the browser `Px` transition lands on this profile correctly.

Verified on apparmor.d.enforced.
