### PR TITLE
fix(profile): gnome-browser-connector-host allow gi typelibs, gio modules and user gschemas

### DIFF
--- a/apparmor.d/groups/gnome/gnome-browser-connector-host
+++ b/apparmor.d/groups/gnome/gnome-browser-connector-host
@@ -20,6 +20,12 @@ profile gnome-browser-connector-host @{exec_path} {
 
   @{lib}/@{python_name}/site-packages/gnome_browser_connector/__pycache__/{,**} rw,
 
+  @{lib}/girepository-1.0/{,*}                                 r,
+  @{lib}/gio/modules/{,*.so*}                                  rm,
+  @{lib}/gio/modules/giomodule.cache                           r,
+  owner @{user_share_dirs}/glib-2.0/schemas/gschemas.compiled  r,
+  owner @{HOME}/                                               r,
+
   owner @{PROC}/@{pid}/mounts r,
 
   include if exists <local/gnome-browser-connector-host>


### PR DESCRIPTION
Under enforce mode, `gnome-browser-connector-host` (a PyGObject / Python script) is
denied several reads it needs at runtime:

- **girepository typelibs** (`@{lib}/girepository-1.0/`) — required by any `import gi`
  / PyGObject code.
- **gio modules** (`@{lib}/gio/modules/`, `giomodule.cache`) — loaded by GLib/GIO at
  startup.
- **the per-user compiled gschemas** (`@{user_share_dirs}/glib-2.0/schemas/gschemas.compiled`)
  — `abstractions/gschemas` only grants the **system** `gschemas.compiled`, not the
  per-user one, so the connector host is denied when a user schema override exists.
- **`@{HOME}/`** directory read.

This adds the missing reads.

Note: the per-user `gschemas.compiled` line is arguably better placed in
`abstractions/gschemas` itself, which would fix the whole class of GLib/GIO apps
project-wide rather than just this profile. Happy to move it there instead if you
prefer — flagging it as an alternative.

Verified on apparmor.d.enforced.
