### PR TITLE
fix(profile): chromium allow the 1Password native messaging host

### DIFF
--- a/apparmor.d/abstractions/app/chromium
+++ b/apparmor.d/abstractions/app/chromium
@@ -95,6 +95,7 @@
   # For storing passwords externally
   @{bin}/keepassxc-proxy    rix, # as a temporary solution - see issue #128
   @{bin}/browserpass        Px,
+  /opt/1Password/1Password-BrowserSupport  rPUx,
 
   # Gnome shell integration
   @{bin}/chrome-gnome-shell            Px,


### PR DESCRIPTION
Under enforce mode, Chromium/Chrome browsers cannot launch the 1Password
browser-integration native-messaging host (`/opt/1Password/1Password-BrowserSupport`),
so the 1Password browser extension fails to connect to the desktop app.

The `firefox` profile already permits this host:

```
/opt/1Password/1Password-BrowserSupport   rPUx,
```

but the shared `abstractions/app/chromium` (included by chrome, chromium, etc.)
had no equivalent rule. This adds it, mirroring firefox's exact rule
(`rPUx`), next to the other external-password-manager hosts (browserpass,
keepassxc-proxy).

Note: the GNOME browser connector host is already handled in this abstraction
(`@{bin}/gnome-browser-connector-host  Px`), so only the 1Password host needed
adding.

Verified on apparmor.d.enforced.
