### PR TITLE
fix(profile): gsd-xsettings allow querying the fcitx5 input method

### DIFF
--- a/apparmor.d/groups/gnome/gsd-xsettings
+++ b/apparmor.d/groups/gnome/gsd-xsettings
@@ -59,6 +59,7 @@ profile gsd-xsettings @{exec_path} flags=(attach_disconnected) {
   @{bin}/xprop          rPx,
   @{bin}/xrdb           rPx,
   @{lib}/{,ibus/}ibus-x11 rPx,
+  @{bin}/fcitx5-remote  rPUx,
 
   /etc/X11/Xsession.options r,
   @{etc_ro}/xdg/Xwayland-session.d/ r,


### PR DESCRIPTION
`gsd-xsettings` queries the active input method at session startup. It already handles IBus via `@{lib}/{,ibus/}ibus-x11 rPx`, but has no rule for fcitx5, a mainstream IBus alternative. Under enforce mode, `gsd-xsettings` invoking `fcitx5-remote` is denied.

This adds a rule mirroring the existing ibus-x11 handling:

```
  @{bin}/fcitx5-remote  rPUx,
```

Since there is no dedicated fcitx5 profile in the tree, `rPUx` is used so the binary transitions to a profile if one ever exists and otherwise runs unconfined, matching the intent of the ibus-x11 line without introducing a dangling profile reference.

Note this is niche — it only affects fcitx5 users. Verified on apparmor.d.enforced.
