### PR TITLE
fix(nautilus): allow reading /etc/os-release and /proc/diskstats

### DIFF
--- a/apparmor.d/groups/gnome/nautilus
+++ b/apparmor.d/groups/gnome/nautilus
@@ -91,7 +91,8 @@ profile nautilus @{exec_path} flags=(attach_disconnected) {
   /usr/share/thumbnailers/{,**} r,
   /usr/share/tracker*/{,**} r,
 
-  /etc/fstab r,
+  /etc/fstab      r,
+  /etc/os-release r,
 
   /var/cache/fontconfig/ rw,
 
@@ -122,6 +123,7 @@ profile nautilus @{exec_path} flags=(attach_disconnected) {
 
   @{run}/mount/utab r,
 
+        @{PROC}/diskstats r,
         @{PROC}/@{pids}/net/wireless r,
         @{PROC}/sys/dev/i915/perf_stream_paranoid r,
   owner @{PROC}/@{pid}/cgroup r,


### PR DESCRIPTION
Under enforce mode the `nautilus` profile denies two read-only accesses it makes in normal use:

```
apparmor="DENIED" operation="open" profile="nautilus" name="/etc/os-release" requested_mask="r"
apparmor="DENIED" operation="open" profile="nautilus" name="/proc/diskstats" requested_mask="r"
```

- `/etc/os-release` — distro name/logo shown in the file-manager About and volume Properties UI.
- `/proc/diskstats` — disk activity for the mounted-volume / Trash views.

This adds both as read-only rules next to the existing `/etc/fstab` and `@{PROC}` entries. `@{PROC}/diskstats r,` matches the idiom already used by the `htop`, `vmstat`, `sysstat-sadc` and `cockpit` profiles.

Tested on `apparmor.d.enforced` (Arch): both denials disappear, no regressions.