### PR TITLE
fix(gschemas): allow reading per-user compiled GSettings schemas

### DIFF
--- a/apparmor.d/abstractions/gschemas
+++ b/apparmor.d/abstractions/gschemas
@@ -9,6 +9,9 @@
   @{system_share_dirs}/glib-2.0/schemas/ r,
   @{system_share_dirs}/glib-2.0/schemas/gschemas.compiled r,
 
+  owner @{user_share_dirs}/glib-2.0/schemas/ r,
+  owner @{user_share_dirs}/glib-2.0/schemas/gschemas.compiled r,
+
   include if exists <abstractions/gschemas.d>
 
 # vim:syntax=apparmor


### PR DESCRIPTION
Applications and users can install GSettings schemas into `~/.local/share/glib-2.0/schemas` and compile them with `glib-compile-schemas`; GLib then reads that `gschemas.compiled` alongside the system one. `abstractions/gschemas` only granted the system path, so under enforce:

```
apparmor="DENIED" operation="open" profile="gnome-calculator-search-provider" name="~/.local/share/glib-2.0/schemas/gschemas.compiled" requested_mask="r"
```

Also seen from `gjs`, `gnome-control-center-global-shortcuts-provider`, `firefox`, and others — several profiles already carry this as a per-profile grant, which this makes redundant.

Adds the per-user schemas dir + compiled file read-only (owner-scoped). Tested on apparmor.d.enforced.