### PR TITLE
fix(borg): allow reading @{PROC}/@{pid}/mounts

### DIFF
--- a/apparmor.d/profiles-a-f/borg
+++ b/apparmor.d/profiles-a-f/borg
@@ -85,6 +85,7 @@ profile borg @{exec_path} flags=(attach_disconnected) {
 
         @{PROC}/sys/fs/pipe-max-size r,
   owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/mounts r,
   owner @{PROC}/@{pid}/stat r,
 
   /dev/fuse rw,


### PR DESCRIPTION
BorgBackup reads its own `/proc/<pid>/mounts` to enumerate mount points (e.g. for `--one-file-system` boundaries and to skip pseudo-filesystems). Under enforce:

```
apparmor="DENIED" operation="open" profile="borg" name="/proc/1234/mounts" requested_mask="r"
```

Adds it owner-scoped next to the existing `@{PROC}/@{pid}` reads. Tested on apparmor.d.enforced.