### PR TITLE
fix(gtk-strict, ibus-strict): allow reading X Compose files

### DIFF
--- a/apparmor.d/abstractions/gtk-strict
+++ b/apparmor.d/abstractions/gtk-strict
@@ -89,6 +89,9 @@
   owner @{user_config_dirs}/gtk-3.0/settings.ini r,
   owner @{user_config_dirs}/gtk-3.0/window_decorations.css r,
 
+  owner @{HOME}/.XCompose r,
+  owner @{user_cache_dirs}/gtk-3.0/compose/{,**} rw,
+
   owner @{user_config_dirs}/gtk-4.0/ rw,
   owner @{user_config_dirs}/gtk-4.0/bookmarks r,
   owner @{user_config_dirs}/gtk-4.0/colors.css r,

--- a/apparmor.d/abstractions/ibus-strict
+++ b/apparmor.d/abstractions/ibus-strict
@@ -13,6 +13,9 @@
   owner @{user_config_dirs}/ibus/bus/@{hex32}-unix-@{int} rw,
   owner @{user_config_dirs}/ibus/bus/@{hex32}-unix-wayland-@{int} rw,
 
+  owner @{HOME}/.XCompose r,
+  owner @{user_cache_dirs}/ibus/compose/{,**} rw,
+
   include if exists <abstractions/ibus-strict.d>
 
 # vim:syntax=apparmor


### PR DESCRIPTION
GTK and ibus read the user Compose file `~/.XCompose` and maintain a compiled Compose cache under their cache dirs (`~/.cache/gtk-3.0/compose/`, `~/.cache/ibus/compose/`). Both are denied under the strict abstractions:

```
apparmor="DENIED" profile="ibus-engine-simple" name="/home/user/.XCompose" ...
apparmor="DENIED" profile="firefox" name="/home/user/.cache/gtk-3.0/compose/..." ...
```

Allow reading `~/.XCompose` and read/write of the compose caches.