### PR TITLE
fix(geoclue): allow reading /etc/os-release

### DIFF
--- a/apparmor.d/groups/freedesktop/geoclue
+++ b/apparmor.d/groups/freedesktop/geoclue
@@ -34,6 +34,7 @@ profile geoclue @{exec_path} flags=(attach_disconnected) {
   @{exec_path} mr,
 
   /etc/geoclue/{,**} r,
+  /etc/os-release r,
   /etc/sysconfig/proxy r,
 
   /var/lib/nscd/services r,


### PR DESCRIPTION
geoclue reads `/etc/os-release` to compose its User-Agent for the online location provider. The read is denied:

```
apparmor="DENIED" operation="open" profile="geoclue" name="/etc/os-release" ...
```

https://claude.ai/code/session_01DohXyQUuSV3iMBjybBg5m8