### PR TITLE
fix(tailscaled): allow os-release, TPM devices and per-pid proc reads

### DIFF
--- a/apparmor.d/groups/network/tailscaled
+++ b/apparmor.d/groups/network/tailscaled
@@ -57,13 +57,17 @@ profile tailscaled @{exec_path} flags=(attach_disconnected) {
 
   owner @{run}/tailscale/{,**} rw,
 
+  /etc/os-release r,
+
   @{PROC}/ r,
   @{PROC}/@{pid}/mounts r,
+  @{PROC}/@{pid}/mountinfo r,
   @{PROC}/@{pid}/net/{,**} r,
   @{PROC}/@{pids}/cmdline r,
   @{PROC}/@{pids}/fd/ r,
   @{PROC}/@{pids}/net/route r,
   @{PROC}/1/cgroup r,
+  @{PROC}/@{pids}/cgroup r,
   @{PROC}/1/environ r,
   @{PROC}/1/stat r,
   @{PROC}/cmdline r,
@@ -71,6 +75,8 @@ profile tailscaled @{exec_path} flags=(attach_disconnected) {
   @{PROC}/sys/net/{,**} r,
 
   /dev/net/tun rw,
+  /dev/tpm0 rw,
+  /dev/tpmrm0 rw,
 
   profile systemctl {
     include <abstractions/base>


### PR DESCRIPTION
tailscaled emits several denials in normal operation:

```
apparmor="DENIED" profile="tailscaled" name="/etc/os-release"
apparmor="DENIED" profile="tailscaled" name="/dev/tpm0"
apparmor="DENIED" profile="tailscaled" name="/dev/tpmrm0"
apparmor="DENIED" profile="tailscaled" name="/proc/<pid>/mountinfo"
apparmor="DENIED" profile="tailscaled" name="/proc/<pid>/cgroup"
```

- `/etc/os-release` — host/OS info in the node's hostinfo.
- `/dev/tpm0`, `/dev/tpmrm0` — TPM-sealed state key storage.
- `/proc/<pid>/cgroup`, `/proc/<pid>/mountinfo` — broadened from the pid-1-only / own-pid rules already present, as tailscaled inspects other processes.

https://claude.ai/code/session_01DohXyQUuSV3iMBjybBg5m8