### PR TITLE
fix(systemd-backlight): allow reading device uevent files

### DIFF
--- a/apparmor.d/groups/systemd/systemd-backlight
+++ b/apparmor.d/groups/systemd/systemd-backlight
@@ -28,6 +28,7 @@ profile systemd-backlight @{exec_path} flags=(attach_disconnected) {
 
   @{sys}/devices/@{pci}/ r,
   @{sys}/devices/@{pci}/class r,
+  @{sys}/devices/@{pci}/{,**/}uevent r,
 
   include if exists <local/systemd-backlight>
 }


### PR DESCRIPTION
systemd-backlight scans the PCI device tree to find backlight devices and reads each node's `uevent`:

```
apparmor="DENIED" operation="open" profile="systemd-backlight" name="/sys/devices/pci0000:00/.../uevent" ...
```

Allow reading `uevent` under the already-permitted `@{sys}/devices/@{pci}/` tree.