### PR TITLE
feat(gnome): allow evolution-alarm-notify to read its cgroup

### DIFF
--- a/apparmor.d/groups/gnome/evolution-alarm-notify
+++ b/apparmor.d/groups/gnome/evolution-alarm-notify
@@ -32,6 +32,8 @@ profile evolution-alarm-notify @{exec_path} flags=(attach_disconnected)  {
 
   owner @{user_share_dirs}/evolution/datetime-formats.ini r,
 
+  @{PROC}/@{pid}/cgroup r,
+
   include if exists <local/evolution-alarm-notify>
 }
 


### PR DESCRIPTION
evolution-alarm-notify opens `@{PROC}/@{pid}/cgroup` at startup but the profile grants no `/proc` access, so under enforce it is denied on every launch:

```
apparmor="DENIED" operation="open" profile="evolution-alarm-notify" name="/proc/<pid>/cgroup" requested_mask="r"
```

Observed on CachyOS (evolution-data-server, `apparmor.d.enforced` 0.4908.0-2) — ~240 denials per session. Add the read next to the other startup reads.

https://claude.ai/code/session_01DohXyQUuSV3iMBjybBg5m8