### PR TITLE
Fix calibre

### DIFF
--- a/apparmor.d/profiles-a-f/calibre
+++ b/apparmor.d/profiles-a-f/calibre
@@ -10,6 +10,7 @@ include <tunables/global>
 @{exec_path}  = @{bin}/calibre{,-*} @{bin}/calibredb @{bin}/ebook{,-*}
 @{exec_path} += @{bin}/fetch-ebook-metadata
 @{exec_path} += @{bin}/lrs2lrf @{bin}/lrf2lrs @{bin}/lrfviewer @{bin}/web2disk
+@{exec_path} += /opt/calibre{,-*}{,/bin}/calibre{,-*}
 profile calibre @{exec_path} {
   include <abstractions/base>
   include <abstractions/bus/session/org.kde.StatusNotifierWatcher>
@@ -58,6 +59,8 @@ profile calibre @{exec_path} {
   @{bin}/pdftohtml       rPUx,
 
   @{open_path}            rPx -> child-open,
+
+  /opt/calibre/{,**} rm,
 
   /usr/share/calibre/{,**} r,
 

--- a/apparmor.d/profiles-a-f/calibre
+++ b/apparmor.d/profiles-a-f/calibre
@@ -90,7 +90,7 @@ profile calibre @{exec_path} {
   owner @{user_cache_dirs}/calibre/ rw,
   owner @{user_cache_dirs}/calibre/** rwkl -> @{user_cache_dirs}/calibre/**,
 
-  owner @{tmp}/@{w}@{w}@{w}@{w}@{w}@{w}@{w}@{w} rwl,
+  owner @{tmp}/@{word8} wl,
   audit owner @{tmp}/@{int}-*/ rw,
   audit owner @{tmp}/@{int}-*/** rwl,
   owner @{tmp}/calibre-@{word8}/{,**} rw,

--- a/apparmor.d/profiles-a-f/calibre
+++ b/apparmor.d/profiles-a-f/calibre
@@ -90,7 +90,7 @@ profile calibre @{exec_path} {
   owner @{user_cache_dirs}/calibre/ rw,
   owner @{user_cache_dirs}/calibre/** rwkl -> @{user_cache_dirs}/calibre/**,
 
-  owner @{tmp}/@{rand8} rw,
+  owner @{tmp}/@{w}@{w}@{w}@{w}@{w}@{w}@{w}@{w} rwl,
   audit owner @{tmp}/@{int}-*/ rw,
   audit owner @{tmp}/@{int}-*/** rwl,
   owner @{tmp}/calibre-@{word8}/{,**} rw,


### PR DESCRIPTION
Official release for Linux ([here](https://calibre-ebook.com/download_linux)) is installed in /opt as default. Additionally, at least from version 9.6 onwards temp files names include word characters instead of just alphanumeric