### PR TITLE
fix(kde) Access to KDE's user language override

### DIFF
--- a/apparmor.d/abstractions/kde-base
+++ b/apparmor.d/abstractions/kde-base
@@ -31,6 +31,7 @@
   owner @{user_config_dirs}/kdedefaults/kdeglobals r,
   owner @{user_config_dirs}/kdedefaults/kwinrc r,
   owner @{user_config_dirs}/kdeglobals r,
+  owner @{user_config_dirs}/klanguageoverridesrc r,
   owner @{user_config_dirs}/kwinrc r,
   owner @{user_config_dirs}/session/ rw,
   owner @{user_config_dirs}/session/* rwlk,


### PR DESCRIPTION
```
apparmor="ALLOWED" operation="open" class="file" profile="plasmashell" name="/home/lakis/.config/klanguageoverridesrc"  comm="plasmashell" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="kwin_wayland" name="/home/lakis/.config/klanguageoverridesrc"  comm="kwin_wayland" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="kcminit" name="/home/lakis/.config/klanguageoverridesrc"  comm="kcminit_startup" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="kcminit" name="/home/lakis/.config/klanguageoverridesrc"  comm="kcminit" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="ksmserver" name="/home/lakis/.config/klanguageoverridesrc"  comm="ksmserver" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="kde-powerdevil" name="/home/lakis/.config/klanguageoverridesrc"  comm="org_kde_powerde" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
apparmor="ALLOWED" operation="open" class="file" profile="kactivitymanagerd" name="/home/lakis/.config/klanguageoverridesrc"  comm="kactivitymanage" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
```