### PR TITLE
fix(plasma-login-manager) Adding of missing permissions on Plasma 6.7

### DIFF
--- a/apparmor.d/groups/kde/kcminit
+++ b/apparmor.d/groups/kde/kcminit
@@ -25,6 +25,7 @@ profile kcminit @{exec_path} {
   @{bin}/xsetroot  rPx,
 
   /etc/xdg/kcmdisplayrc r,
+  /etc/X11/xorg.conf r,
 
   owner @{HOME}/.Xdefaults r,
 

--- a/apparmor.d/groups/kde/ksplashqml
+++ b/apparmor.d/groups/kde/ksplashqml
@@ -39,6 +39,8 @@ profile ksplashqml @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_config_dirs}/ksplashrc r,
   owner @{user_config_dirs}/plasmarc r,
 
+  owner @{user_share_dirs}/plasma/look-and-feel/*/metadata.json r,
+
   include if exists <local/ksplashqml>
 }
 

--- a/apparmor.d/groups/kde/plasma-login-greeter
+++ b/apparmor.d/groups/kde/plasma-login-greeter
@@ -25,12 +25,15 @@ profile plasma-login-greeter @{exec_path} flags=(attach_disconnected,mediate_del
 
   @{exec_path} mr,
 
+  @{lib}/ r,
+
   /usr/share/plasma/{,**} r,
   /usr/share/wayland-sessions/{,*.desktop} r,
 
   @{etc_ro}/login.defs r,
   @{etc_ro}/login.defs.d/{,*} r,
   /etc/fstab r,
+  /etc/plasmalogin.conf r,
 
   /var/lib/AccountsService/icons/@{user} r,
 
@@ -44,6 +47,9 @@ profile plasma-login-greeter @{exec_path} flags=(attach_disconnected,mediate_del
   @{sys}/devices/**/uevent r,
 
   owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/task/@{tid}/comm w,
+
+  /dev/tty r,
 
   include if exists <local/plasma-login-greeter>
 }

--- a/apparmor.d/groups/kde/plasma-login-wallpaper
+++ b/apparmor.d/groups/kde/plasma-login-wallpaper
@@ -14,15 +14,25 @@ profile plasma-login-wallpaper @{exec_path} {
 
   @{exec_path} mr,
 
+  @{bin}/ r,
+
   /usr/share/plasma/{,**} r,
   /usr/share/wallpapers/{,**} r,
 
   @{etc_ro}/login.defs r,
+  /etc/plasmalogin.conf r,
 
   owner @{sddm_cache_dirs}/plasma-login-wallpaper/ rw,
   owner @{sddm_cache_dirs}/plasma-login-wallpaper/** rwkl,
+  owner @{sddm_cache_dirs}/nvidia/ rw,
+  owner @{sddm_cache_dirs}/nvidia/GLCache/ rw,
+  owner @{sddm_cache_dirs}/nvidia/GLCache/** rwk,
   owner @{sddm_config_dirs}/kdedefaults/* r,
   owner @{sddm_config_dirs}/kdeglobals r,
+  owner @{sddm_config_dirs}/kcminputrc r,
+  owner @{sddm_config_dirs}/plasmarc r,
+
+  owner @{PROC}/@{pid}/task/@{tid}/comm w,
 
   include if exists <local/plasma-login-wallpaper>
 }

--- a/apparmor.d/groups/kde/plasmalogin
+++ b/apparmor.d/groups/kde/plasmalogin
@@ -25,6 +25,8 @@ profile plasmalogin @{exec_path} flags=(attach_disconnected) {
 
   /usr/share/wayland-sessions/plasma.desktop r,
 
+  /etc/plasmalogin.conf r,
+
   /tmp/.@{rand6}/ rw,
   /tmp/.@{rand6}/** rw,
   /tmp/plasmalogin--@{rand6} rw,

--- a/apparmor.d/groups/kde/plasmalogin-helper
+++ b/apparmor.d/groups/kde/plasmalogin-helper
@@ -36,16 +36,27 @@ profile plasmalogin-helper @{exec_path} flags=(attach_disconnected) {
 
   @{bin}/startplasma-login-wayland Px,
   @{shells_path}                   Px -> plasmalogin-shell,
+  @{bin}/startplasma-wayland       Px -> startplasma,
   @{bin}/ksecretd                 PUx,
 
   @{bin}/cat           rix,
   @{bin}/find          rix,
+  @{bin}/mktemp        rix,
+  @{bin}/rm            rix,
   @{bin}/tr            rix,
   @{bin}/tty           rix,
+  @{bin}/vapoursynth   rix,
   @{bin}/xargs         rix,
 
   @{bin}/pidof          Px,
   @{bin}/flatpak        Cx -> flatpak,
+
+  @{lib}/plasma-dbus-run-session-if-needed rix,
+  @{lib}/@{multiarch}/libexec/plasma-dbus-run-session-if-needed  rix,
+
+  @{bin}/ r,
+
+  owner @{HOME}/ r,
 
   /usr/share/plasmalogin/scripts/wayland-session rix,
   /usr/share/plasmalogin/scripts/Xsession rix,
@@ -55,6 +66,7 @@ profile plasmalogin-helper @{exec_path} flags=(attach_disconnected) {
   @{etc_ro}/profile.d/{,*} r,
   /etc/debuginfod/{,*} r,
   /etc/machine-id r,
+  /etc/plasmalogin.conf r,
   /etc/profile r,
   /etc/shells r,
 
@@ -68,6 +80,7 @@ profile plasmalogin-helper @{exec_path} flags=(attach_disconnected) {
   owner @{user_share_dirs}/plasmalogin/wayland-session.log w,
 
   /tmp/plasmalogin-auth-@{uuid} rw,
+  owner @{tmp}/xsess-env-@{rand6} rw,
 
         @{run}/faillock/@{user} rwk,
         @{run}/systemd/io.systemd.Login rw,
@@ -76,6 +89,7 @@ profile plasmalogin-helper @{exec_path} flags=(attach_disconnected) {
         @{PROC}/@{pid}/loginuid w,
         @{PROC}/@{pid}/uid_map r,
   owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/mounts r,
 
   /dev/tty@{u8} rw,
   /dev/tty rw,
@@ -84,6 +98,10 @@ profile plasmalogin-helper @{exec_path} flags=(attach_disconnected) {
     include <abstractions/base>
 
     @{bin}/flatpak mr,
+
+    /dev/tty@{u8} rw,
+
+    owner @{user_share_dirs}/plasmalogin/wayland-session.log w,
 
     include if exists <local/plasmalogin-helper_flatpak>
   }

--- a/apparmor.d/groups/kde/plasmalogin-shell
+++ b/apparmor.d/groups/kde/plasmalogin-shell
@@ -10,9 +10,10 @@ include <tunables/global>
 profile plasmalogin-shell @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>
+  include <abstractions/nameservice-strict>
   include <abstractions/shells>
 
-  @{shells_path} mr,
+  @{shells_path} mrix,
 
   @{bin}/cat           rix,
   @{bin}/find          rix,
@@ -34,6 +35,8 @@ profile plasmalogin-shell @{exec_path} {
   /etc/debuginfod/{,*} r,
 
   owner @{user_share_dirs}/plasmalogin/wayland-session.log w,
+
+  owner /tmp/xsess-env-@{rand6} w,
 
   owner @{PROC}/@{pid}/fd/ r,
 

--- a/apparmor.d/groups/kde/startplasma-login-wayland
+++ b/apparmor.d/groups/kde/startplasma-login-wayland
@@ -26,10 +26,9 @@ profile startplasma-login-wayland @{exec_path} {
 
   owner @{sddm_cache_dirs}/#@{int} rw,
   owner @{sddm_cache_dirs}/ksycoca{5,6}_* rwkl -> @{sddm_cache_dirs}/#@{int},
-  owner @{sddm_config_dirs}/kdedefaults/kdeglobals r,
-  owner @{sddm_config_dirs}/kdedefaults/package r,
-  owner @{sddm_config_dirs}/kdeglobals r,
-  owner @{sddm_config_dirs}/plasma-localerc r,
+  owner @{sddm_config_dirs}/kdedefaults/* r,
+  owner @{sddm_config_dirs}/kdedefaults/package w,
+  owner @{sddm_config_dirs}/* r,
 
   @{PROC}/sys/kernel/random/boot_id r,
 


### PR DESCRIPTION
Fixes locking PLM on Plasma 6.7 from running.
Includes changes related to proprietary Nvidia drivers. This cache is used by other Plasma components, but so far I was adding the same entries separately each time.

The only issue I have is with vapoursynth - it does not seem to me to be connected to plasmalogin-helper and I haven't seen any problem if denied, but i left it in the profile as is requested.

Logs are in a file, as the first check generated over 2k lines for all 8 profiles.
[Logs.txt](https://github.com/user-attachments/files/29886347/fix-plm.txt)
