### PR TITLE
fix(KDE) Extended permissions for kde xdg-portal

### DIFF
--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -18,6 +18,8 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   include <abstractions/qt5-shader-cache>
   include <abstractions/thumbnails-cache-write>
 
+  capability sys_ptrace,
+
   network inet dgram,
   network inet6 dgram,
   network inet stream,
@@ -25,6 +27,8 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   network netlink raw,
 
   signal send set=term peer=kioworker,
+
+  ptrace read,
 
   #aa:dbus own bus=session name=org.freedesktop.impl.portal.desktop.kde
 
@@ -70,6 +74,8 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   owner @{user_state_dirs}/xdg-desktop-portal-kdestaterc rw,
   owner @{user_state_dirs}/xdg-desktop-portal-kdestaterc.@{rand6} rwlk,
   owner @{user_state_dirs}/xdg-desktop-portal-kdestaterc.lock rwk,
+
+  owner @{att}/.flatpak-info r,
 
         @{run}/user/@{uid}/gvfs/ r,
   owner @{run}/user/@{uid}/#@{int} rw,


### PR DESCRIPTION
Extension of permissions for xdg-desktop-portal-kde.

```
apparmor="ALLOWED" operation="capable" class="cap" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" capability=19  capname="sys_ptrace"
apparmor="ALLOWED" operation="ptrace" class="ptrace" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" requested_mask="read" denied_mask="read" peer="fapp//&fbwrap"
apparmor="ALLOWED" operation="ptrace" class="ptrace" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" requested_mask="read" denied_mask="read" peer="dolphin"
apparmor="ALLOWED" operation="ptrace" class="ptrace" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" requested_mask="read" denied_mask="read" peer="konsole"
apparmor="ALLOWED" operation="ptrace" class="ptrace" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" requested_mask="read" denied_mask="read" peer="plasmashell"
apparmor="ALLOWED" operation="ptrace" class="ptrace" profile="xdg-desktop-portal-kde"  comm="xdg-desktop-por" requested_mask="read" denied_mask="read" peer="unconfined"
apparmor="ALLOWED" operation="open" class="file" profile="xdg-desktop-portal-kde" name="/att/xdg-desktop-portal-kde/.flatpak-info"  comm="xdg-desktop-por" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000 FSUID="lakis" OUID="lakis"
```