### PR TITLE
Draft: AppImage profiles

### DIFF
--- a/apparmor.d/profiles-a-f/AppImage
+++ b/apparmor.d/profiles-a-f/AppImage
@@ -1,0 +1,54 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{HOME}/**.{a,A}pp{i,I}mage
+profile AppImage @{HOME}/**.{a,A}pp{i,I}mage {
+  include <abstractions/base>
+
+  mount fstype=fuse.*.{a,A}pp{i,I}mage options=(ro nodev nosuid),
+
+  @{exec_path} r,
+
+  @{bin}/fusermount cx -> fusermount,
+  /tmp/.mount*@{rand6}/AppRun rpx -> AppRun,
+
+  /dev/fuse rw,
+
+  /tmp/.mount_*@{rand6}/ rw,
+
+  owner @{PROC}/@{pid}/cgroup r,
+
+  profile fusermount {
+    include <abstractions/base>
+    include <abstractions/nameservice-strict>
+
+    capability dac_read_search,
+    capability dac_override,
+    capability sys_admin,
+
+    mount fstype=fuse options=(ro nodev nosuid),
+    mount fstype=fuse.*.{a,A}pp{i,I}mage options=(ro nodev nosuid),
+    umount /tmp/.mount_*@{rand6}/,
+
+    @{bin}/fusermount r,
+
+    /dev/fuse rw,
+
+    /etc/fuse.conf r,
+
+    @{PROC}/@{pid}/mounts r,
+
+    /tmp/.mount_*@{rand6}/ rw,
+
+    include if exists <local/AppImage_fusermount>
+    }
+
+  include if exists <local/AppImage>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/AppImage
+++ b/apparmor.d/profiles-a-f/AppImage
@@ -14,8 +14,8 @@ profile AppImage @{HOME}/**.{a,A}pp{i,I}mage {
 
   @{exec_path} r,
 
-  @{bin}/fusermount cx -> fusermount,
-  /tmp/.mount*@{rand6}/AppRun rpx -> AppRun,
+  @{bin}/fusermount Cx -> fusermount,
+  /tmp/.mount*@{rand6}/AppRun rPx -> AppRun,
 
   /dev/fuse rw,
 

--- a/apparmor.d/profiles-a-f/AppImage
+++ b/apparmor.d/profiles-a-f/AppImage
@@ -1,5 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2026 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/4.0>,
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = @{HOME}/**.{a,A}pp{i,I}mage
-profile AppImage @{HOME}/**.{a,A}pp{i,I}mage {
+profile AppImage @{exec_path} {
   include <abstractions/base>
 
   mount fstype=fuse.*.{a,A}pp{i,I}mage options=(ro nodev nosuid),

--- a/apparmor.d/profiles-a-f/AppRun
+++ b/apparmor.d/profiles-a-f/AppRun
@@ -23,7 +23,7 @@ profile AppRun /tmp/.mount*@{rand6}/AppRun {
 
   @{sh_path}      r,
   @{bin}/dirname  rix,
-  @{bin}/ldconfig rix,
+  @{sbin}/ldconfig rix,
   @{bin}/{,e}grep rix,
   @{bin}/readlink rix,
 

--- a/apparmor.d/profiles-a-f/AppRun
+++ b/apparmor.d/profiles-a-f/AppRun
@@ -1,0 +1,42 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = /tmp/.mount*@{rand6}/AppRun
+profile AppRun /tmp/.mount*@{rand6}/AppRun {
+  include <abstractions/base>
+  include <abstractions/desktop>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  @{exec_path} r,
+
+  @{sh_path}      r,
+  @{bin}/ldconfig rix,
+  @{bin}/grep     rix,
+  @{bin}/readlink rix,
+  @{bin}/dirname  rix,
+
+  /tmp/.mount_*@{rand6}/usr/bin/** ix, # Can we get the name of the executable to transition to existing profiles?
+  /tmp/.mount_*@{rand6}/freetype_probe rix,
+
+  /dev/tty rw,
+
+  /tmp/.mount_*@{rand6}/{,**} r,
+  /tmp/.mount_*@{rand6}/usr/lib/**.so* m,
+  /tmp/.mount_*@{rand6}/usr/local/**.so* m,
+
+  include if exists <local/AppRun>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/AppRun
+++ b/apparmor.d/profiles-a-f/AppRun
@@ -1,5 +1,5 @@
 # apparmor.d - Full set of apparmor profiles
-# Copyright (C) 2022-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2022-2026 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
 abi <abi/4.0>,
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 include <tunables/global>
 
 @{exec_path} = /tmp/.mount*@{rand6}/AppRun
-profile AppRun /tmp/.mount*@{rand6}/AppRun {
+profile AppRun @{exec_path} {
   include <abstractions/base>
   include <abstractions/desktop>
   include <abstractions/graphics>
@@ -21,11 +21,11 @@ profile AppRun /tmp/.mount*@{rand6}/AppRun {
 
   @{exec_path} r,
 
-  @{sh_path}      r,
-  @{bin}/dirname  rix,
+  @{sh_path}       r,
+  @{bin}/dirname   rix,
   @{sbin}/ldconfig rix,
-  @{bin}/{,e}grep rix,
-  @{bin}/readlink rix,
+  @{bin}/{,e}grep  rix,
+  @{bin}/readlink  rix,
 
   /tmp/.mount_*@{rand6}/usr/bin/** ix, # Can we get the name of the executable to transition to existing profiles?
   /tmp/.mount_*@{rand6}/freetype_probe rix,

--- a/apparmor.d/profiles-a-f/AppRun
+++ b/apparmor.d/profiles-a-f/AppRun
@@ -22,10 +22,10 @@ profile AppRun /tmp/.mount*@{rand6}/AppRun {
   @{exec_path} r,
 
   @{sh_path}      r,
-  @{bin}/ldconfig rix,
-  @{bin}/grep     rix,
-  @{bin}/readlink rix,
   @{bin}/dirname  rix,
+  @{bin}/ldconfig rix,
+  @{bin}/{,e}grep rix,
+  @{bin}/readlink rix,
 
   /tmp/.mount_*@{rand6}/usr/bin/** ix, # Can we get the name of the executable to transition to existing profiles?
   /tmp/.mount_*@{rand6}/freetype_probe rix,

--- a/dists/flags/main.flags
+++ b/dists/flags/main.flags
@@ -25,6 +25,8 @@ akonadi_notes_agent complain
 akonadi_sendlater_agent complain
 akonadi_unifiedmailbox_agent complain
 anacron complain
+AppImage complain
+AppRun complain
 at complain
 atd complain
 auditctl complain


### PR DESCRIPTION
AppRun as how it is right now it's a base profile that needs further and broad rules to accomodate all kind of apps that are shipped as AppImage, for now I mark this as draft, users can adapt AppRun to suit their own needs.

Profiles assume appimages are stored somewhere in @{HOME}