### PR TITLE
feat(checkupdates) Introduction of a profile for the checkupdates script for pacman (Arch)

### DIFF
--- a/apparmor.d/groups/pacman/checkupdates
+++ b/apparmor.d/groups/pacman/checkupdates
@@ -1,0 +1,79 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/checkupdates
+profile checkupdates @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/consoles>
+
+  capability dac_read_search,
+
+  @{sh_path}             r,
+  @{bin}/cat             rix,
+  @{bin}/diff            rix,
+  @{bin}/fakeroot        Cx -> fakeroot,
+  @{bin}/gettext         rix,
+  @{bin}/{,e}grep        rix,
+  @{bin}/ln              rix,
+  @{bin}/mkdir           rix,
+  @{bin}/mv              rix,
+  @{bin}/pacman          Px,
+  @{bin}/pacman-conf     Px,
+  @{bin}/rm              rix,
+  @{bin}/sudo            Cx -> sudo,
+  @{bin}/tput            rix,
+
+  @{exec_path}   r,
+
+  /usr/share/makepkg/util/*.sh r,
+  /usr/share/terminfo/{,**} r,
+
+  owner @{user_state_dirs}/checkupdates/ w,
+  owner @{user_state_dirs}/checkupdates/current_check rw,
+  owner @{user_state_dirs}/checkupdates/last_check rw,
+
+  owner @{tmp}/checkup-db-@{uid}/ w,
+  owner @{tmp}/checkup-db-@{uid}/local w,
+
+  owner /dev/pts/@{u8} rw,
+
+  profile fakeroot {
+    include <abstractions/base>
+    include <abstractions/consoles>
+
+    capability dac_read_search,
+
+    @{sh_path}        r,
+    @{bin}/cut        rix,
+    @{bin}/faked      rix,
+    @{bin}/fakeroot   r,
+    @{bin}/getopt     rix,
+    @{bin}/pacman     Px,
+    @{bin}/sed        rix,
+
+    include if exists <local/checkupdates_fakeroot>
+  }
+
+  profile sudo {
+    include <abstractions/base>
+    include <abstractions/app/sudo>
+
+    capability sys_ptrace,
+
+    ptrace read,
+
+    @{bin}/pacman Px,
+
+    include if exists <local/checkupdates_sudo>
+  }
+
+  include if exists <local/checkupdates>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/pacman/pacman
+++ b/apparmor.d/groups/pacman/pacman
@@ -110,10 +110,10 @@ profile pacman @{exec_path} flags=(attach_disconnected) {
   owner /var/lib/pacman/{,**} rwl,
   owner @{tmp}/alpm_@{rand6}/{,**} rw,
   owner @{tmp}/arch-update-@{uid}/checkupdates-@{rand}/sync/** w,
-  owner @{tmp}/checkup-db-@{int}/db.lck rw,
-  owner @{tmp}/checkup-db-@{int}/sync/{,*.db*} rw,
-  owner @{tmp}/checkup-db-@{uid}/sync/download-@{rand6}/ rw,
-  owner @{tmp}/checkup-db-@{uid}/sync/download-@{rand6}/{,*} rw,
+  @{tmp}/checkup-db-@{int}/db.lck rw,
+  @{tmp}/checkup-db-@{int}/sync/{,*.db*} rw,
+  @{tmp}/checkup-db-@{uid}/sync/download-@{rand6}/ rw,
+  @{tmp}/checkup-db-@{uid}/sync/download-@{rand6}/{,*} rw,
 
   @{run}/utmp rk,
 


### PR DESCRIPTION
Profile for checkupdates script. The script is recommended for checking updates on ArchLinux and other distros using pacman.

Small changes required in the pacman profile, as the database is created by non root user.

[Logs](https://github.com/user-attachments/files/30016884/aa-profile-pacman-checkupdates.txt)
