### PR TITLE
fix(justfile): allow `just pkg` with non-zstd PKGEXT

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -296,9 +296,9 @@ build-rpm: (_ensure_pkgdest)
 [group('packages')]
 pkg: build-pkg
 	@sudo pacman -U --noconfirm \
-		{{pkgdest}}/{{pkgname}}-`just version`*.pkg.tar.zst \
-		{{pkgdest}}/{{pkgname}}-base-`just version`*.pkg.tar.zst \
-		{{pkgdest}}/{{pkgname}}-tools-`just version`*.pkg.tar.zst
+		{{pkgdest}}/{{pkgname}}-`just version`*.pkg.tar* \
+		{{pkgdest}}/{{pkgname}}-base-`just version`*.pkg.tar* \
+		{{pkgdest}}/{{pkgname}}-tools-`just version`*.pkg.tar*
 
 # Build & install apparmor.d on Debian based systems
 [group('packages')]


### PR DESCRIPTION
`pacman -U` was hardcoded to `.pkg.tar.zst`. Match any `.pkg.tar*` extension so makepkg settings like `PKGEXT='.pkg.tar'` work.

AI-assisted.