### PR TITLE
fix(protonmail): support kbuildsycoca atomic saves

### DIFF
--- a/apparmor.d/abstractions/common/xdg
+++ b/apparmor.d/abstractions/common/xdg
@@ -55,6 +55,10 @@
   @{bin}/qtpaths              ix,
   @{bin}/qtxdg-mat            ix,
 
+  @{bin}/kbuildsycoca{,5,6}   rix,
+
+  @{etc_ro}/xdg/menus/*.menu r,
+
   / r,
 
   @{PROC}/version r,

--- a/apparmor.d/abstractions/kde-base
+++ b/apparmor.d/abstractions/kde-base
@@ -18,7 +18,7 @@
   /etc/xdg/kdeglobals r,
   /etc/xdg/kwinrc r,
 
-  owner @{user_cache_dirs}/#@{int} rw,
+  owner @{user_cache_dirs}/#@{int} rwlk,
   owner @{user_cache_dirs}/icon-cache.kcache rw,
   owner @{user_cache_dirs}/ksycoca{5,6}_??{_,-}* rwlk,
 

--- a/apparmor.d/groups/freedesktop/xdg-mime
+++ b/apparmor.d/groups/freedesktop/xdg-mime
@@ -16,7 +16,6 @@ profile xdg-mime @{exec_path} flags=(attach_disconnected) {
   @{exec_path} r,
 
   @{bin}/dbus-send            Cx -> bus,
-  @{bin}/kbuildsycoca{,5}     Px,
   @{bin}/mimetype             Px,
   @{bin}/vendor_perl/mimetype Px,
   @{bin}/xprop                Px,

--- a/apparmor.d/groups/kde/kbuildsycoca
+++ b/apparmor.d/groups/kde/kbuildsycoca
@@ -7,7 +7,7 @@ abi <abi/4.0>,
 
 include <tunables/global>
 
-@{exec_path} = @{bin}/kbuildsycoca{,5}
+@{exec_path} = @{bin}/kbuildsycoca{,5,6}
 profile kbuildsycoca @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/freedesktop.org>

--- a/apparmor.d/profiles-m-r/protonmail
+++ b/apparmor.d/profiles-m-r/protonmail
@@ -14,7 +14,7 @@ include <tunables/global>
 @{cache_dirs} = @{user_cache_dirs}/@{name}
 
 @{exec_path} = @{bin}/@{name} /opt/proton-mail/@{name}
-profile protonmail @{exec_path} flags=(attach_disconnected) {
+profile protonmail @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/common/electron>
   include <abstractions/secrets-service>


### PR DESCRIPTION
On KDE systems, `protonmail` invokes `xdg-mime`, which can launch `kbuildsycoca6`. `kbuildsycoca` performs atomic saves via an anonymous unlinked temp file (`#<inode>`) and links it to the real `ksycoca6_*` cache file. This requires `mediate_deleted` on the profile where the helper runs.

Move the `kbuildsycoca` exec, menu read, cache, and explicit `link` rules into `abstractions/common/xdg` (pulled in by `common/electron`) so all Electron apps that hit this code path get them. Also add link permission to the KDE cache temp file in `abstractions/kde-base`, update the dedicated `kbuildsycoca` profile to cover version 6, and drop the now-conflicting `Px` transition from `groups/freedesktop/xdg-mime` (the rules in `common/xdg` handle it via `rix`). `protonmail` keeps only the profile-level `mediate_deleted` flag.

Log entries fixed:
```
ALLOWED protonmail exec @{bin}/kbuildsycoca6 -> protonmail//null-@{bin}/kbuildsycoca6 comm=xdg-mime requested_mask=x denied_mask=x
ALLOWED protonmail open @{etc_ro}/xdg/menus/plasma-applications.menu comm=kbuildsycoca6 requested_mask=r denied_mask=r
ALLOWED protonmail link owner @{user_cache_dirs}/ksycoca6_* -> @{user_cache_dirs}/#@{int} comm=kbuildsycoca6 requested_mask=l denied_mask=l
ALLOWED protonmail link owner @{user_cache_dirs}/#@{int} info="Failed name lookup - deleted entry" comm=kbuildsycoca6 requested_mask=l denied_mask=l error=-2
```


  *AI-assisted*
