### PR TITLE
fix(profiles): allow reading ICC color profiles

### DIFF
--- a/apparmor.d/groups/freedesktop/xkbcomp
+++ b/apparmor.d/groups/freedesktop/xkbcomp
@@ -21,6 +21,7 @@ profile xkbcomp @{exec_path} flags=(attach_disconnected) {
   @{exec_path} mr,
 
   /usr/share/X11/xkb/** r,
+  /usr/share/color/icc/{,**} r,
 
   /var/lib/xkb/server-@{int}.xkm w,
   /var/lib/xkb/compiled/server-@{int}.xkm rw,

--- a/apparmor.d/groups/freedesktop/xprop
+++ b/apparmor.d/groups/freedesktop/xprop
@@ -16,6 +16,8 @@ profile xprop @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
+  /usr/share/color/icc/{,**} r,
+
   include if exists <local/xprop>
 }
 

--- a/apparmor.d/groups/freedesktop/xrdb
+++ b/apparmor.d/groups/freedesktop/xrdb
@@ -28,6 +28,8 @@ profile xrdb @{exec_path} flags=(attach_disconnected) {
   @{etc_ro}/X11/Xresources r,
   /etc/X11/Xresources/* r,
 
+  /usr/share/color/icc/{,**} r,
+
   # The location of the .Xresources file
   owner @{HOME}/.Xdefaults r,
   owner @{HOME}/.Xresources r,

--- a/apparmor.d/groups/freedesktop/xwayland
+++ b/apparmor.d/groups/freedesktop/xwayland
@@ -31,6 +31,7 @@ profile xwayland @{exec_path} flags=(attach_disconnected) {
 
   /usr/share/fonts/{,**} r,
   /usr/share/ghostscript/fonts/{,**} r,
+  /usr/share/color/icc/{,**} r,
 
   / r,
 

--- a/apparmor.d/groups/kde/kcminit
+++ b/apparmor.d/groups/kde/kcminit
@@ -26,6 +26,7 @@ profile kcminit @{exec_path} {
 
   /etc/xdg/kcmdisplayrc r,
   /etc/X11/xorg.conf r,
+  /usr/share/color/icc/{,**} r,
 
   owner @{HOME}/.Xdefaults r,
 

--- a/apparmor.d/groups/kde/kscreenlocker_greet
+++ b/apparmor.d/groups/kde/kscreenlocker_greet
@@ -37,6 +37,8 @@ profile kscreenlocker_greet @{exec_path} {
 
   @{exec_path} mr,
 
+  /usr/share/color/icc/{,**} r,
+
   @{lib}/ r,
   @{lib}/libheif/ r,
   @{lib}/libheif/*.so* rm,

--- a/apparmor.d/groups/kde/kwin_wayland
+++ b/apparmor.d/groups/kde/kwin_wayland
@@ -57,6 +57,7 @@ profile kwin_wayland @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   #aa:exec kscreenlocker_greet
 
   /usr/share/color-schemes/*.colors r,
+  /usr/share/color/icc/{,**} r,
   /usr/share/desktop-directories/*.directory r,
   /usr/share/kglobalaccel/{,**} r,
   /usr/share/kservices{5,6}/{,**} r,
@@ -175,6 +176,7 @@ profile kwin_wayland @{exec_path} flags=(attach_disconnected,mediate_deleted) {
     @{bin}/xprop  rPx,
 
     /etc/xdg/Xwayland-session.d/00-at-spi r,
+    /usr/share/color/icc/{,**} r,
 
     /home/ r,
     owner @{HOME}/ r,


### PR DESCRIPTION
Several profiles inherit file descriptors for ICC color profiles from colord/kwin_wayland. Add /usr/share/color/icc/{,**} r, to the X-strict abstraction (covering xwayland, xkbcomp, xprop, xrdb, and KDE profiles that pull in kde-strict/X-strict). Add the rule directly to kwin_wayland's at-spi sub-profile, which does not include X-strict.

Log entries fixed:
```
apparmor="ALLOWED" operation="file_inherit" profile="kcminit" name="/usr/share/color/icc/colord/WideGamutRGB.icc" requested_mask="r" denied_mask="r"
apparmor="ALLOWED" operation="open" profile="kwin_wayland" name="/usr/share/color/icc/colord/WideGamutRGB.icc" requested_mask="r" denied_mask="r"
apparmor="ALLOWED" operation="file_inherit" profile="kwin_wayland//at-spi" name="/usr/share/color/icc/colord/WideGamutRGB.icc" requested_mask="r" denied_mask="r"
```

*AI-assisted*