### PR TITLE
feat: add fedora support

### DIFF
--- a/apparmor.d/abstractions/X-strict
+++ b/apparmor.d/abstractions/X-strict
@@ -32,6 +32,8 @@
   owner @{run}/user/@{uid}/X11/Xauthority r,
   owner @{run}/user/@{uid}/xauth_@{rand6} rl,
 
+  /dev/udmabuf rw,
+
   include if exists <abstractions/X-strict.d>
 
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/app/bus
+++ b/apparmor.d/abstractions/app/bus
@@ -10,6 +10,10 @@
   include <abstractions/consoles>
   include <abstractions/nameservice-strict>
 
+  # dbus-launch bootstraps X11/dbus auth cookies it doesn't own
+  capability dac_override,
+  capability dac_read_search,
+
   @{bin}/dbus-launch  mrix,
   @{bin}/dbus-send    mrix,
 

--- a/apparmor.d/abstractions/app/flatpak
+++ b/apparmor.d/abstractions/app/flatpak
@@ -96,6 +96,56 @@
   # apply_extra
   /app/extra/** w,
 
+  # Qt runtime translations, remapped inside the flatpak sandbox
+  /usr/translations/{,**} r,
+
+  /etc/issue r,
+  /etc/os-release r,
+
+  # Self-introspection within the sandbox's own low-pid namespace
+  @{PROC}/[0-9]*/ r,
+  @{PROC}/[0-9]*/mountinfo r,
+  @{PROC}/[0-9]*/mounts r,
+  @{PROC}/[0-9]*/net/arp r,
+  @{PROC}/[0-9]*/oom_score r,
+  @{PROC}/[0-9]*/task/[0-9]*/comm rw,
+  @{PROC}/[0-9]*/statm r,
+
+  # Some apps blindly open() with O_CREAT even for files that already
+  # exist, e.g. AnyDesk's /proc/cpuinfo probe
+  @{PROC}/cpuinfo rw,
+
+  # Hardware/platform device identification (e.g. Electron gamepad enumeration)
+  @{sys}/devices/platform/uevent r,
+  @{sys}/devices/platform/**/uevent r,
+
+  # Network interface / PCI device enumeration (e.g. lspci, network client
+  # apps reading a MAC address for machine identification)
+  @{sys}/bus/pci/slots/ r,
+  @{sys}/bus/pci/slots/*/address r,
+  @{sys}/devices/@{pci}/label r,
+  @{sys}/devices/@{pci}/net/*/address r,
+  @{PROC}/bus/pci/devices r,
+
+  # CPU topology/capability enumeration
+  @{sys}/devices/system/cpu/cpu@{int}/cache/index@{int}/number_of_sets r,
+  @{sys}/devices/system/cpu/cpu@{int}/hotplug/state r,
+  @{sys}/devices/system/cpu/cpu@{int}/topology/core_id r,
+  @{sys}/devices/system/cpu/cpu@{int}/topology/core_siblings r,
+  @{sys}/devices/system/cpu/hotplug/states r,
+  @{sys}/devices/system/cpu/vulnerabilities/ r,
+  @{sys}/devices/system/cpu/vulnerabilities/* r,
+
+  /dev/urandom rw,
+
+  # Gamepad/joystick enumeration (e.g. browser Gamepad API implementations)
+  /dev/input/by-id/ r,
+  /dev/input/by-path/ r,
+
+  # Qt platform theme engine plugin, present in the shared freedesktop
+  # runtime any Qt-based flatpak app pulls in
+  /usr/share/runtime/lib/plugins/Kvantum/styles/*.so m,
+
   include if exists <abstractions/app/flatpak.d>
 
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/app/git
+++ b/apparmor.d/abstractions/app/git
@@ -10,6 +10,7 @@
 
   include <abstractions/consoles>
   include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
   include <abstractions/ssl_certs>
 
   network inet dgram,

--- a/apparmor.d/abstractions/app/pkexec
+++ b/apparmor.d/abstractions/app/pkexec
@@ -24,10 +24,14 @@
 
   network netlink raw,   # PAM
 
+  ptrace read peer=@{profile_name},
+
   #aa:dbus talk bus=system name=org.freedesktop.PolicyKit1.Authority label=polkitd
 
   @{bin}/pkexec    mr,
+  @{bin}/env       rix,
 
+  /etc/machine-id r,
   /etc/shells r,
 
         @{PROC}/@{pid}/cgroup r,

--- a/apparmor.d/abstractions/app/sudo-rs
+++ b/apparmor.d/abstractions/app/sudo-rs
@@ -18,8 +18,9 @@
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_resource,
 
-  network (create receive send) netlink raw,
+  network (create receive send bind) netlink raw,
 
   unix type=stream addr=@@{udbus}/bus/sudo/system,
 
@@ -30,6 +31,12 @@
 
   @{bin}/sudo        mr,
   @{bin}/sudo-rs     mr,
+
+  # pam_unix execs this setuid helper to verify the password (/etc/shadow
+  # isn't directly readable). Ux needs no transition-table entry or
+  # target-profile lookup, sidestepping the Px/px merge issue seen in the
+  # sudo profile - see profiles-s-z/sudo for the full explanation.
+  priority=1 @{sbin}/unix_chkpwd rUx,
 
   @{etc_ro}/sudo.conf r,
   @{etc_ro}/sudoers r,
@@ -43,6 +50,7 @@
   owner @{run}/sudo-rs/ts/ w,
   owner @{run}/sudo-rs/ts/@{uid} rwk,
 
+  @{PROC}/@{pid}/cgroup r,
   @{PROC}/@{pid}/loginuid r,
   @{PROC}/@{pid}/stat r,
   @{PROC}/sys/kernel/random/boot_id r,

--- a/apparmor.d/abstractions/audio-client
+++ b/apparmor.d/abstractions/audio-client
@@ -59,7 +59,7 @@
 
   owner @{user_share_dirs}/openal/hrtf/{,**} r,
   owner @{user_share_dirs}/sounds/ r,
-  owner @{user_share_dirs}/sounds/__custom/index.theme r,
+  owner @{user_share_dirs}/sounds/*/index.theme r,
 
   owner @{run}/user/@{uid}/pipewire-@{int} rw,
 

--- a/apparmor.d/abstractions/authentication.d/complete
+++ b/apparmor.d/abstractions/authentication.d/complete
@@ -16,4 +16,8 @@
   @{etc_ro}/security/pam_env.conf.d/ r,
   @{etc_ro}/security/pam_env.conf.d/{,*.conf} r,
 
+  # authselect's generated PAM stack, read by any PAM-using process on Fedora
+  #aa:only fedora
+  @{etc_ro}/authselect/system-auth r,
+
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/cgroup-limits
+++ b/apparmor.d/abstractions/cgroup-limits
@@ -16,11 +16,14 @@
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/memory.max r,
   owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/**/memory.high r,
   owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/**/memory.max r,
+  owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/**/memory.current r,
+  owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/**/memory.stat r,
 
         @{sys}/fs/cgroup/cpu.max r,
         @{sys}/fs/cgroup/user.slice/cpu.max r,
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/cpu.max r,
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/cpu.max r,
+        @{sys}/fs/cgroup/user.slice/user-0.slice/session-@{int}.scope/cpu.max r,
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/cpu.max r,
   owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/**/cpu.max r,
 

--- a/apparmor.d/abstractions/common/xdg
+++ b/apparmor.d/abstractions/common/xdg
@@ -62,6 +62,18 @@
 
   @{bin}/kbuildsycoca{,5,6}   rix,
 
+  # kbuildsycoca{,5,6} runs ix (not Px), so it needs its own rules here too
+  owner @{user_cache_dirs}/ksycoca* rwk,
+  owner @{user_config_dirs}/kdedefaults/kdeglobals r,
+  owner @{user_config_dirs}/kdeglobals r,
+  #aa:only fedora
+  /usr/share/kde-settings/kde-profile/default/xdg/kdeglobals r,
+  #aa:only fedora
+  /usr/share/kde-settings/kde-profile/default/xdg/kde-mimeapps.list r,
+
+  /usr/share/qt{,5,6}/qtlogging.ini r,
+  /usr/share/qt{,5,6}/translations/*.qm r,
+
   @{etc_ro}/xdg/menus/*.menu r,
 
   / r,

--- a/apparmor.d/abstractions/flatpak/baseapp/org.winehq.Wine
+++ b/apparmor.d/abstractions/flatpak/baseapp/org.winehq.Wine
@@ -32,6 +32,11 @@
   # https://www.phoronix.com/news/Linux-6.14-NTSYNC-Driver-Ready
   /dev/ntsync r,
 
+  # Steam Play compatibility tools (Proton and community builds); mrix
+  # matches abstractions/common/pressure-vessel's rule for the same tree
+  @{user_share_dirs}/Steam/compatibilitytools.d/*/files/bin/wine{,64,server} mrix,
+  @{HOME}/.steam/steam/steamapps/common/Proton*/files/bin/wine{,64,server} Ux,
+
   include if exists <abstractions/flatpak/baseapp/org.winehq.Wine.d>
 
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/fontconfig-cache-write
+++ b/apparmor.d/abstractions/fontconfig-cache-write
@@ -10,6 +10,10 @@
   include <abstractions/fontconfig-cache>
 
         /var/cache/fontconfig/ w,
+
+  #aa:only fedora
+  @{lib}/fontconfig/cache/ w,
+
   owner /var/cache/fontconfig/CACHEDIR.TAG w,
   owner /var/cache/fontconfig/CACHEDIR.TAG.LCK wl,
   owner /var/cache/fontconfig/CACHEDIR.TAG.NEW w,

--- a/apparmor.d/abstractions/fonts.d/complete
+++ b/apparmor.d/abstractions/fonts.d/complete
@@ -1,0 +1,16 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+  /usr/share/X11/fonts/Type1/{,**} r,
+
+  #aa:only fedora
+  @{lib}/fontconfig/cache/ rw,
+  #aa:only fedora
+  @{lib}/fontconfig/cache/** rwk,
+
+  # App-registered font directories scanned by fc-cache
+  owner @{user_config_dirs}/inkscape/fonts/ r,
+  owner @{user_share_dirs}/krita/fonts/ r,
+
+# vim:syntax=apparmor

--- a/apparmor.d/abstractions/graphics
+++ b/apparmor.d/abstractions/graphics
@@ -11,8 +11,13 @@
 
   /etc/igfx_user_feature{,_next,_report}.txt w,
   /etc/libva.conf r,
+  /etc/egl/egl_external_platform.d/{,*.json} r,
 
+  @{sys}/bus/ r,
   @{sys}/bus/pci/devices/ r,
+
+  # Lossless Scaling frame-generation Vulkan layer
+  owner @{user_config_dirs}/lsfg-vk/conf.toml r,
 
   # GPU sysfs for PCI graphics cards:
   @{sys}/devices/@{pci}/current_link_speed r,  # Current PCIe link speed (e.g., 8.0 GT/s)

--- a/apparmor.d/abstractions/gtk-strict
+++ b/apparmor.d/abstractions/gtk-strict
@@ -63,6 +63,7 @@
   owner @{HOME}/.gtk r,
   owner @{HOME}/.gtkrc r,
   owner @{HOME}/.gtkrc-2.0 r,
+  owner @{HOME}/.gtkrc-2.0-kde4 r,
   owner @{HOME}/.gtk-bookmarks r,
 
   owner @{user_cache_dirs}/gtk-4.0/ rw,

--- a/apparmor.d/abstractions/icons
+++ b/apparmor.d/abstractions/icons
@@ -18,6 +18,9 @@
 
   owner @{user_share_dirs}/icons/{,**} r,
 
+  # Qt6's icon-theme fallback-chain lookup cache
+  owner @{user_cache_dirs}/union/{,**} r,
+
   include if exists <abstractions/icons.d>
 
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/kde-base
+++ b/apparmor.d/abstractions/kde-base
@@ -18,9 +18,19 @@
   /etc/xdg/kdeglobals r,
   /etc/xdg/kwinrc r,
   /etc/xdg/menus/plasma-applications.menu r,
+  /etc/xdg/menus/preferences-merged/ r,
+  /etc/xdg/menus/preferences-post-merged/ r,
+  /etc/xdg/menus/settings-merged/ r,
+
+  /usr/share/desktop-directories/*.directory r,
+
+  #aa:only fedora
+  /usr/share/kde-settings/kde-profile/default/xdg/{,**} r,
 
   owner @{user_cache_dirs}/#@{int} rwlk,
+  owner @{user_cache_dirs}/#@{int} rwl -> @{user_cache_dirs}/ksycoca{5,6}_*,
   owner @{user_cache_dirs}/icon-cache.kcache rw,
+  owner @{user_cache_dirs}/ksycoca{5,6}_* rwl -> @{user_cache_dirs}/#@{int},
   owner @{user_cache_dirs}/ksycoca{5,6}_??{_,-}* rwlk,
 
   owner @{user_config_dirs}/#@{int} rw,

--- a/apparmor.d/abstractions/nvidia-strict
+++ b/apparmor.d/abstractions/nvidia-strict
@@ -11,6 +11,9 @@
   /opt/cuda/targets/@{arch}-linux/lib/*.so mr,
   /opt/cuda/targets/@{arch}-linux/lib/*.so.* mr,
 
+  /usr/local/cuda-*/targets/@{arch}-linux/lib/*.so mr,
+  /usr/local/cuda-*/targets/@{arch}-linux/lib/*.so.* mr,
+
   /usr/share/nvidia/nvidia-application-profiles-* r,
 
   /etc/nvidia/nvidia-application-profiles-* r,

--- a/apparmor.d/abstractions/openssl.d/complete
+++ b/apparmor.d/abstractions/openssl.d/complete
@@ -4,4 +4,11 @@
 
   /usr/share/ssl/ r,
 
+  #aa:only fedora
+  /etc/pki/tls/openssl.cnf r,
+  #aa:only fedora
+  /etc/pki/tls/openssl.d/{,*} r,
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/opensslcnf.config r,
+
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/p11-kit.d/complete
+++ b/apparmor.d/abstractions/p11-kit.d/complete
@@ -1,0 +1,18 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+  #aa:only fedora
+  /etc/pki/ca-trust/source/ r,
+  #aa:only fedora
+  /etc/pki/ca-trust/source/anchors/ r,
+  #aa:only fedora
+  /etc/pki/ca-trust/source/blocklist/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/anchors/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/blocklist/ r,
+
+# vim:syntax=apparmor

--- a/apparmor.d/abstractions/qt5-settings-write.d/complete
+++ b/apparmor.d/abstractions/qt5-settings-write.d/complete
@@ -1,0 +1,32 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# KConfig's shared-config lock file, used by any Qt/KDE app touching kdeglobals
+
+  owner @{user_config_dirs}/kdeglobals w,
+  owner @{user_config_dirs}/kdeglobals.lock rwk,
+  owner @{user_config_dirs}/kdeglobals.@{rand6} rwl -> @{user_config_dirs}/#@{int},
+
+  # KPropertiesDialog "Share" tab (NFS/Samba) queried when browsing $HOME
+  network inet dgram,
+
+  /etc/exports r,
+  /etc/krb5.conf r,
+  /etc/krb5.conf.d/ r,
+  /etc/krb5.conf.d/* r,
+  /var/lib/sss/pubconf/krb5.include.d/ r,
+  /etc/samba/smb.conf r,
+  /etc/samba/usershares.conf r,
+  owner @{user_config_dirs}/knfsshare r,
+  @{bin}/net       rix,
+  @{bin}/testparm  rix,
+
+  /var/lib/samba/lock/ r,
+  /var/lib/samba/lock/msg.lock/ rw,
+
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+  /etc/crypto-policies/back-ends/krb5.config r,
+
+# vim:syntax=apparmor

--- a/apparmor.d/abstractions/ssl_certs.d/complete
+++ b/apparmor.d/abstractions/ssl_certs.d/complete
@@ -4,4 +4,37 @@
 
   /etc/ca-certificates.conf r,
 
+  #aa:only fedora
+  /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem r,
+  #aa:only fedora
+  /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt r,
+  #aa:only fedora
+  /etc/pki/ca-trust/extracted/pem/directory-hash/ r,
+  #aa:only fedora
+  /etc/pki/ca-trust/extracted/pem/directory-hash/*.pem r,
+
+  #aa:only fedora
+  /etc/pki/ca-trust/source/ r,
+  #aa:only fedora
+  /etc/pki/ca-trust/source/README r,
+  #aa:only fedora
+  /etc/pki/ca-trust/source/anchors/ r,
+  #aa:only fedora
+  /etc/pki/ca-trust/source/blocklist/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/README r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/ca-bundle.trust.p11-kit r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/anchors/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-source/blocklist/ r,
+  #aa:only fedora
+  /usr/share/pki/ca-trust-legacy/ca-bundle.legacy.default.crt r,
+
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
 # vim:syntax=apparmor

--- a/apparmor.d/abstractions/themes
+++ b/apparmor.d/abstractions/themes
@@ -9,6 +9,11 @@
   owner @{HOME}/.themes/{,**} r,
   owner @{user_share_dirs}/themes/{,**} r,
 
+  # Third-party QStyle/window-decoration engine config (e.g. Klassy, Kvantum);
+  # engine name isn't known ahead of time, so this can't be scoped narrower
+  owner @{user_config_dirs}/*rc r,
+  owner @{user_config_dirs}/*/*rc r,
+
   include if exists <abstractions/themes.d>
 
 # vim:syntax=apparmor

--- a/apparmor.d/groups/apparmor/apparmor.systemd
+++ b/apparmor.d/groups/apparmor/apparmor.systemd
@@ -19,8 +19,11 @@ profile apparmor.systemd @{exec_path} {
 
   @{sh_path}                  rix,
   @{bin}/{,e}grep             rix,
-  @{sbin}/aa-status           rPx,
-  @{sbin}/apparmor_parser     rPx,
+  # PUx, not Px: a full restart's aa-teardown unloads these two profiles
+  # before this step runs, so a hard Px fails with "profile transition not
+  # found" during that window.
+  @{sbin}/aa-status           rPUx,
+  @{sbin}/apparmor_parser     rPUx,
   @{bin}/getconf              rix,
   @{bin}/ls                   rix,
   @{bin}/sed                  rix,

--- a/apparmor.d/groups/browsers/brave-origin
+++ b/apparmor.d/groups/browsers/brave-origin
@@ -1,0 +1,50 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2019-2021 Mikhail Morfikov
+# Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{name} = brave-origin{,-beta,-dev}
+@{domain} = com.brave.Brave org.chromium.Chromium
+@{lib_dirs} = /opt/brave.com/brave-origin
+@{config_dirs} = @{user_config_dirs}/BraveSoftware/ @{user_config_dirs}/Brave-Origin{,-Beta}/
+@{cache_dirs} = @{user_cache_dirs}/BraveSoftware/ @{user_cache_dirs}/Brave-Origin{,-Beta}/
+
+@{exec_path} = @{lib_dirs}/brave-origin @{lib_dirs}/brave
+profile brave-origin @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/app/chromium>
+
+  #aa:dbus own bus=session name=org.mpris.MediaPlayer2.brave-origin path=/org/mpris/MediaPlayer2
+
+  ptrace trace peer=brave-origin,
+
+  @{exec_path} mrix,
+
+  @{bin}/man  rPUx, # For "brave-origin --help"
+
+  @{lib_dirs}/chrome_crashpad_handler  Px -> brave-origin//&brave-origin//crashpad_handler,
+
+  /usr/share/chromium/extensions/ r,
+
+  /etc/opt/brave-origin/ r,
+  /etc/opt/brave-origin/native-messaging-hosts/* r,
+  /etc/opt/chrome/ r,
+  /etc/opt/chrome/native-messaging-hosts/* r,
+
+  owner @{config_dirs}/WidevineCdm/libwidevinecdm.so mrw,
+
+  owner @{tmp}/net-export/ rw,
+
+  # Silencer
+  deny /etc/opt/ w,
+  deny /dev/disk/by-uuid/ r,
+
+  include if exists <local/brave-origin>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/claude-desktop
+++ b/apparmor.d/groups/browsers/claude-desktop
@@ -1,0 +1,44 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{name} = claude-desktop-unofficial
+@{domain} = io.github.aaddrick.claude-desktop-debian org.chromium.Chromium
+@{lib_dirs} = @{lib}/@{name}
+@{config_dirs} = @{user_config_dirs}/Claude/
+@{cache_dirs} = @{user_cache_dirs}/Claude/
+
+@{exec_path} = @{bin}/@{name} @{lib_dirs}/claude-desktop
+profile claude-desktop @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/app/chromium>
+
+  #aa:dbus own bus=session name=org.mpris.MediaPlayer2.claude-desktop path=/org/mpris/MediaPlayer2
+
+  ptrace trace peer=claude-desktop,
+
+  @{exec_path} mrix,
+
+  @{lib_dirs}/chrome_crashpad_handler Px -> claude-desktop//&claude-desktop//crashpad_handler,
+  @{lib_dirs}/chrome-sandbox           rPx,
+
+  /usr/share/claude-desktop-unofficial/{,**} r,
+
+  owner @{config_dirs}/{,**} rw,
+  owner @{cache_dirs}/{,**} rw,
+  owner @{user_share_dirs}/Claude/{,**} rw,
+
+  owner @{tmp}/claude-desktop-*/ rw,
+  owner @{tmp}/claude-desktop-*/** rw,
+
+  # Silencer
+  deny /dev/disk/by-uuid/ r,
+
+  include if exists <local/claude-desktop>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/browsers/helium-bin
+++ b/apparmor.d/groups/browsers/helium-bin
@@ -1,0 +1,65 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2019-2021 Mikhail Morfikov
+# Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+# abstractions/app/chromium's crashpad_handler subprofile uses peer=@{name}
+# to scope ptrace/signal to the real parent - profile name here is
+# "helium-bin", not "helium", so both must be listed
+@{name} = helium helium-bin
+@{domain} = com.imput.helium org.chromium.Chromium
+@{lib_dirs} = /opt/helium
+@{config_dirs} = @{user_config_dirs}/net.imput.helium{,-beta} @{user_config_dirs}/Helium{,-Beta}
+@{cache_dirs} = @{user_cache_dirs}/net.imput.helium{,-beta} @{user_cache_dirs}/Helium{,-Beta}
+
+@{exec_path} = @{lib_dirs}/helium @{lib_dirs}/chrome
+profile helium-bin @{exec_path} flags=(complain,attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/app/chromium>
+
+  userns,
+
+  #aa:dbus own bus=session name=org.mpris.MediaPlayer2.helium path=/org/mpris/MediaPlayer2
+
+  ptrace trace peer=helium-bin,
+
+  @{exec_path} mrix,
+
+  @{bin}/man  rPUx, # For "helium --help"
+
+  @{lib_dirs}/helium_crashpad_handler  Px -> helium-bin//&helium-bin//crashpad_handler,
+
+  @{sh_path}                   rix, # For helium-wrapper
+  @{bin}/dirname                rix,
+  @{bin}/readlink               rix,
+
+  /usr/share/chromium/extensions/ r,
+
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
+  /opt/helium/{,**} r,
+  /opt/helium/helium mr,
+  /opt/helium/helium_crashpad_handler mr,
+  /opt/helium/chromedriver mr,
+  /opt/helium/*.so* mr,
+  /opt/helium/locales/{,*} r,
+  /opt/helium/WidevineCdm/{,**} r,
+
+  owner @{config_dirs}/WidevineCdm/libwidevinecdm.so mrw,
+
+  owner @{tmp}/net-export/ rw,
+
+  # Silencer
+  deny /etc/opt/ w,
+  deny /dev/disk/by-uuid/ r,
+  deny @{user_share_dirs}/gvfs-metadata/* r,
+
+  include if exists <local/helium-bin>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/bus/dbus-session
+++ b/apparmor.d/groups/bus/dbus-session
@@ -24,6 +24,8 @@ profile dbus-session flags=(attach_disconnected) {
   include <abstractions/deny-sensitive-home>
   include <abstractions/nameservice-strict>
 
+  capability net_admin,
+
   signal receive set=(term hup)      peer=gdm{,-*},
 
   ptrace read,
@@ -71,6 +73,9 @@ profile dbus-session flags=(attach_disconnected) {
 
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
+
+  #aa:only fedora
+  /etc/selinux/config r,
 
   # Dbus can receive any user files
   owner @{HOME}/** r,

--- a/apparmor.d/groups/bus/dbus-system
+++ b/apparmor.d/groups/bus/dbus-system
@@ -81,6 +81,9 @@ profile dbus-system flags=(attach_disconnected) {
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
 
+  #aa:only fedora
+  /etc/selinux/config r,
+
   @{att}@{desktop_share_dirs}/icc/ r,
   @{att}@{desktop_share_dirs}/icc/edid-@{hex32}.icc r,
   @{att}@{user_share_dirs}/icc/ r,

--- a/apparmor.d/groups/children/child-modprobe-nvidia
+++ b/apparmor.d/groups/children/child-modprobe-nvidia
@@ -45,6 +45,9 @@ profile child-modprobe-nvidia flags=(attach_disconnected) {
   owner /dev/nvidia-caps/ w,
   owner /dev/nvidia-caps/nvidia-cap@{int} w,
 
+  @{PROC}/sys/kernel/modprobe r,
+  /dev/pts/[0-9]* rw,
+
   deny  @{HOME}/.steam/** r,
 
   profile kmod {
@@ -52,10 +55,13 @@ profile child-modprobe-nvidia flags=(attach_disconnected) {
     include <abstractions/app/kmod>
 
     capability mknod,
+    capability sys_module,
+    capability perfmon,
 
     /etc/nvidia/{current,legacy*,tesla*}/*.conf r,
 
     @{sys}/module/compression r,
+    @{sys}/module/nvidia/initstate r,
 
     deny @{HOME}/.steam/** r,
 

--- a/apparmor.d/groups/children/child-open
+++ b/apparmor.d/groups/children/child-open
@@ -27,6 +27,16 @@ profile child-open flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/app-open>
   include <abstractions/app/open>
 
+  # Sockets inherited across exec from network-active callers (e.g. torrent
+  # clients keeping DHT/LSD/UPnP sockets open while spawning xdg-open)
+  network inet dgram,   # file_inherit
+  network inet6 dgram,  # file_inherit
+  network inet stream,  # file_inherit
+  network inet6 stream, # file_inherit
+  network netlink raw,  # file_inherit
+
+  @{sh_path} rix,
+
   include if exists <usr/child-open.d>
   include if exists <local/child-open>
 }

--- a/apparmor.d/groups/children/child-open-any
+++ b/apparmor.d/groups/children/child-open-any
@@ -16,12 +16,16 @@ profile child-open-any flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/app/open>
   include <abstractions/path>
 
-  @{bin}/**                     PUx,
-  @{lib}/**                     PUx,
-  @{user_bin_dirs}/**           PUx,
-  /opt/*/**                     PUx,
-  /usr/local/bin/**             PUx,
-  /usr/share/**                 PUx,
+  # Falls back to inherited confinement instead of transitioning when
+  # invoked under no_new_privs (e.g. portal-spawned) - see
+  # docs/development/internal.md "No New Privileges". These need mmap
+  # too in that case, to load the target binary in-place.
+  @{bin}/**                     mPUx,
+  @{lib}/**                     mPUx,
+  @{user_bin_dirs}/**           mPUx,
+  /opt/*/**                     mPUx,
+  /usr/local/bin/**             mPUx,
+  /usr/share/**                 mPUx,
 
   include if exists <usr/child-open-any.d>
   include if exists <local/child-open-any>

--- a/apparmor.d/groups/children/glycin
+++ b/apparmor.d/groups/children/glycin
@@ -26,6 +26,9 @@ profile glycin flags=(attach_disconnected) {
 
   @{lib}/glycin-loaders/@{d}+/glycin-* Cx -> &glycin//loaders,
 
+  # Inherited fd from the parent bwrap process
+  /dev/udmabuf rw,
+
   #aa:lint ignore=too-wide
   # Safe deny of inherited files from parent process.
   deny network inet dgram,
@@ -40,6 +43,7 @@ profile glycin flags=(attach_disconnected) {
   deny /dev/shm/** rw,
   deny /dev/dri/* rw,
   deny @{att}/dev/tty@{u8} rw,
+  deny /tmp/.org.chromium.Chromium.@{rand6} rw,
 
   profile loaders flags=(attach_disconnected) {
     include <abstractions/base>
@@ -47,7 +51,13 @@ profile glycin flags=(attach_disconnected) {
 
     unix type=stream,
 
+    # flatpak-portal sends SIGINT to cancel an in-flight thumbnail/preview load
+    signal receive set=int peer=flatpak-portal,
+
     @{lib}/glycin-loaders/@{d}+/glycin-* mr,
+
+    # zbus resolving peer credentials over the session bus (arbitrary pid)
+    @{PROC}/[0-9]*/cgroup r,
 
     @{att}/usr/share/glycin-loaders/{,**} r,
 

--- a/apparmor.d/groups/cosmic/cosmic-app-library
+++ b/apparmor.d/groups/cosmic/cosmic-app-library
@@ -1,0 +1,32 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-app-library
+profile cosmic-app-library @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/applications/{,**.desktop} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/cosmic/{,**} r,
+  /usr/share/pixmaps/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/applications/{,**.desktop} r,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-app-library>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-audio
+++ b/apparmor.d/groups/cosmic/cosmic-applet-audio
@@ -1,0 +1,30 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-audio
+profile cosmic-applet-audio @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+  owner @{run}/user/@{uid}/pulse/ r,
+  owner @{run}/user/@{uid}/pulse/native rw,
+
+  include if exists <local/cosmic-applet-audio>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-battery
+++ b/apparmor.d/groups/cosmic/cosmic-applet-battery
@@ -1,0 +1,31 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-battery
+profile cosmic-applet-battery @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/upower-observe>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  @{sys}/class/power_supply/{,**} r,
+
+  include if exists <local/cosmic-applet-battery>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-bluetooth
+++ b/apparmor.d/groups/cosmic/cosmic-applet-bluetooth
@@ -1,0 +1,38 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-bluetooth
+profile cosmic-applet-bluetooth @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  dbus send bus=system path=/org/bluez{,/**}
+       interface=org.freedesktop.DBus.Properties
+       peer=(name=org.bluez),
+  dbus send bus=system path=/org/bluez{,/**}
+       interface=org.bluez.*
+       peer=(name=org.bluez),
+  dbus receive bus=system path=/org/bluez{,/**}
+       interface=org.freedesktop.DBus.Properties
+       peer=(name=org.bluez),
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-applet-bluetooth>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-network
+++ b/apparmor.d/groups/cosmic/cosmic-applet-network
@@ -1,0 +1,41 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-network
+profile cosmic-applet-network @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  dbus send bus=system path=/org/freedesktop/NetworkManager{,/**}
+       interface=org.freedesktop.DBus.Properties
+       peer=(name=org.freedesktop.NetworkManager),
+  dbus send bus=system path=/org/freedesktop/NetworkManager{,/**}
+       interface=org.freedesktop.NetworkManager*
+       peer=(name=org.freedesktop.NetworkManager),
+  dbus receive bus=system path=/org/freedesktop/NetworkManager{,/**}
+       interface=org.freedesktop.DBus.Properties
+       peer=(name=org.freedesktop.NetworkManager),
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-applet-network>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-notifications
+++ b/apparmor.d/groups/cosmic/cosmic-applet-notifications
@@ -1,0 +1,27 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-notifications
+profile cosmic-applet-notifications @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-applet-notifications>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applet-power
+++ b/apparmor.d/groups/cosmic/cosmic-applet-power
@@ -1,0 +1,30 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-applet-power
+profile cosmic-applet-power @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/bus/system/org.freedesktop.login1>
+  include <abstractions/upower-observe>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-applet-power>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-applets
+++ b/apparmor.d/groups/cosmic/cosmic-applets
@@ -1,0 +1,29 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+# Shared profile for simple panel applets
+@{exec_path} = @{bin}/cosmic-applet-a11y @{bin}/cosmic-applet-minimize @{bin}/cosmic-applet-tiling @{bin}/cosmic-applet-time @{bin}/cosmic-applet-workspaces @{bin}/cosmic-applet-input-sources @{bin}/cosmic-applet-status-area @{bin}/cosmic-app-list @{bin}/cosmic-panel-button @{bin}/cosmic-applet-clippy-land @{bin}/cosmic-ext-applet-logomenu @{bin}/cosmic-ext-applet-sysinfo
+profile cosmic-applets @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/applications/{,**.desktop} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-applets>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-bg
+++ b/apparmor.d/groups/cosmic/cosmic-bg
@@ -1,0 +1,29 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-bg
+profile cosmic-bg @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/backgrounds/{,**} r,
+  /usr/share/pixmaps/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{HOME}/Pictures/{,**} r,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-bg>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-comp
+++ b/apparmor.d/groups/cosmic/cosmic-comp
@@ -1,0 +1,51 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-comp
+profile cosmic-comp @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  capability sys_ptrace,
+
+  network netlink raw,
+  network unix stream,
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/wayland-sessions/{,*.desktop} r,
+  /usr/share/xkb/{,**} r,
+  /usr/share/X11/xkb/{,**} r,
+  /usr/share/libinput/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/ rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /dev/dri/{,*} rw,
+  /dev/input/{,*} rw,
+  /dev/uinput rw,
+
+  @{sys}/devices/**/uevent r,
+  @{sys}/class/input/ r,
+  @{sys}/class/drm/ r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+  @{PROC}/1/environ r,
+
+  include if exists <local/cosmic-comp>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-edit
+++ b/apparmor.d/groups/cosmic/cosmic-edit
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-edit
+profile cosmic-edit @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/fonts/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-edit>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-calculator
+++ b/apparmor.d/groups/cosmic/cosmic-ext-calculator
@@ -1,0 +1,26 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-ext-calculator
+profile cosmic-ext-calculator @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-ext-calculator>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-camera
+++ b/apparmor.d/groups/cosmic/cosmic-ext-camera
@@ -1,0 +1,30 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/camera
+profile cosmic-ext-camera @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  /dev/video{,*} rw,
+
+  owner @{HOME}/Pictures/{,**} rw,
+  owner @{HOME}/Videos/{,**} rw,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-ext-camera>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-logomenu
+++ b/apparmor.d/groups/cosmic/cosmic-ext-logomenu
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-ext-applet-logomenu @{bin}/cosmic-ext-logomenu-settings
+profile cosmic-ext-logomenu @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/applications/{,**.desktop} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-ext-logomenu>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-storage
+++ b/apparmor.d/groups/cosmic/cosmic-ext-storage
@@ -1,0 +1,38 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-ext-storage
+profile cosmic-ext-storage @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  @{bin}/cosmic-ext-storage-daemon Px,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{HOME}/{,**} r,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /media/{,**} r,
+  @{run}/media/{,**} r,
+
+  @{sys}/block/ r,
+  @{sys}/class/block/{,**} r,
+  @{sys}/devices/**/block/{,**} r,
+
+  include if exists <local/cosmic-ext-storage>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-storage-daemon
+++ b/apparmor.d/groups/cosmic/cosmic-ext-storage-daemon
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-ext-storage-daemon
+profile cosmic-ext-storage-daemon @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-system>
+
+  capability sys_admin,
+
+  @{exec_path} mr,
+
+  @{sys}/block/ r,
+  @{sys}/class/block/{,**} r,
+  @{sys}/devices/**/block/{,**} r,
+
+  @{PROC}/mounts r,
+  @{PROC}/@{pids}/mountinfo r,
+
+  include if exists <local/cosmic-ext-storage-daemon>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-tasks
+++ b/apparmor.d/groups/cosmic/cosmic-ext-tasks
@@ -1,0 +1,26 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/tasks
+profile cosmic-ext-tasks @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-ext-tasks>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-ext-xcalendar
+++ b/apparmor.d/groups/cosmic/cosmic-ext-xcalendar
@@ -1,0 +1,27 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/xcalendar
+profile cosmic-ext-xcalendar @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-ext-xcalendar>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-files
+++ b/apparmor.d/groups/cosmic/cosmic-files
@@ -1,0 +1,36 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-files @{bin}/cosmic-files-applet
+profile cosmic-files @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/mime/{,**} r,
+  /usr/share/applications/{,**.desktop} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /media/{,**} r,
+  @{run}/media/{,**} r,
+
+  include if exists <local/cosmic-files>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-greeter
+++ b/apparmor.d/groups/cosmic/cosmic-greeter
@@ -1,0 +1,56 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-greeter
+profile cosmic-greeter @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus/system/org.freedesktop.login1>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+  include <abstractions/upower-observe>
+
+  network netlink raw,
+
+  dbus send bus=system path=/org/freedesktop/DBus
+       interface=org.freedesktop.DBus
+       member=ListActivatableNames
+       peer=(name=org.freedesktop.DBus, label="@{p_dbus_system}"),
+
+  @{exec_path} mr,
+
+  @{bin}/cosmic-greeter-daemon  Px,
+  @{bin}/cosmic-greeter-start   Px,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/wayland-sessions/{,*.desktop} r,
+  /usr/share/xsessions/{,*.desktop} r,
+
+  /etc/greetd/{,*} r,
+  @{etc_ro}/login.defs r,
+  @{etc_ro}/login.defs.d/{,*} r,
+  /etc/fstab r,
+  /etc/pam.d/cosmic-greeter r,
+
+  /var/lib/AccountsService/icons/@{user} r,
+  /var/lib/AccountsService/users/@{user} r,
+
+  / r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/ rw,
+
+  owner @{tmp}/cosmic-greeter-* rw,
+
+  @{sys}/devices/**/uevent r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+
+  include if exists <local/cosmic-greeter>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-greeter-daemon
+++ b/apparmor.d/groups/cosmic/cosmic-greeter-daemon
@@ -1,0 +1,33 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-greeter-daemon
+profile cosmic-greeter-daemon @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus/system/org.freedesktop.login1>
+  include <abstractions/nameservice-strict>
+
+  capability setuid setgid dac_override,
+
+  @{exec_path} mr,
+
+  /etc/greetd/{,*} r,
+  /etc/pam.d/cosmic-greeter r,
+  @{etc_ro}/login.defs r,
+  @{etc_ro}/login.defs.d/{,*} r,
+  /etc/security/{,*} r,
+
+  /var/lib/AccountsService/users/{,*} r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+  @{PROC}/1/environ r,
+
+  include if exists <local/cosmic-greeter-daemon>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-greeter-start
+++ b/apparmor.d/groups/cosmic/cosmic-greeter-start
@@ -1,0 +1,34 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-greeter-start
+profile cosmic-greeter-start @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  @{bin}/cosmic-greeter      Px,
+  @{bin}/cosmic-comp         Px,
+  @{bin}/dbus-run-session    Px,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/wayland-sessions/{,*.desktop} r,
+
+  /etc/greetd/{,*} r,
+
+  owner @{run}/user/@{uid}/ rw,
+  owner @{tmp}/cosmic-greeter-* rw,
+
+  @{sys}/devices/**/uevent r,
+
+  include if exists <local/cosmic-greeter-start>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-idle
+++ b/apparmor.d/groups/cosmic/cosmic-idle
@@ -1,0 +1,25 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-idle
+profile cosmic-idle @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+
+  include if exists <local/cosmic-idle>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-launcher
+++ b/apparmor.d/groups/cosmic/cosmic-launcher
@@ -1,0 +1,33 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-launcher
+profile cosmic-launcher @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/applications/{,**.desktop} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/cosmic/{,**} r,
+  /usr/share/pixmaps/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/applications/{,**.desktop} r,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-launcher>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-notifications
+++ b/apparmor.d/groups/cosmic/cosmic-notifications
@@ -1,0 +1,27 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-notifications
+profile cosmic-notifications @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-notifications>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-osd
+++ b/apparmor.d/groups/cosmic/cosmic-osd
@@ -1,0 +1,31 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-osd
+profile cosmic-osd @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  @{sys}/class/backlight/{,**} r,
+  @{sys}/class/leds/{,**} r,
+
+  include if exists <local/cosmic-osd>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-panel
+++ b/apparmor.d/groups/cosmic/cosmic-panel
@@ -1,0 +1,36 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-panel
+profile cosmic-panel @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  @{bin}/cosmic-app-list          Px,
+  @{bin}/cosmic-applet-*          Px,
+  @{bin}/cosmic-panel-button      Px,
+  @{bin}/cosmic-applet-clippy-land Px,
+  @{bin}/cosmic-ext-applet-*     Px,
+  @{bin}/cosmic-files-applet      Px,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/applications/{,**.desktop} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-panel>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-player
+++ b/apparmor.d/groups/cosmic/cosmic-player
@@ -1,0 +1,34 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-player
+profile cosmic-player @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/gstreamer-1.0/{,**} r,
+
+  owner @{HOME}/{,**} r,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+  owner @{run}/user/@{uid}/pulse/ r,
+  owner @{run}/user/@{uid}/pulse/native rw,
+
+  /media/{,**} r,
+  @{run}/media/{,**} r,
+
+  include if exists <local/cosmic-player>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-randr
+++ b/apparmor.d/groups/cosmic/cosmic-randr
@@ -1,0 +1,21 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-randr
+profile cosmic-randr @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+
+  @{exec_path} mr,
+
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-randr>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-reader
+++ b/apparmor.d/groups/cosmic/cosmic-reader
@@ -1,0 +1,31 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-reader
+profile cosmic-reader @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/fonts/{,**} r,
+
+  owner @{HOME}/{,**} r,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /media/{,**} r,
+  @{run}/media/{,**} r,
+
+  include if exists <local/cosmic-reader>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-session
+++ b/apparmor.d/groups/cosmic/cosmic-session
@@ -1,0 +1,49 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-session @{bin}/start-cosmic
+profile cosmic-session @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  @{bin}/cosmic-comp              Px,
+  @{bin}/cosmic-panel             Px,
+  @{bin}/cosmic-bg                Px,
+  @{bin}/cosmic-settings-daemon   Px,
+  @{bin}/cosmic-launcher          Px,
+  @{bin}/cosmic-notifications     Px,
+  @{bin}/cosmic-workspaces        Px,
+  @{bin}/dbus-run-session         Px,
+  @{bin}/dbus-daemon              Px,
+  @{bin}/dconf                    Px,
+  @{bin}/systemctl                Px,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/wayland-sessions/{,*.desktop} r,
+  /usr/share/dconf/{,**} r,
+  /usr/share/applications/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+  /etc/environment r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/ rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/environ r,
+
+  include if exists <local/cosmic-session>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-settings
+++ b/apparmor.d/groups/cosmic/cosmic-settings
@@ -1,0 +1,46 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-settings
+profile cosmic-settings @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/fonts/{,**} r,
+  /usr/share/X11/xkb/{,**} r,
+  /usr/share/xkb/{,**} r,
+  /usr/share/libinput/{,**} r,
+  /usr/share/backgrounds/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+  /etc/fwupd/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{HOME}/Pictures/{,**} r,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /dev/input/{,*} r,
+
+  @{sys}/class/backlight/ r,
+  @{sys}/class/backlight/**/brightness r,
+  @{sys}/devices/**/uevent r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+
+  include if exists <local/cosmic-settings>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-settings-daemon
+++ b/apparmor.d/groups/cosmic/cosmic-settings-daemon
@@ -1,0 +1,41 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-settings-daemon
+profile cosmic-settings-daemon @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/polkit-1/rules.d/cosmic-settings-daemon.rules r,
+  /usr/share/X11/xkb/{,**} r,
+  /usr/share/xkb/{,**} r,
+  /usr/share/libinput/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+
+  /dev/input/{,*} rw,
+
+  @{sys}/class/backlight/{,**} rw,
+  @{sys}/class/leds/{,**} rw,
+  @{sys}/devices/**/uevent r,
+  @{sys}/devices/**/power/{,**} r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+
+  include if exists <local/cosmic-settings-daemon>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-term
+++ b/apparmor.d/groups/cosmic/cosmic-term
@@ -1,0 +1,39 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-term
+profile cosmic-term @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  # Terminal needs to exec arbitrary user-typed programs unconfined
+  @{bin}/* Ux,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/fonts/{,**} r,
+  /usr/share/terminfo/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/mountinfo r,
+
+  /dev/ptmx rw,
+  /dev/pts/* rw,
+
+  include if exists <local/cosmic-term>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/cosmic-workspaces
+++ b/apparmor.d/groups/cosmic/cosmic-workspaces
@@ -1,0 +1,27 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/cosmic-workspaces
+profile cosmic-workspaces @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+  /usr/share/icons/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/cosmic-workspaces>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cosmic/noctua
+++ b/apparmor.d/groups/cosmic/noctua
@@ -1,0 +1,26 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/noctua
+profile noctua @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+
+  @{exec_path} mr,
+
+  /usr/share/cosmic/{,**} r,
+
+  owner @{user_config_dirs}/cosmic/{,**} rw,
+  owner @{user_share_dirs}/cosmic/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/noctua>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cups/cupsd
+++ b/apparmor.d/groups/cups/cupsd
@@ -17,6 +17,7 @@ profile cupsd @{exec_path} flags=(attach_disconnected) {
   include <abstractions/bus/system/org.freedesktop.ColorManager>
   include <abstractions/nameservice-strict>
   include <abstractions/python>
+  include <abstractions/ssl_certs>
 
   capability audit_write,
   capability chown,
@@ -35,6 +36,7 @@ profile cupsd @{exec_path} flags=(attach_disconnected) {
   network inet stream,
   network inet6 dgram,
   network inet6 stream,
+  network netlink raw,
 
   network appletalk dgram,
   network ash dgram,
@@ -89,6 +91,7 @@ profile cupsd @{exec_path} flags=(attach_disconnected) {
 
   /etc/cups/{,**} rw,
   /etc/foomatic/* r,
+  /etc/libaudit.conf r,
   /etc/papersize r,
   /etc/paperspecs r,
   /etc/pnm2ppa.conf r,

--- a/apparmor.d/groups/display-manager/lightdm
+++ b/apparmor.d/groups/display-manager/lightdm
@@ -51,6 +51,9 @@ profile lightdm @{exec_path} flags=(attach_disconnected) {
   @{bin}/plymouth              rPx,
   @{bin}/gnome-keyring-daemon  rPx,
   @{bin}/lightdm-session       rPx,
+  @{bin}/ksecretd              rPx,
+  @{bin}/kwalletd{5,6}         rPx,
+  @{lib}/pam_kwallet_init      rPx,
 
   @{lib}/{,at-spi2{,-core}/}at-spi-bus-launcher rPx,
 

--- a/apparmor.d/groups/dnf/dnf
+++ b/apparmor.d/groups/dnf/dnf
@@ -1,0 +1,80 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/dnf
+profile dnf @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bash-strict>
+  include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
+  include <abstractions/ssl_certs>
+  include <abstractions/python>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability fsetid,
+  capability mknod,
+  capability net_admin,
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability sys_chroot,
+  capability sys_ptrace,
+
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  @{sh_path} rix,
+  @{bin}/dnf5 rPx,
+  @{bin}/rpm            rPx,
+  @{bin}/rpmkeys        rPx,
+  @{bin}/gpg{,2}        rPx,
+  @{bin}/gpgv{,2}       rPx,
+
+  # Legacy dnf4 plugin/module machinery (python).
+  @{lib}/python3.*/site-packages/dnf{,-plugins}/{,**} r,
+  @{lib}/python3.*/site-packages/dnf-plugins/**/*.py r,
+  @{lib}/python3.*/site-packages/dnf/{,**} r,
+
+  /etc/dnf/{,**} r,
+  /etc/yum.repos.d/{,**} r,
+  /etc/yum.conf r,
+  /etc/rpm/{,**} r,
+  /etc/pki/rpm-gpg/{,**} r,
+  /etc/os-release r,
+  /etc/system-release{,-cpe} r,
+  /etc/redhat-release r,
+
+  /var/lib/dnf/{,**} rwk,
+  /var/lib/rpm/{,**} rwk,
+  /usr/share/rpm/{,**} rwk,
+  /var/cache/libdnf5/{,**} rwk,
+  /var/cache/dnf/{,**} rwk,
+  /var/log/dnf{,5}{,.log} rw,
+  /var/log/dnf5.rpm.log rw,
+  /var/log/hawkey.log rw,
+
+  /var/tmp/ rw,
+  /var/tmp/dnf-*/{,**} rwk,
+  owner /tmp/dnf-*/{,**} rwk,
+
+  @{PROC}/@{pid}/mounts r,
+  @{PROC}/sys/kernel/random/uuid r,
+  @{sys}/fs/cgroup/{,**} r,
+
+  include if exists <local/dnf>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/dnf/dnf5
+++ b/apparmor.d/groups/dnf/dnf5
@@ -1,0 +1,92 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/dnf5
+profile dnf5 @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bash-strict>
+  include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
+  include <abstractions/ssl_certs>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability fsetid,
+  capability mknod,
+  capability net_admin,
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability sys_chroot,
+  capability sys_ptrace,
+
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  @{sh_path} rix,
+  @{bin}/dnf{,-3}          rPx,
+  @{bin}/rpm               rPx,
+  @{bin}/rpmkeys           rPx,
+  @{bin}/gpg{,2}           rPx,
+  @{bin}/gpgv{,2}          rPx,
+  @{bin}/ostree            rPx,
+  @{bin}/bootc             rPx,
+
+  @{lib}/dnf5/{,**} rmix,
+  @{lib}/dnf5-plugins/{,**} rmix,
+  @{lib}/libdnf5/{,**} rm,
+
+  /etc/dnf/{,**} r,
+  /etc/yum.repos.d/{,**} r,
+  /etc/yum.conf r,
+  /etc/rpm/{,**} r,
+  /etc/pki/rpm-gpg/{,**} r,
+  /etc/os-release r,
+  /etc/system-release{,-cpe} r,
+  /etc/redhat-release r,
+  /etc/rhsm/{,**} r,
+  /etc/pki/ca-trust/{,**} r,
+  /etc/ca-certificates/{,**} r,
+  /usr/share/crypto-policies/{,**} r,
+
+  /var/lib/dnf/{,**} rwk,
+  /var/lib/rpm/{,**} rwk,
+  /usr/share/rpm/{,**} rwk,
+  /var/lib/rpmstate/{,**} rwk,
+  /var/cache/libdnf5/{,**} rwk,
+  @{lib}/sysimage/libdnf5/{,**} rwk,
+  /var/log/dnf5{,.log} rw,
+  /var/log/dnf5.rpm.log rw,
+  /var/log/hawkey.log rw,
+
+  /var/tmp/ rw,
+  /var/tmp/dnf5-*/{,**} rwk,
+  /var/tmp/rpm-tmp.@{rand6} rwk,
+  owner /tmp/dnf5-*/{,**} rwk,
+  owner /tmp/tmp.@{rand10}/{,**} rwk,
+  owner /tmp/librepo-tmp-* rwk,
+
+  @{efi}/{,**} r,
+  @{lib}/modules/{,**} r,
+
+  @{PROC}/@{pid}/mounts r,
+  @{PROC}/sys/kernel/random/uuid r,
+  @{PROC}/sys/kernel/osrelease r,
+  @{sys}/fs/cgroup/{,**} r,
+
+  include if exists <local/dnf5>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/filesystem/btrfs
+++ b/apparmor.d/groups/filesystem/btrfs
@@ -28,6 +28,7 @@ profile btrfs @{exec_path} flags=(attach_disconnected) {
   @{efi}/ r,
   @{efi}/**/ r,
   /home/ r,
+  /home/.snapshots/ r, #aa:lint ignore=tunables
   /opt/ r,
   /root/ r,
   /srv/ r,
@@ -49,6 +50,7 @@ profile btrfs @{exec_path} flags=(attach_disconnected) {
   # For fsck of the btrfs filesystem directly from gparted
   owner @{tmp}/gparted-*/ rw,
 
+  @{run}/blkid/ w,
   @{run}/blkid/blkid.tab{,-@{rand6}} rw,
   @{run}/blkid/blkid.tab.old rwl -> @{run}/blkid/blkid.tab,
   @{run}/snapper-tools-*/ r,

--- a/apparmor.d/groups/filesystem/mkfs-fat
+++ b/apparmor.d/groups/filesystem/mkfs-fat
@@ -10,6 +10,7 @@ include <tunables/global>
 @{exec_path} = @{bin}/{mkfs.fat,mkfs.msdos,mkfs.vfat,mkdosfs}
 profile mkfs-fat @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/disks-write>
   include <abstractions/user-download-strict>
 

--- a/apparmor.d/groups/flatpak/fapp
+++ b/apparmor.d/groups/flatpak/fapp
@@ -18,6 +18,16 @@ profile fapp flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/app/flatpak>
 
+  # Some apps (mobile/console ports especially) write settings/data straight
+  # to the sandbox root instead of XDG dirs; this is the app's own ephemeral
+  # bwrap tmpfs, not the host
+  #aa:lint ignore=too-wide
+  owner /{,**} rw,
+
+  # /home/ itself is root-owned, so abstractions/flatpak/filesystem's
+  # "owner /home/ r," doesn't cover it; listing just reveals usernames
+  /home/ rw,
+
   deny @{att}/ r,
   deny @{att}@{run}/.userns r,
 

--- a/apparmor.d/groups/flatpak/fbwrap
+++ b/apparmor.d/groups/flatpak/fbwrap
@@ -62,6 +62,16 @@ profile fbwrap flags=(attach_disconnected,mediate_deleted) {
 
   /bindfile@{rand6} rw,
 
+  # Some apps (mobile/console ports especially) write settings/data straight
+  # to the sandbox root instead of XDG dirs; this is the app's own ephemeral
+  # bwrap tmpfs, not the host
+  #aa:lint ignore=too-wide
+  owner /{,**} rw,
+
+  # /home/ itself is root-owned, so abstractions/flatpak/filesystem's
+  # "owner /home/ r," doesn't cover it; listing just reveals usernames
+  /home/ rw,
+
   owner @{run}/flatpak/.flatpak/@{int}/.ref rk,
   owner @{run}/flatpak/ld.so.conf.d/  r,
   owner @{run}/flatpak/ld.so.conf.d/*.conf r,
@@ -87,12 +97,17 @@ profile fbwrap flags=(attach_disconnected,mediate_deleted) {
     @{sbin}/ldconfig mr,
     @{lib}/ r,
 
+    /app/etc/ld.so.conf r,
+
     /usr/share/runtime/lib/plugins/QGnomePlatform/lib/{,*} r,
 
     /app/lib/{,**} r,
     /app/lib{32,64}/{,**} r,
+    /app/extensions/*/lib/{,**} r,
 
     owner /var/cache/ldconfig/aux-cache r,
+    owner /etc/ld.so.cache rw,
+    owner /etc/ld.so.cache~ rwk,
 
     owner @{run}/flatpak/ld.so.conf.d/ r,
     owner @{run}/flatpak/ld.so.conf.d/*.conf r,

--- a/apparmor.d/groups/flatpak/flatpak-portal
+++ b/apparmor.d/groups/flatpak/flatpak-portal
@@ -6,6 +6,8 @@ abi <abi/5.0>,
 
 include <tunables/global>
 
+@{appid} = @{word}.@{word}.@{word}{,.@{word}}
+
 @{exec_path} = @{lib}/flatpak-portal
 profile flatpak-portal @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
@@ -40,12 +42,27 @@ profile flatpak-portal @{exec_path} flags=(attach_disconnected) {
 
   /usr/share/xdg-desktop-portal/portals/{,*.portal} r,
 
+  /etc/flatpak/installations.d/ r,
+  /etc/flatpak/remotes.d/ r,
+  /usr/share/flatpak/remotes.d/ r,
+
+  /var/lib/flatpak/app/@{appid}/@{arch}/stable/@{hex64}/deploy r,
+
+  /var/lib/flatpak/repo/ r,
+  /var/lib/flatpak/repo/config r,
+  /var/lib/flatpak/repo/objects/ r,
+  /var/lib/flatpak/repo/tmp/ r,
+
         / r,
   owner /att/**/ r,
   owner @{att}/.flatpak-info r,
 
   owner @{att}@{HOME}/.var/app/*/.local/share/*/logs/* rw,
   owner @{att}@{HOME}/.var/app/*/.local/share/*/**/usr/.ref rw,
+  owner @{HOME}/.var/app/*/sandbox/ rw,
+  owner @{att}@{HOME}/.var/app/*/sandbox/ rw,
+
+  owner @{user_cache_dirs}/flatpak/system-cache/ r,
 
   owner @{user_config_dirs}/user-dirs.dirs r,
 

--- a/apparmor.d/groups/flatpak/flatpak-session-helper
+++ b/apparmor.d/groups/flatpak/flatpak-session-helper
@@ -34,13 +34,16 @@ profile flatpak-session-helper @{exec_path} flags=(attach_disconnected,mediate_d
   @{bin}/dbus-monitor                 rPUx,
   @{bin}/flatpak                       rPx,
   @{bin}/getent                        rix,
+  @{bin}/git                           rPx,
   @{bin}/p11-kit                       rCx -> p11-kit,
   @{bin}/pkexec                        rCx -> pkexec,
   @{bin}/printenv                      rix,
   @{bin}/ps                            rPx,
+  @{bin}/update-desktop-database       rPx,
 
-  /var/lib/flatpak/app/@{appid}/**/@{bin}/**  rPx -> flatpak-session-helper-app,
-  /var/lib/flatpak/app/@{appid}/**/@{lib}/**  rPx -> flatpak-session-helper-app,
+  /var/lib/flatpak/app/@{appid}/**/@{bin}/**      rPx -> flatpak-session-helper-app,
+  /var/lib/flatpak/app/@{appid}/**/@{lib}/**      rPx -> flatpak-session-helper-app,
+  /var/lib/flatpak/runtime/**/files/@{lib}/**     rPx -> flatpak-session-helper-app,
 
   owner @{user_cache_dirs}/.flatpak-helper/{,**} rw,
 
@@ -53,6 +56,14 @@ profile flatpak-session-helper @{exec_path} flags=(attach_disconnected,mediate_d
   profile pkexec flags=(attach_disconnected,mediate_deleted) {
     include <abstractions/base>
     include <abstractions/app/pkexec>
+
+    # abstractions/app/pkexec's own ptrace rule only covers self (@{profile_name});
+    # pkexec here ptraces its own parent to check its confinement
+    ptrace read peer=flatpak-session-helper,
+
+    # env (rix'd from abstractions/app/pkexec) execs straight into a flatpak
+    # runtime's dynamic linker, mirroring the parent profile's own transition
+    /var/lib/flatpak/runtime/**/files/@{lib}/** rPx -> flatpak-session-helper-app,
 
     include if exists <local/flatpak-session-helper_pkexec>
   }

--- a/apparmor.d/groups/freedesktop/boltd
+++ b/apparmor.d/groups/freedesktop/boltd
@@ -30,6 +30,7 @@ profile boltd @{exec_path} flags=(attach_disconnected) {
   owner @{run}/boltd/{,**} rw,
 
   @{run}/udev/data/+thunderbolt:* r,      # For Thunderbolt devices, such as docks, external GPUs, and storage devices.
+  @{run}/udev/data/+wmi:* r,              # WMI-exposed ACPI objects enumerated alongside thunderbolt devices
 
   @{sys}/bus/ r,
   @{sys}/bus/thunderbolt/devices/ r,

--- a/apparmor.d/groups/freedesktop/cpupower
+++ b/apparmor.d/groups/freedesktop/cpupower
@@ -31,6 +31,7 @@ profile cpupower @{exec_path} {
   @{sys}/devices/system/cpu/cpufreq/{,**} r,
   @{sys}/devices/system/cpu/cpufreq/policy@{int}/* rw,
   @{sys}/devices/system/cpu/cpuidle/{,**} r,
+  @{sys}/devices/system/cpu/intel_pstate/{,**} r,
   @{sys}/devices/virtual/powercap/{,**} r,
 
   /dev/cpu/@{int}/msr r,

--- a/apparmor.d/groups/freedesktop/fc-cache
+++ b/apparmor.d/groups/freedesktop/fc-cache
@@ -19,6 +19,9 @@ profile fc-cache @{exec_path} {
 
   @{exec_path} mr,
 
+  # fontconfig's wrapper execs the arch-specific cache builders as children
+  @{bin_dirs}/fc-cache-{32,64} mrix,
+
   /var/cache/fontconfig/{,**} rw,
   /var/cache/fontconfig/*.cache-@{int} rwk,
   /var/cache/fontconfig/*.cache-@{int}.LCK rwl,

--- a/apparmor.d/groups/freedesktop/upowerd
+++ b/apparmor.d/groups/freedesktop/upowerd
@@ -42,6 +42,7 @@ profile upowerd @{exec_path} flags=(attach_disconnected) {
 
   @{run}/udev/data/ r,                    # Lists all udev data files
   @{run}/udev/data/+acpi:* r,             # Exposes ACPI objects (power buttons, batteries, thermal)
+  @{run}/udev/data/+auxiliary:* r,        # Auxiliary bus devices, e.g. acpi.video_bus
   @{run}/udev/data/+hid:* r,              # For Human Interface Device (mice, controllers, drawing tablets, scanners)
   @{run}/udev/data/+i2c:* r,              # For Inter-Integrated Circuit, low-speed peripherals (sensors, EEPROMs, etc.)
   @{run}/udev/data/+pci:* r,              # Identifies all PCI devices (CPU, GPU, Network, Disks, USB, etc.)

--- a/apparmor.d/groups/freedesktop/wireplumber
+++ b/apparmor.d/groups/freedesktop/wireplumber
@@ -53,6 +53,11 @@ profile wireplumber @{exec_path} flags=(attach_disconnected) {
   /usr/share/spa-*/bluez@{int}/{,*} r,
   /usr/share/wireplumber/{,**} r,
 
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
+  /etc/wireplumber/{bluetooth,main,policy}.lua.d/ r,
+
         / r,
         /att/**/ r,
   owner @{att}/.flatpak-info r,

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal
@@ -102,6 +102,9 @@ profile xdg-desktop-portal @{exec_path} flags=(attach_disconnected) {
 
   /etc/sysconfig/proxy r,
 
+  #aa:only fedora
+  /usr/share/kde-settings/kde-profile/default/xdg/{,**} r,
+
         / r,
   /att/**/ r,
   @{att}/ r,
@@ -115,11 +118,17 @@ profile xdg-desktop-portal @{exec_path} flags=(attach_disconnected) {
 
   # The portal can receive any user file as it is a file chooser for UI app.
   owner @{HOME}/** r,
+  owner @{att}@{HOME}/** r,
   owner @{HOME}/.var/app/*/{,**} rw,
 
         @{user_config_dirs}/kioslaverc r,
   owner @{user_config_dirs}/xdg-desktop-portal/* r,
   owner @{user_share_dirs}/xdg-desktop-portal/{,**} rw,
+
+  # Background/Autostart portal writing a new autostart entry
+  owner @{user_config_dirs}/autostart/ rw,
+  owner @{user_config_dirs}/autostart/*.desktop rw,
+  owner @{user_config_dirs}/autostart/*.desktop.@{rand6} rwl -> @{user_config_dirs}/autostart/*.desktop,
 
   owner @{tmp}/gtkprint@{rand6} r,
   owner @{tmp}/icon@{rand6} rw,

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
@@ -25,6 +25,9 @@ profile xdg-desktop-portal-gtk @{exec_path} flags=(attach_disconnected) {
   include <abstractions/sys/dmi>
   include <abstractions/thumbnails-cache-read>
 
+  capability dac_override,
+  capability dac_read_search,
+
   network inet stream,
 
   signal receive set=term peer=gdm,
@@ -54,6 +57,10 @@ profile xdg-desktop-portal-gtk @{exec_path} flags=(attach_disconnected) {
   owner @{user_config_dirs}/autostart/ w,
 
   owner @{tmp}/runtime-*/xauth_@{rand6} r,
+
+  # Not owner-scoped: this root-run instance's fsuid won't match the
+  # cookie's owning uid, same as nvidia-settings' equivalent rule
+  @{run}/user/@{uid}/xauth_@{rand6} r,
 
   @{run}/mount/utab r,
 

--- a/apparmor.d/groups/freedesktop/xdg-document-portal
+++ b/apparmor.d/groups/freedesktop/xdg-document-portal
@@ -17,12 +17,20 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
   include <abstractions/mime>
   include <abstractions/nameservice-strict>
 
+  capability dac_override,
+  capability setuid,
   capability sys_admin,
   capability sys_nice,
   capability sys_ptrace,
   capability sys_resource,
 
+  # Root-run instance (e.g. system-level portal) mounts/unmounts its fuse.portal
+  # directly via a "fuse mainloop" thread instead of transitioning through the
+  # setuid fusermount helper below, since it's already privileged
+  @{bin}/mount rix,
+
   mount fstype=fuse.portal -> @{run}/user/@{uid}/doc/,
+  umount @{run}/user/@{uid}/doc/,
 
   signal receive set=term peer=gdm,
   signal receive set=hup  peer=gdm-session-worker,
@@ -56,6 +64,14 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
 
   owner @{user_share_dirs}/flatpak/db/documents r,
   owner @{user_share_dirs}/Trash/files/** r,
+
+  # Portal receives fds for arbitrary user-picked files, including temp
+  # files apps generate under /tmp (e.g. Spectacle screenshots)
+  #aa:lint ignore=too-wide
+  owner @{tmp}/** r,
+
+  #aa:only fedora
+  /usr/share/kde-settings/kde-profile/default/xdg/kde-mimeapps.list r,
 
   owner @{run}/user/@{uid}/.flatpak/@{int}/bwrapinfo.json r,
   owner @{run}/user/@{uid}/doc/ rw,

--- a/apparmor.d/groups/freedesktop/xdg-mime
+++ b/apparmor.d/groups/freedesktop/xdg-mime
@@ -11,7 +11,10 @@ include <tunables/global>
 profile xdg-mime @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/common/xdg>
+  include <abstractions/kde-base>
   include <abstractions/mime>
+
+  capability mknod,
 
   @{exec_path} r,
 
@@ -25,6 +28,20 @@ profile xdg-mime @{exec_path} flags=(attach_disconnected) {
   owner @{user_config_dirs}/mimeapps.list{,.new} rw,
 
   owner @{tmp}/wl-copy-buffer-@{rand6}/stdin r,
+
+  # AppImage's own squashfuse-mounted runtime bundles its own glibc gconv
+  /tmp/.mount_*/shared/lib/gconv/gconv-modules r,
+
+  # AppImage's own bundled kbuildsycoca6 (a different binary path than
+  # groups/kde/kbuildsycoca) rebuilds the desktop/mime db from the mount
+  /tmp/.mount_*/share/mime/ r,
+  /tmp/.mount_*/share/mime/*/ r,
+  /tmp/.mount_*/share/mime/mime.cache r,
+  /tmp/.mount_*/share/mime/types r,
+  /etc/machine-id r,
+  @{PROC}/sys/kernel/random/boot_id r,
+  owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/mounts r,
 
   # file_inherit
   deny /opt/*/** r,

--- a/apparmor.d/groups/freedesktop/xdg-open
+++ b/apparmor.d/groups/freedesktop/xdg-open
@@ -14,7 +14,11 @@ profile xdg-open @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/app/open>
   include <abstractions/common/xdg>
+  include <abstractions/kde-base>
   include <abstractions/path>
+
+  capability dac_override,
+  capability dac_read_search,
 
   @{exec_path} r,
 
@@ -32,12 +36,16 @@ profile xdg-open @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   /usr/share/**                 PUx,
 
   @{PROC}/version r,
+  @{PROC}/@{pid}/mountinfo r,
+  @{PROC}/@{pid}/mounts r,
 
   profile bus flags=(attach_disconnected) {
     include <abstractions/base>
     include <abstractions/app/bus>
     include <abstractions/bus-session>
     include <abstractions/consoles>
+
+    owner @{tmp}/xauth.@{rand10} r, # file_inherit
 
     include if exists <local/xdg-open_bus>
   }

--- a/apparmor.d/groups/freedesktop/xdg-settings
+++ b/apparmor.d/groups/freedesktop/xdg-settings
@@ -11,16 +11,35 @@ include <tunables/global>
 profile xdg-settings @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/common/xdg>
+  include <abstractions/mime>
+
+  capability mknod,
 
   @{exec_path} r,
 
   @{bin}/dbus-send            Cx -> bus,
   @{bin}/kreadconfig{,5}      Px,
-  @{bin}/xdg-mime             Px,
   @{bin}/xprop                Px,
 
+  # Invoked under contexts that set no_new_privs (e.g. portal-spawned), which
+  # blocks the usual Px transition to the dedicated xdg-mime profile - see
+  # docs/development/internal.md "No New Privileges". Inherit instead, so
+  # bring in the rules xdg-mime itself needs (abstractions/mime, mknod,
+  # mimeapps.list) since they no longer come from the xdg-mime profile.
+  @{bin}/xdg-mime             rix,
+
+  owner @{user_config_dirs}/mimeapps.list{,.new} rw,
   owner @{user_config_dirs}/xfce4/helpers.rc{,.@{rand6}} rw,
   owner @{user_share_dirs}/applications/{,**} rw,
+
+  # kbuildsycoca6 inherits this profile for the same no_new_privs reason as
+  # xdg-mime above (portal-spawned context blocks the usual Px transition)
+  /etc/machine-id r,
+  owner @{user_cache_dirs}/#@{int} rw,
+
+  @{PROC}/@{pid}/mountinfo r,
+  @{PROC}/@{pid}/mounts r,
+  @{PROC}/sys/kernel/random/boot_id r,
 
   profile bus flags=(attach_disconnected) {
     include <abstractions/base>

--- a/apparmor.d/groups/freedesktop/xhost
+++ b/apparmor.d/groups/freedesktop/xhost
@@ -10,12 +10,11 @@ include <tunables/global>
 @{exec_path} = @{bin}/xhost
 profile xhost @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/nameservice-strict>
   include <abstractions/X-strict>
 
   @{exec_path} mr,
-
-  /dev/tty@{u8} rw,
 
   # Silencer
   deny @{user_share_dirs}/gvfs-metadata/* r,

--- a/apparmor.d/groups/freedesktop/xkbcomp
+++ b/apparmor.d/groups/freedesktop/xkbcomp
@@ -22,6 +22,7 @@ profile xkbcomp @{exec_path} flags=(attach_disconnected) {
 
   /usr/share/X11/xkb/** r,
   /usr/share/color/icc/{,**} r,
+  /usr/share/xwayland/protocol.txt r,  # file_inherit from Xwayland
 
   /var/lib/xkb/server-@{int}.xkm w,
   /var/lib/xkb/compiled/server-@{int}.xkm rw,

--- a/apparmor.d/groups/freedesktop/xorg
+++ b/apparmor.d/groups/freedesktop/xorg
@@ -20,6 +20,7 @@ profile xorg @{exec_path} flags=(attach_disconnected) {
   include <abstractions/graphics-full>
   include <abstractions/input>
   include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
 
   capability chown,
   capability dac_override,
@@ -70,6 +71,14 @@ profile xorg @{exec_path} flags=(attach_disconnected) {
   /usr/share/libinput*/{,**} r,
 
   /etc/X11/{,**} r,
+  /etc/egl/egl_external_platform.d/ r,
+
+  @{run}/udev/data/+auxiliary:* r,        # Auxiliary bus devices, e.g. acpi.video_bus
+
+  @{PROC}/[0-9]*/stat r,
+
+  # PCI ROM sysfs interface requires a write (echo 1) to unlock read access
+  @{sys}/devices/@{pci}/rom rw,
 
   owner @{HOME}/ r,
 

--- a/apparmor.d/groups/freedesktop/xprop
+++ b/apparmor.d/groups/freedesktop/xprop
@@ -18,6 +18,8 @@ profile xprop @{exec_path} flags=(attach_disconnected) {
 
   /usr/share/color/icc/{,**} r,
 
+  owner @{tmp}/xauth.@{rand10} r, # file_inherit
+
   include if exists <local/xprop>
 }
 

--- a/apparmor.d/groups/freedesktop/xrandr
+++ b/apparmor.d/groups/freedesktop/xrandr
@@ -18,7 +18,12 @@ profile xrandr @{exec_path} {
 
   @{run}/sddm/xauth_@{rand6} r,
 
+  # Not owner-scoped: this root-run instance's fsuid won't match the
+  # cookie's owning uid, same as nvidia-settings' equivalent rule
+  @{run}/user/@{uid}/xauth_@{rand6} r,
+
   owner /dev/tty@{u8} rw,
+  owner /dev/pts/@{int} rw, # file_inherit
 
   include if exists <local/xrandr>
 }

--- a/apparmor.d/groups/freedesktop/xwayland
+++ b/apparmor.d/groups/freedesktop/xwayland
@@ -32,6 +32,10 @@ profile xwayland @{exec_path} flags=(attach_disconnected) {
   /usr/share/fonts/{,**} r,
   /usr/share/ghostscript/fonts/{,**} r,
   /usr/share/color/icc/{,**} r,
+  /usr/share/xwayland/protocol.txt r,
+
+  /etc/egl/egl_external_platform.d/ r,
+  /etc/X11/fontpath.d/ r,
 
   / r,
 

--- a/apparmor.d/groups/gpg/dirmngr
+++ b/apparmor.d/groups/gpg/dirmngr
@@ -30,6 +30,7 @@ profile dirmngr @{exec_path} {
   owner @{HOME}/@{XDG_GPG_DIR}/crls.d/DIR.txt rw,
   owner @{HOME}/@{XDG_GPG_DIR}/dirmngr_ldapservers.conf r,
   owner @{HOME}/@{XDG_GPG_DIR}/dirmngr.conf r,
+  owner @{HOME}/@{XDG_GPG_DIR}/dirmngr.conf.gpgconf.@{int}.new r,
 
   owner @{MOUNTS}/{,/*}/@{XDG_GPG_DIR}/ rw,
   owner @{MOUNTS}/{,/*}/@{XDG_GPG_DIR}/common.conf r,

--- a/apparmor.d/groups/gpg/gpg
+++ b/apparmor.d/groups/gpg/gpg
@@ -16,6 +16,8 @@ profile gpg @{exec_path} flags=(attach_disconnected) {
   include <abstractions/user-read-strict>
 
   capability dac_read_search,
+  #aa:only fedora
+  capability mknod,
 
   network netlink raw,
 
@@ -46,6 +48,20 @@ profile gpg @{exec_path} flags=(attach_disconnected) {
 
   owner /var/lib/*/{,.}gnupg/ rw,
   owner /var/lib/*/{,.}gnupg/** rwlk -> /var/lib/*/{,.}gnupg/**,
+
+  # dnf5/libdnf5 repo signature verification: key material and repo cache
+  # files opened by the caller and inherited across the exec, plus dnf5's
+  # own tmp gnupg homedir (gnupg dotlock protocol needs the l/k bits).
+  #aa:only fedora
+  owner @{tmp}/key.@{rand6} rw,
+  #aa:only fedora
+  owner @{tmp}/librepo-tmp-@{rand6} rw,
+  #aa:only fedora
+  owner @{tmp}/libdnf5.@{rand6}/{,**} rwlk,
+  #aa:only fedora
+  /var/cache/libdnf5/**/repodata/* rw,
+  #aa:only fedora
+  @{lib}/sysimage/rpm/.rpm.lock w,
 
   # TODO: Remove after zypper profile is created
   #aa:only zypper

--- a/apparmor.d/groups/gpg/gpg-agent
+++ b/apparmor.d/groups/gpg/gpg-agent
@@ -26,6 +26,7 @@ profile gpg-agent @{exec_path} {
 
   owner @{HOME}/@{XDG_GPG_DIR}/ rw,
   owner @{HOME}/@{XDG_GPG_DIR}/*.conf r,
+  owner @{HOME}/@{XDG_GPG_DIR}/*.conf.gpgconf.@{int}.new r,
   owner @{HOME}/@{XDG_GPG_DIR}/private-keys-v1.d/ rw,
   owner @{HOME}/@{XDG_GPG_DIR}/private-keys-v1.d/@{hex}.key{,.tmp} rw,
   owner @{HOME}/@{XDG_GPG_DIR}/{,d.@{rand}/}S.gpg-agent{,.ssh,.browser,.extra} rw,

--- a/apparmor.d/groups/gpg/gpg-connect-agent
+++ b/apparmor.d/groups/gpg/gpg-connect-agent
@@ -12,11 +12,17 @@ profile gpg-connect-agent @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>
 
+  capability mknod,
+
   @{exec_path} mr,
 
   @{bin}/gpg-agent rPx,
 
   /etc/inputrc r,
+
+  owner @{HOME}/@{XDG_GPG_DIR}/.#lk0x@{hex}.*.@{pid} rw,
+  owner @{HOME}/@{XDG_GPG_DIR}/.#lk0x@{hex}.*.@{pid}x rwl -> @{HOME}/@{XDG_GPG_DIR}/.#lk0x@{hex}.*.@{pid},
+  owner @{HOME}/@{XDG_GPG_DIR}/gnupg_spawn_agent_sentinel.lock rwl -> @{HOME}/@{XDG_GPG_DIR}/.#lk0x@{hex}.*.@{pid},
 
   owner @{run}/user/@{uid}/gnupg/ w,
   owner @{run}/user/@{uid}/gnupg/d.*/ rw,

--- a/apparmor.d/groups/gpg/keyboxd
+++ b/apparmor.d/groups/gpg/keyboxd
@@ -16,6 +16,7 @@ profile keyboxd @{exec_path} {
   owner @{HOME}/@{XDG_GPG_DIR}/ w,
   owner @{HOME}/@{XDG_GPG_DIR}/common.conf r,
   owner @{HOME}/@{XDG_GPG_DIR}/keyboxd.conf r,
+  owner @{HOME}/@{XDG_GPG_DIR}/keyboxd.conf.gpgconf.@{int}.new r,
   owner @{HOME}/@{XDG_GPG_DIR}/public-keys.d/ rw,
   owner @{HOME}/@{XDG_GPG_DIR}/public-keys.d/* rwlk,
 

--- a/apparmor.d/groups/gpg/scdaemon
+++ b/apparmor.d/groups/gpg/scdaemon
@@ -35,6 +35,7 @@ profile scdaemon @{exec_path} {
   /var/tmp/zypp.tmp/zypp.@{rand6}/zypp-trusted-*/S.scdaemon w,
 
   owner @{HOME}/@{XDG_GPG_DIR}/scdaemon.conf r,
+  owner @{HOME}/@{XDG_GPG_DIR}/scdaemon.conf.gpgconf.@{int}.new r,
   owner @{HOME}/@{XDG_GPG_DIR}/common.conf r,
   owner @{HOME}/@{XDG_GPG_DIR}/reader_@{int}.status rw,
 

--- a/apparmor.d/groups/kde/ark
+++ b/apparmor.d/groups/kde/ark
@@ -1,0 +1,45 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/ark
+profile ark @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  @{bin}/bsdtar   Px,
+  @{bin}/7z       Px,
+  @{bin}/unrar    Px,
+  @{bin}/unzip    Px,
+  @{bin}/zip      Px,
+  @{bin}/gzip     Px,
+  @{bin}/bzip2    Px,
+  @{bin}/xz       Px,
+  @{bin}/zstd     Px,
+
+  /usr/share/ark/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/mime/{,**} r,
+  /usr/share/kf6/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_config_dirs}/arkrc r,
+  owner @{user_share_dirs}/ark/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /tmp/ r,
+  owner @{tmp}/ark-* rw,
+
+  include if exists <local/ark>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/gwenview
+++ b/apparmor.d/groups/kde/gwenview
@@ -1,0 +1,33 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/gwenview @{bin}/gwenview_importer
+profile gwenview @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/gwenview/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/mime/{,**} r,
+  /usr/share/kf6/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_share_dirs}/gwenview/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  /media/{,**} r,
+  @{run}/media/{,**} r,
+
+  include if exists <local/gwenview>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/kate
+++ b/apparmor.d/groups/kde/kate
@@ -1,0 +1,35 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/kate
+profile kate @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/kate/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/kf6/{,**} r,
+  /usr/share/ktexteditor/{,**} r,
+  /usr/share/mime/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{HOME}/{,**} rw,
+  owner @{user_config_dirs}/katerc r,
+  owner @{user_share_dirs}/kate/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/kate>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/kcalc
+++ b/apparmor.d/groups/kde/kcalc
@@ -1,0 +1,29 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/kcalc
+profile kcalc @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/kcalc/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/kf6/{,**} r,
+
+  owner @{user_config_dirs}/kcalcrc r,
+  owner @{user_share_dirs}/kcalc/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/kcalc>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/kinfocenter
+++ b/apparmor.d/groups/kde/kinfocenter
@@ -1,0 +1,36 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/kinfocenter
+profile kinfocenter @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/kinfocenter/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/kf6/{,**} r,
+
+  @{sys}/devices/{,**} r,
+  @{sys}/class/{,**} r,
+  @{sys}/bus/{,**} r,
+  @{sys}/firmware/dmi/tables/{,*} r,
+
+  @{PROC}/version r,
+  @{PROC}/@{pids}/status r,
+
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/kinfocenter>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/kmenuedit
+++ b/apparmor.d/groups/kde/kmenuedit
@@ -1,0 +1,33 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/kmenuedit
+profile kmenuedit @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/applications/{,**.desktop} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/kf6/{,**} r,
+  /usr/share/kmenuedit/{,**} r,
+
+  @{etc_ro}/xdg/{,**} r,
+
+  owner @{user_config_dirs}/menus/{,**} rw,
+  owner @{user_share_dirs}/applications/{,**.desktop} rw,
+  owner @{user_share_dirs}/desktop-directories/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+
+  include if exists <local/kmenuedit>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/kscreenlocker_greet
+++ b/apparmor.d/groups/kde/kscreenlocker_greet
@@ -65,6 +65,13 @@ profile kscreenlocker_greet @{exec_path} {
   /etc/xdg/kscreenlockerrc r,
   /etc/xdg/plasmarc r,
 
+  # authselect's generated PAM stack, read via /etc/pam.d/* symlinks on Fedora
+  #aa:only fedora
+  @{etc_ro}/authselect/fingerprint-auth r,
+  @{etc_ro}/authselect/password-auth r,
+  @{etc_ro}/authselect/postlogin r,
+  @{etc_ro}/authselect/smartcard-auth r,
+
   / r,
 
   /var/lib/AccountsService/icons/* r,
@@ -105,6 +112,8 @@ profile kscreenlocker_greet @{exec_path} {
 
   @{sys}/devices/system/node/ r,
   @{sys}/devices/system/node/node@{int}/meminfo r,
+  @{sys}/devices/virtual/sound/seq/uevent r,
+  @{sys}/devices/virtual/sound/timer/uevent r,
 
         @{PROC}/@{pids}/cgroup r,
         @{PROC}/@{pids}/cmdline r,

--- a/apparmor.d/groups/kde/ksecretd
+++ b/apparmor.d/groups/kde/ksecretd
@@ -11,6 +11,7 @@ profile ksecretd @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/kde-strict>
   include <abstractions/graphics>
+  include <abstractions/openssl>
 
   #aa:dbus own bus=session name=org.freedesktop.impl.portal.desktop.kwallet
   #aa:dbus own bus=session name=org.freedesktop.secrets

--- a/apparmor.d/groups/kde/kwalletd
+++ b/apparmor.d/groups/kde/kwalletd
@@ -46,6 +46,9 @@ profile kwalletd @{exec_path} {
 
   owner @{tmp}/kwalletd5.* rw,
 
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
   owner @{PROC}/@{pid}/cmdline r,
   owner @{PROC}/@{pid}/fd/ r,
 

--- a/apparmor.d/groups/kde/kwalletmanager
+++ b/apparmor.d/groups/kde/kwalletmanager
@@ -34,6 +34,8 @@ profile kwalletmanager @{exec_path} {
   owner @{user_config_dirs}/kwalletrc.* rwl -> @{user_config_dirs}/#@{int},
   owner @{user_config_dirs}/kwalletrc.lock rwk,
 
+  owner @{user_state_dirs}/kwalletmanagerstaterc r,
+
         @{PROC}/@{pid}/mountinfo r,
         @{PROC}/@{pid}/mounts r,
   owner @{PROC}/@{pid}/cmdline r,

--- a/apparmor.d/groups/kde/okular
+++ b/apparmor.d/groups/kde/okular
@@ -32,6 +32,8 @@ profile okular @{exec_path} {
 
   @{exec_path} mr,
 
+  /dev/tty r,
+
   @{bin}/testparm  rix,
   @{bin}/net       rix,
   @{bin}/ps2pdf   rPUx,
@@ -45,6 +47,7 @@ profile okular @{exec_path} {
 
   /usr/share/color-schemes/{,**} r,
   /usr/share/okular/{,**} r,
+  /usr/share/templates/ r,
   /usr/share/thumbnailers/{,**} r,
 
   /etc/exports r,
@@ -52,7 +55,10 @@ profile okular @{exec_path} {
   /etc/xdg/dolphinrc r,
 
   / r,
-  @{MOUNTS}/ r,
+  @{MOUNTDIRS}/ r,
+  @{MOUNTS}/ rw,
+  @{MOUNTS}/** rw,
+  @{run}/mount/utab r,
 
   owner @{user_cache_dirs}/kcrash-metadata/okular.*.ini w,
   owner @{user_cache_dirs}/okular/{,**} rw,
@@ -92,6 +98,7 @@ profile okular @{exec_path} {
   owner @{run}/user/@{uid}/#@{int} rw,
   owner @{run}/user/@{uid}/okular@{rand6}.@{int}.kioworker.socket rwl,
 
+  @{run}/udev/data/b8:@{int} r,       # for /dev/sd*
   @{run}/udev/data/b259:@{int} r,     # Block Extended Major
 
   owner @{PROC}/@{pid}/fd/ r,

--- a/apparmor.d/groups/kde/plasma-emojier
+++ b/apparmor.d/groups/kde/plasma-emojier
@@ -17,7 +17,10 @@ profile plasma-emojier @{exec_path} {
 
   /usr/share/plasma/emoji/*.dict r,
 
-  owner @{user_cache_dirs}/qtshadercache-@{arch}-little_endian-lp64/@{hex38}@{int2} rwk,
+  /dev/tty r,
+  @{bin}/ r,
+
+  owner @{user_cache_dirs}/qtshadercache-@{arch}-little_endian-lp64/@{hex} rwk,
   owner @{user_cache_dirs}/plasma.emojier/ rw,
   owner @{user_cache_dirs}/plasma.emojier/** rwlk,
 

--- a/apparmor.d/groups/kde/spectacle
+++ b/apparmor.d/groups/kde/spectacle
@@ -1,0 +1,31 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/spectacle
+profile spectacle @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/graphics>
+  include <abstractions/kde-strict>
+
+  @{exec_path} mr,
+
+  /usr/share/spectacle/{,**} r,
+  /usr/share/icons/{,**} r,
+  /usr/share/kf6/{,**} r,
+
+  owner @{HOME}/Pictures/{,**} rw,
+  owner @{user_config_dirs}/spectaclerc r,
+  owner @{user_share_dirs}/spectacle/{,**} rw,
+  owner @{run}/user/@{uid}/wayland-* rw,
+  owner @{tmp}/spectacle-* rw,
+
+  include if exists <local/spectacle>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/kde/xwaylandvideobridge
+++ b/apparmor.d/groups/kde/xwaylandvideobridge
@@ -18,6 +18,9 @@ profile xwaylandvideobridge @{exec_path} {
   /usr/share/color-schemes/{,*} r,
 
   /etc/machine-id r,
+  /etc/egl/egl_external_platform.d/ r,
+
+  /dev/tty r,
 
   owner @{user_cache_dirs}/xwaylandvideobridge/ rw,
   owner @{user_cache_dirs}/xwaylandvideobridge/** rwk,

--- a/apparmor.d/groups/network/nm-dispatcher
+++ b/apparmor.d/groups/network/nm-dispatcher
@@ -68,11 +68,19 @@ profile nm-dispatcher @{exec_path} flags=(attach_disconnected) {
   /etc/NetworkManager/dispatcher.d/ r,
   /etc/NetworkManager/dispatcher.d/** rix,
   /etc/dhcp/dhclient-exit-hooks.d/ntp r,
+  /etc/dhcp/dhclient.d/ r,
+  /etc/dhcp/dhclient.d/*.sh rix,
 
   /usr/share/tlp/{,**} rw,
 
   /etc/fstab r,
   /etc/ntp.conf r,
+
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
+  # Also used by openSUSE (shared SUSE/RHEL sysconfig convention)
+  /etc/sysconfig/network r,
   /etc/sysconfig/network/config r,
 
   / r,

--- a/apparmor.d/groups/network/nm-online
+++ b/apparmor.d/groups/network/nm-online
@@ -25,6 +25,9 @@ profile nm-online @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
   include if exists <local/nm-online>
 }
 

--- a/apparmor.d/groups/polkit/pkexec
+++ b/apparmor.d/groups/polkit/pkexec
@@ -27,6 +27,7 @@ profile pkexec @{exec_path} {
   /usr/share/**  PUx,
 
   /etc/default/locale r,
+  /etc/machine-id r,
 
         @{PROC}/@{pid}/cgroup r,
         @{PROC}/@{pid}/stat r,

--- a/apparmor.d/groups/polkit/polkit-agent-helper
+++ b/apparmor.d/groups/polkit/polkit-agent-helper
@@ -19,6 +19,7 @@ profile polkit-agent-helper @{exec_path} flags=(attach_disconnected) {
   capability audit_write,
   capability chown,
   capability dac_override,
+  capability dac_read_search,
   capability fowner,
   capability net_admin,
   capability setgid,

--- a/apparmor.d/groups/polkit/polkitd
+++ b/apparmor.d/groups/polkit/polkitd
@@ -31,8 +31,8 @@ profile polkitd @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
-  @{bin}/pkla-check-authorization  rPx,
-  @{bin}/pkla-admin-identities     rPx,
+  @{bin}/pkla-check-authorization  rix,
+  @{bin}/pkla-admin-identities     rix,
 
   /usr/share/gvfs/remote-volume-monitors/{,**} r,
   /usr/share/polkit-1/polkitd.conf r,
@@ -50,6 +50,8 @@ profile polkitd @{exec_path} flags=(attach_disconnected) {
   /usr/share/polkit-1/rules.d/ r,
   /usr/share/polkit-1/rules.d/*.rules r,
   /usr/share/polkit-1/rules.d/*.rules.example r,
+  #aa:only fedora
+  /usr/share/polkit-1/rules.d/*.rules.choice r,
 
   # Vendor policies
   /usr/share/polkit-1/actions/ r,

--- a/apparmor.d/groups/procps/pkill
+++ b/apparmor.d/groups/procps/pkill
@@ -12,6 +12,7 @@ profile pkill @{exec_path} {
   include <abstractions/app/pgrep>
 
   capability kill,
+  capability dac_read_search,
 
   signal send,
 

--- a/apparmor.d/groups/systemd/systemd-backlight
+++ b/apparmor.d/groups/systemd/systemd-backlight
@@ -28,6 +28,8 @@ profile systemd-backlight @{exec_path} flags=(attach_disconnected) {
 
   @{sys}/devices/@{pci}/ r,
   @{sys}/devices/@{pci}/class r,
+  @{sys}/devices/pci@{hex4}:@{hex2}/uevent r,
+  @{sys}/devices/pci@{hex4}:@{hex2}/**/uevent r,
 
   include if exists <local/systemd-backlight>
 }

--- a/apparmor.d/groups/systemd/systemd-coredump
+++ b/apparmor.d/groups/systemd/systemd-coredump
@@ -13,6 +13,7 @@ profile systemd-coredump @{exec_path} flags=(attach_disconnected,mediate_deleted
   include <abstractions/bus-system>
   include <abstractions/common/systemd>
   include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
 
   userns,
 
@@ -46,9 +47,11 @@ profile systemd-coredump @{exec_path} flags=(attach_disconnected,mediate_deleted
 
   /etc/systemd/coredump.conf r,
   /etc/systemd/coredump.conf.d/{,**} r,
+  /etc/login.defs r,
 
   owner @{HOME}/**.so* r,
   owner @{HOME}/.var/app/*/** r, # Crash from flatpak apps
+  owner @{user_share_dirs}/Steam/compatibilitytools.d/*/files/lib/wine/@{arch}-unix/wine{,-preloader} r,
 
   /var/lib/systemd/coredump/{,**} rwl,
 

--- a/apparmor.d/groups/systemd/systemd-journald
+++ b/apparmor.d/groups/systemd/systemd-journald
@@ -34,6 +34,7 @@ profile systemd-journald @{exec_path} flags=(attach_disconnected,mediate_deleted
 
   /etc/systemd/journald.conf r,
   /etc/systemd/journald.conf.d/{,**} r,
+  /etc/login.defs r,
 
   /{run,var}/log/ w,
   /{run,var}/log/journal/ rw,

--- a/apparmor.d/groups/systemd/systemd-logind
+++ b/apparmor.d/groups/systemd/systemd-logind
@@ -44,6 +44,7 @@ profile systemd-logind @{exec_path} flags=(attach_disconnected,mediate_deleted) 
   @{exec_path} mr,
 
   /etc/machine-id r,
+  /etc/login.defs r,
   /etc/systemd/logind.conf r,
   /etc/systemd/logind.conf.d/{,**} r,
   /etc/systemd/sleep.conf r,

--- a/apparmor.d/groups/systemd/systemd-run
+++ b/apparmor.d/groups/systemd/systemd-run
@@ -1,0 +1,46 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+# run0 is a symlink to systemd-run; both use this profile
+@{exec_path} = @{bin}/systemd-run @{bin}/run0
+profile systemd-run @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/app-launcher-root>
+  include <abstractions/bus-system>
+  include <abstractions/nameservice-strict>
+
+  capability setuid,
+  capability setgid,
+  capability sys_ptrace,
+
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  @{bin}/@{shells}  rUx,
+  @{bin}/**         PUx,
+  @{lib}/**         PUx,
+
+  @{etc_ro}/login.defs r,
+  /etc/passwd r,
+  /etc/machine-id r,
+
+  @{run}/systemd/private/ r,
+  @{run}/systemd/transient/ rw,
+
+  @{PROC}/@{pid}/loginuid r,
+  @{PROC}/@{pid}/stat r,
+  @{PROC}/sys/kernel/osrelease r,
+
+  /dev/ptmx rwk,
+  /dev/tty rwk,
+
+  include if exists <local/systemd-run>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sysusers
+++ b/apparmor.d/groups/systemd/systemd-sysusers
@@ -14,6 +14,8 @@ profile systemd-sysusers @{exec_path} flags=(attach_disconnected) {
 
   capability audit_write,
   capability chown,
+  capability dac_override,
+  capability dac_read_search,
   capability fsetid,
   capability net_admin,
 
@@ -38,7 +40,12 @@ profile systemd-sysusers @{exec_path} flags=(attach_disconnected) {
   @{run}/{,**} rw,
 
   /etc/ r,
+  /etc/login.defs r,
   /etc/nsswitch.conf r,
+
+  # On systems with authselect installed, /etc/nsswitch.conf is a symlink to /etc/authselect/nsswitch.conf
+  #aa:only fedora
+  /etc/authselect/nsswitch.conf r,
   /etc/{passwd,shadow} rw,
   /etc/{passwd,shadow}- rw,
   /etc/{passwd,shadow}+ rw,

--- a/apparmor.d/groups/systemd/systemd-user-runtime-dir
+++ b/apparmor.d/groups/systemd/systemd-user-runtime-dir
@@ -32,6 +32,7 @@ profile systemd-user-runtime-dir @{exec_path} flags=(attach_disconnected) {
   @{exec_path} mr,
 
   /etc/machine-id r,
+  /etc/login.defs r,
 
   /dev/shm/ r,
   /tmp/ r,

--- a/apparmor.d/groups/systemd/systemd-userdbd
+++ b/apparmor.d/groups/systemd/systemd-userdbd
@@ -27,6 +27,7 @@ profile systemd-userdbd @{exec_path} flags=(attach_disconnected,mediate_deleted)
 
   /etc/gshadow r,
   /etc/shadow r,
+  /etc/login.defs r,
 
   /etc/machine-id r,
   /etc/userdb/{,**} r,

--- a/apparmor.d/groups/utils/agetty
+++ b/apparmor.d/groups/utils/agetty
@@ -35,6 +35,9 @@ profile agetty @{exec_path} {
   /etc/inittab r,
   /etc/os-release r,
 
+  # cockpit is packaged for Fedora, RHEL, Debian, Ubuntu and openSUSE alike
+  @{run}/cockpit/{,motd,active.issue,inactive.issue} r,
+
         @{run}/credentials/serial-getty@hvc@{int}.service/ r,
         @{run}/credentials/getty@tty@{int}.service/ r,
         @{run}/credentials/serial-getty@ttyS@{int}.service/ r,

--- a/apparmor.d/groups/utils/nproc
+++ b/apparmor.d/groups/utils/nproc
@@ -18,6 +18,7 @@ profile nproc @{exec_path} flags=(attach_disconnected) {
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/cpu.max r,
         @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/cpu.max r,
   owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/cpu.max r,
+  owner @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/**/cpu.max r,
 
   owner @{PROC}/@{pid}/cgroup r,
 

--- a/apparmor.d/groups/utils/uname
+++ b/apparmor.d/groups/utils/uname
@@ -16,6 +16,20 @@ profile uname @{exec_path} flags=(attach_disconnected) {
 
   @{att}/dev/tty@{u8} rw,
 
+  /dev/pts/[0-9]* rwk,
+
+  # Steam's pressure-vessel container runtime
+  /var/pressure-vessel/ldso/ld.so.cache r,
+
+  # Steam LD_PRELOADs its overlay into every child it spawns, including
+  # trivial uname invocations made by game launchers/wrappers
+  owner @{steam_share_dirs}/**/gameoverlayrenderer.so r,
+
+  # Flatpak's host-compat runtime layer bind-mounts host libs under /run/host;
+  # /usr/lib64 is the RPM multilib convention, shared by Fedora and openSUSE
+  #aa:only fedora opensuse
+  @{run}/host/usr/lib64/libc.so.6 mr,
+
   # File Inherit
   deny network,
   deny owner @{user_share_dirs}/gvfs-metadata/* r,

--- a/apparmor.d/profiles-a-f/alsactl
+++ b/apparmor.d/profiles-a-f/alsactl
@@ -15,12 +15,15 @@ profile alsactl @{exec_path} {
 
   @{exec_path} mr,
 
+  /etc/alsa/alsactl.conf r,
+
   /var/lib/alsa/asound.state rw,
   /var/lib/alsa/asound.state{,.*} rw,
 
         @{run}/lock/asound.state.lock rwk,
         @{run}/lock/card@{int}.lock rwk,
   owner @{run}/alsa/{,**} rw,
+  @{run}/alsactl.pid rw,
 
   @{sys}/devices/@{pci}/subsystem_device r,
   @{sys}/devices/@{pci}/subsystem_vendor r,

--- a/apparmor.d/profiles-a-f/aria2
+++ b/apparmor.d/profiles-a-f/aria2
@@ -1,0 +1,32 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/aria2c
+profile aria2 @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+
+  @{exec_path} mr,
+
+  @{etc_ro}/aria2/{,*} r,
+
+  owner @{HOME}/Downloads/{,**} rw,
+  owner @{HOME}/.aria2/{,**} rw,
+  owner @{user_config_dirs}/aria2/{,**} rw,
+
+  owner @{tmp}/aria2-* rw,
+
+  include if exists <local/aria2>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/doas
+++ b/apparmor.d/profiles-a-f/doas
@@ -1,0 +1,45 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/doas
+profile doas @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/app-launcher-root>
+  include <abstractions/authentication>
+  include <abstractions/consoles>
+  include <abstractions/nameservice-strict>
+
+  capability audit_write,
+  capability dac_override,
+  capability dac_read_search,
+  capability setgid,
+  capability setuid,
+  capability sys_resource,
+
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  @{bin}/@{shells}  rUx,
+  @{lib}/**         PUx,
+  /opt/*/**         PUx,
+
+  @{etc_ro}/doas.conf r,
+  @{etc_ro}/login.defs r,
+  /etc/passwd r,
+
+  @{PROC}/@{pid}/loginuid r,
+  @{PROC}/@{pid}/stat r,
+
+  /dev/ptmx rwk,
+  /dev/tty rwk,
+
+  include if exists <local/doas>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-a-f/ffprobe
+++ b/apparmor.d/profiles-a-f/ffprobe
@@ -12,6 +12,8 @@ profile ffprobe @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>
   include <abstractions/dri-common>
+  include <abstractions/graphics>
+  include <abstractions/ssl_certs>
   include <abstractions/user-download-strict>
 
   @{exec_path} mr,

--- a/apparmor.d/profiles-a-f/fwupd
+++ b/apparmor.d/profiles-a-f/fwupd
@@ -23,6 +23,9 @@ profile fwupd @{exec_path} flags=(attach_disconnected) {
   include <abstractions/sqlite>
   include <abstractions/tpm>
 
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/gnutls.config r,
+
   capability dac_override,
   capability dac_read_search,
   capability linux_immutable,

--- a/apparmor.d/profiles-g-l/gamemoded
+++ b/apparmor.d/profiles-g-l/gamemoded
@@ -21,6 +21,8 @@ profile gamemoded @{exec_path} flags=(attach_disconnected) {
 
   /etc/ r,
   /etc/gamemode.ini r,
+  /usr/share/gamemode/ r,
+  /usr/share/gamemode/gamemode.ini r,
 
   owner @{HOME}/ r,
   owner @{user_config_dirs}/ r,

--- a/apparmor.d/profiles-g-l/git
+++ b/apparmor.d/profiles-g-l/git
@@ -28,7 +28,9 @@ profile git @{exec_path} flags=(attach_disconnected) {
 
   @{pager_path}      Px -> child-pager,
 
-  @{bin}/gh          Px,
+  # PUx, not Px: no dedicated gh/glab profile exists in this project
+  @{bin}/gh          PUx,
+  @{bin}/glab        PUx,
   @{bin}/man         Px,
   @{bin}/meld       PUx,
   @{lib}/code/extensions/git/dist/askpass.sh     Px,
@@ -42,6 +44,10 @@ profile git @{exec_path} flags=(attach_disconnected) {
   @{bin}/gpg{,2}         Cx -> &git//gpg,
   @{bin}/ssh            rCx -> &git//ssh,
   @{bin}/ssh.hmac         r,
+
+  # HTTPS credential prompts (askpass) can invoke this even outside the ssh
+  # child hat - confirmed denied under the top-level git profile itself.
+  @{bin}/ksshaskpass    rPx,
 
   /usr/share/libalternatives/{,**} r,
   /usr/share/terminfo/** r,
@@ -121,7 +127,7 @@ profile git @{exec_path} flags=(attach_disconnected) {
     @{bin}/ssh mr,
     @{bin}/ssh.hmac r,
 
-    @{bin}/ksshaskpass ix,
+    @{bin}/ksshaskpass rPx,
     @{lib}/code/extensions/git/dist/ssh-askpass.sh Px,
 
     @{etc_ro}/ssh/ssh_config.d/{,*} r,
@@ -159,6 +165,7 @@ profile git @{exec_path} flags=(attach_disconnected) {
     owner @{user_projects_dirs}/**/ r,
     owner @{user_projects_dirs}/**/.git/@{int} rw,
     owner @{user_projects_dirs}/**/.git/*MSG rw,
+    owner @{user_projects_dirs}/**/.git/rebase-merge/{,**} rw,
 
     # The git repository files
     owner @{user_build_dirs}/ r,

--- a/apparmor.d/profiles-g-l/gparted
+++ b/apparmor.d/profiles-g-l/gparted
@@ -52,6 +52,7 @@ profile gparted @{exec_path} flags=(attach_disconnected) {
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-*-@{int}.scope/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-*-@{int}.scope/*/cpu.max r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-{c,}@{int}.scope/cpu.max r,
 
   @{PROC}/@{pids}/cmdline r,
   @{PROC}/@{pids}/stat r,

--- a/apparmor.d/profiles-g-l/gpartedbin
+++ b/apparmor.d/profiles-g-l/gpartedbin
@@ -49,6 +49,7 @@ profile gpartedbin @{exec_path} flags=(attach_disconnected) {
   @{sbin}/e2fsck    rPx,
   @{sbin}/e2image   rPx,
   @{sbin}/e2label   rPx,
+  @{sbin}/dump.exfat rix,
   @{bin}/exfatfsck  rix,
   @{sbin}/fatlabel  rPx,
   @{sbin}/fsck.*    rPUx,
@@ -87,11 +88,13 @@ profile gpartedbin @{exec_path} flags=(attach_disconnected) {
 
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-gparted@@{hex32}.service/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/cpu.max r,
-  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-@{int}.scope/cpu.max r,
+  @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/session-{c,}@{int}.scope/cpu.max r,
+  @{sys}/fs/cgroup/user.slice/user-0.slice/session-{c,}@{int}.scope/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-*-@{int}.scope/cpu.max r,
   @{sys}/fs/cgroup/user.slice/user-@{uid}.slice/user@@{uid}.service/app.slice/app-*-@{int}.scope/*/cpu.max r,
 
         @{PROC}/devices r,
+        @{PROC}/mdstat r,
         @{PROC}/partitions r,
         @{PROC}/swaps r,
         @{PROC}/version r,
@@ -138,7 +141,7 @@ profile gpartedbin @{exec_path} flags=(attach_disconnected) {
     @{bin}/umount mr,
 
     owner @{run}/mount/ rw,
-    owner @{run}/mount/utab{,.*} rw,
+    owner @{run}/mount/utab{,.*} rwk,
     owner @{run}/mount/utab.lock wk,
 
     owner @{PROC}/@{pid}/mountinfo r,

--- a/apparmor.d/profiles-g-l/gssproxy
+++ b/apparmor.d/profiles-g-l/gssproxy
@@ -11,6 +11,10 @@ profile gssproxy @{exec_path} {
   include <abstractions/base>
   include <abstractions/authentication>
   include <abstractions/nameservice-strict>
+  include <abstractions/openssl>
+
+  capability mknod,
+  capability net_admin,
 
   @{exec_path} mr,
 
@@ -18,9 +22,13 @@ profile gssproxy @{exec_path} {
 
   /etc/gssproxy/{,**} r,
 
+  #aa:only fedora
+  /etc/crypto-policies/back-ends/krb5.config r,
+
   owner /var/lib/gssproxy/{,**} rw,
   owner @{run}/gssproxy.pid rw,
   owner @{run}/gssproxy.sock rw,
+  owner @{run}/gssproxy.default.sock rw,
 
   owner @{PROC}/@{pids}/net/rpc/use-gss-proxy rw,
 

--- a/apparmor.d/profiles-g-l/heroic
+++ b/apparmor.d/profiles-g-l/heroic
@@ -1,0 +1,75 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{name} = heroic
+@{domain} = org.chromium.Chromium
+@{lib_dirs} = /opt/@{name}/ @{lib}/@{name}/
+@{config_dirs} = @{user_config_dirs}/@{name}
+@{cache_dirs} = @{user_cache_dirs}/@{name}
+@{wineprefix_dirs} = @{HOME}/Games/Heroic/Prefixes/*/
+
+@{exec_path} = @{bin}/heroic @{lib_dirs}/heroic
+profile heroic @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/audio-client>
+  include <abstractions/common/electron>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+  include <abstractions/screensaver>
+  include <abstractions/ssl_certs>
+  include <abstractions/user-download-strict>
+  include <abstractions/vulkan-strict>
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  @{exec_path} mrix,
+  @{sh_path}    rix,
+
+  @{lib_dirs}/chrome-sandbox rix,
+
+  # Bundled backend CLIs (legendary/gogdl/nile), vendored inside heroic's own
+  # resources dir rather than separately packaged, so rix instead of a transition
+  @{lib_dirs}/resources/app.asar.unpacked/**/legendary{,.exe} rix,
+  @{lib_dirs}/resources/app.asar.unpacked/**/gogdl{,.exe} rix,
+  @{lib_dirs}/resources/app.asar.unpacked/**/nile{,.exe} rix,
+  @{lib_dirs}/resources/app.asar.unpacked/**/comet{,.exe} rix,
+  @{lib_dirs}/resources/app.asar.unpacked/**/vulkan-helper rix,
+
+  # Launching games goes through umu-run (Proton/Wine) or native binaries.
+  @{bin}/umu-run                    Px,
+  owner @{wineprefix_dirs}/ rw,
+  owner @{wineprefix_dirs}/** rwlk,
+
+  @{open_path} rPx -> child-open-strict,
+
+  /etc/ r,
+
+  owner @{HOME}/Games/{,**} rw,
+
+  owner @{config_dirs}/{,**} rwk,
+  owner @{cache_dirs}/{,**} rwk,
+
+  owner @{user_config_dirs}/autostart/heroic.desktop rw,
+
+  owner "@{tmp}/Heroic Crashes/" rw,
+  owner @{tmp}/heroic.sock rw,
+
+  owner @{run}/user/@{uid}/heroic-ipc-@{int} rw,
+
+  owner @{PROC}/@{pid}/mem r,
+
+  deny ptrace read,
+
+  include if exists <local/heroic>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/iw
+++ b/apparmor.d/profiles-g-l/iw
@@ -14,8 +14,8 @@ profile iw @{exec_path} {
   # To be able to manage network interfaces.
   capability net_admin,
 
-  # Needed?
-  audit deny capability sys_module,
+  # Needed to autoload the regulatory-domain database (e.g. `iw reg set`)
+  capability sys_module,
 
   network netlink raw,
 

--- a/apparmor.d/profiles-g-l/kmod
+++ b/apparmor.d/profiles-g-l/kmod
@@ -18,6 +18,9 @@ profile kmod @{exec_path} flags=(attach_disconnected) {
   capability mknod,
   capability net_admin,
   capability sys_module,
+  capability sys_admin,
+  capability bpf,
+  capability perfmon,
   capability syslog,
 
   network inet raw,

--- a/apparmor.d/profiles-g-l/ksshaskpass
+++ b/apparmor.d/profiles-g-l/ksshaskpass
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/ksshaskpass
+profile ksshaskpass @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/common/xdg>
+  include <abstractions/consoles>
+  include <abstractions/kde-strict>
+  include <abstractions/nameservice-strict>
+  include <abstractions/qt5-compose-cache-write>
+
+  @{exec_path} mr,
+
+  owner @{tmp}/xauth_@{rand6} r,
+  owner /dev/shm/#@{int} rw,
+
+  owner @{PROC}/@{pid}/cmdline r,
+
+  include if exists <local/ksshaskpass>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-g-l/logrotate
+++ b/apparmor.d/profiles-g-l/logrotate
@@ -55,6 +55,8 @@ profile logrotate @{exec_path} flags=(attach_disconnected) {
   /etc/ r,
   @{etc_ro}/logrotate.conf rk,
   @{etc_ro}/logrotate.d/ r,
+  @{etc_ro}/popt.d/ r,
+  @{etc_ro}/popt.d/* r,
   @{etc_ro}/rc*.d/ r,
   @{etc_ro}/logrotate.d/* rk,
 
@@ -64,6 +66,8 @@ profile logrotate @{exec_path} flags=(attach_disconnected) {
 
   /var/lib/{,misc/}logrotate/status rwk,
   /var/lib/{,misc/}logrotate/status.tmp rw,
+  /var/lib/{,misc/}logrotate/logrotate.status rwk,
+  /var/lib/{,misc/}logrotate/logrotate.status.tmp rw,
   /var/lib/{,misc/}logrotate.status rwk,
   /var/lib/{,misc/}logrotate.status.tmp rw,
 

--- a/apparmor.d/profiles-g-l/lsb-release
+++ b/apparmor.d/profiles-g-l/lsb-release
@@ -38,6 +38,13 @@ profile lsb-release @{exec_path} flags=(attach_disconnected) {
   @{etc_ro}/lsb-release r,
   @{etc_ro}/lsb-release.d/{,*} r,
 
+  /dev/pts/[0-9]* rwk,
+
+  # Invoked from inside an AppImage's own mounted runtime (squashfuse mount
+  # under /tmp/.mount_<name+hash>/), which bundles its own glibc gconv
+  # modules. Wildcarded since the name+hash varies per AppImage.
+  /tmp/.mount_*/shared/lib/gconv/gconv-modules r,
+
   # file_inherit
   deny /opt/*/** r,
   deny owner @{user_config_dirs}/*/** r,

--- a/apparmor.d/profiles-m-r/mangoapp
+++ b/apparmor.d/profiles-m-r/mangoapp
@@ -1,0 +1,49 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# MangoHud itself is a Vulkan/OpenGL layer (mangohud.so) preloaded into the
+# game's own process via LD_PRELOAD - it runs inside whatever profile confines
+# the game, not a profile of its own. mangoapp is the standalone overlay
+# window process (used under gamescope) that the preloaded layer talks to
+# over a local socket, and is the only independently-exec'd MangoHud binary.
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{config_dirs} = @{user_config_dirs}/MangoHud
+@{cache_dirs} = @{user_cache_dirs}/mangoapp
+
+@{exec_path} = @{bin}/mangoapp
+profile mangoapp @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+  include <abstractions/vulkan-strict>
+  include <abstractions/wayland-strict>
+
+  @{exec_path} mr,
+
+  /etc/ r,
+  /etc/xdg/MangoHud/{,**} r,
+
+  owner @{config_dirs}/{,**} r,
+  owner @{cache_dirs}/{,**} rw,
+
+  owner @{user_share_dirs}/fonts/{,**} r,
+  /usr/share/fonts/{,**} r,
+
+  owner @{tmp}/mangoapp*.sock rw,
+  owner @{run}/user/@{uid}/mangoapp*.sock rw,
+
+  @{sys}/devices/@{pci}/**  r,
+  @{sys}/class/drm/{,**} r,
+
+  owner @{PROC}/@{pid}/stat r,
+  owner @{PROC}/@{pid}/statm r,
+
+  include if exists <local/mangoapp>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/mkvtoolnix-gui
+++ b/apparmor.d/profiles-m-r/mkvtoolnix-gui
@@ -10,7 +10,10 @@ include <tunables/global>
 @{exec_path} = @{bin}/mkvtoolnix-gui
 profile mkvtoolnix-gui @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
+  include <abstractions/audio-client>
   include <abstractions/desktop>
+  include <abstractions/devices-usb-read>
+  include <abstractions/disks-read>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/nameservice-strict>
@@ -19,28 +22,52 @@ profile mkvtoolnix-gui @{exec_path} flags=(attach_disconnected,mediate_deleted) 
   include <abstractions/qt5>
   include <abstractions/ssl_certs>
   include <abstractions/sys/dmi>
+  include <abstractions/thumbnails-cache-read>
+  include <abstractions/thumbnails-cache-write>
   include <abstractions/user-download-strict>
 
   signal (send) set=(term, kill) peer=mkvmerge,
+  signal send set=term peer=kioworker,
 
   @{exec_path} mr,
 
   @{bin}/mkvmerge      rPx,
   @{bin}/mediainfo-gui rPx,
 
+  #aa:exec kioworker
+
+  network netlink raw,
+
   /usr/share/hwdata/pnp.ids r,
   /usr/share/mkvtoolnix/{,**} r,
+  /usr/share/thumbnailers/{,*} r,
+  /usr/share/templates/ r,
+
+  @{lib}/ r,
+
+  @{efi}/ r,
+
+  #aa:lint ignore=too-wide
+  / r,
+  /*/ r,
+
+  owner @{HOME}/{,**} rw,
+  @{MOUNTDIRS}/ r,
+  @{MOUNTS}/ rw,
+  @{MOUNTS}/** rw,
+  @{run}/mount/utab r,
+  owner @{run}/user/@{uid}/filehelper* rw,
 
   /etc/fstab r,
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
 
-  owner @{user_music_dirs}/** rw,
-  owner @{user_videos_dirs}/** rw,
+  owner @{user_share_dirs}/user-places.xbel{,*} rwl,
 
   owner @{user_config_dirs}/bunkus.org/ rw,
   owner @{user_config_dirs}/bunkus.org/mkvtoolnix-gui/ rw,
   owner @{user_config_dirs}/bunkus.org/mkvtoolnix-gui/** rwlk -> @{user_config_dirs}/bunkus.org/mkvtoolnix-gui/#@{int},
+  owner @{user_config_dirs}/mkvtoolnix-guirc.lock rwk,
 
   owner @{user_cache_dirs}/ rw,
   owner @{user_cache_dirs}/bunkus.org/ rw,
@@ -54,6 +81,10 @@ profile mkvtoolnix-gui @{exec_path} flags=(attach_disconnected,mediate_deleted) 
   owner @{tmp}/MKVToolNix-GUI-MuxJob-*.json rwl -> /tmp/#@{int},
   owner @{tmp}/MKVToolNix-GUI-Instance-Communicator-* rw,
   owner /dev/shm/#@{int} rw,
+  /dev/shm/ r,
+
+  owner @{run}/user/@{uid}/#@{int} rw,
+  owner @{run}/user/@{uid}/mkvtoolnix-gui@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
 
   @{att}@{run}/systemd/inhibit/@{int}.ref w,
 
@@ -61,8 +92,10 @@ profile mkvtoolnix-gui @{exec_path} flags=(attach_disconnected,mediate_deleted) 
   deny       @{PROC}/sys/kernel/random/boot_id r,
              @{PROC}/@{pid}/mountinfo r,
              @{PROC}/@{pid}/mounts r,
+       owner @{PROC}/@{pid}/stat r,
        owner @{PROC}/@{pid}/task/@{tid}/comm w,
 
+  /dev/tty r,
   owner /dev/tty@{u8} rw,
 
   include if exists <local/mkvtoolnix-gui>

--- a/apparmor.d/profiles-m-r/mono-sgen
+++ b/apparmor.d/profiles-m-r/mono-sgen
@@ -10,10 +10,13 @@ include <tunables/global>
 profile mono-sgen @{exec_path} {
   include <abstractions/base>
   include <abstractions/audio-client>
+  include <abstractions/cgroup-limits>
   include <abstractions/desktop>
   include <abstractions/graphics>
+  include <abstractions/ibus-strict>
   include <abstractions/nameservice-strict>
   include <abstractions/ssl_certs>
+  include <abstractions/thumbnails-cache-read>
 
   network inet dgram,
   network inet6 dgram,
@@ -30,15 +33,33 @@ profile mono-sgen @{exec_path} {
   /usr/share/.mono/{,**} rw,
 
   /etc/mono/{,**} r,
+  /etc/fstab r,
+  /.profile r,
+
+  # Pinta's Open/Save dialogs browse, mime-sniff and save anywhere under $HOME
+  owner @{HOME}/{,**} rw,
+
+  @{MOUNTDIRS}/ r,
+  owner @{MOUNTS}/ r,
+  owner @{MOUNTS}/** r,
+
+  @{run}/mount/utab r,
 
   owner @{user_config_dirs}/openra/{,**} rw,
   owner @{user_config_dirs}/.mono/{,**} r,
+  owner @{user_config_dirs}/Pinta/{,**} rw,
+  owner @{user_config_dirs}/mono.addins/{,**} rw,
+  owner @{user_config_dirs}/mono.addins/addin-db-002/fdb-lock rwk,
 
   owner @{tmp}/*.* rw,
   owner @{tmp}/CASESENSITIVETEST* rw,
   owner /dev/shm/mono.@{int} rw,
 
   owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/statm r,
+
+  signal (send) set=kill peer=unconfined,
 
   include if exists <local/mono-sgen>
 }

--- a/apparmor.d/profiles-m-r/nvidia-settings
+++ b/apparmor.d/profiles-m-r/nvidia-settings
@@ -9,31 +9,108 @@ include <tunables/global>
 @{exec_path} = @{bin}/nvidia-settings
 profile nvidia-settings @{exec_path} flags=(attach_disconnected) {
   include <abstractions/base>
+  include <abstractions/cgroup-limits>
   include <abstractions/dconf-write>
   include <abstractions/desktop>
   include <abstractions/gstreamer>
+  include <abstractions/nameservice-strict>
   include <abstractions/nvidia-strict>
+  include <abstractions/thumbnails-cache-read>
+  include <abstractions/app/bus>
+
+  capability dac_override,
+  capability dac_read_search,
+  capability mknod,
+  capability sys_admin,
+  capability sys_nice,
+  capability perfmon,
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
 
   @{exec_path} mr,
+
+  @{bin}/kmod         rPx,
 
   /usr/share/pixmaps/{,**} r,
 
   owner @{HOME}/.nvidia-settings-rc rw,
 
+  # Not owner-scoped: run via sudo, this process's fsuid (root) won't match
+  # the file's owning uid, but the cookie itself is meant to be read by
+  # whoever needs to authenticate to this specific display.
+  @{run}/user/@{uid}/xauth_@{rand6} r,
+
+  /etc/glvnd/egl_vendor.d/{,*.json} r,
+  /usr/share/glvnd/egl_vendor.d/{,*.json} r,
+  /etc/egl/egl_external_platform.d/{,*.json} r,
+  /usr/share/egl/egl_external_platform.d/{,*.json} r,
+
+  /etc/vulkan/explicit_layer.d/{,*.json} r,
+  /etc/vulkan/icd.d/{,*.json} r,
+  /etc/vulkan/implicit_layer.d/{,*.json} r,
+  /usr/share/vulkan/explicit_layer.d/{,*.json} r,
+  /usr/share/vulkan/icd.d/{,*.json} r,
+  /usr/share/vulkan/implicit_layer.d/{,*.json} r,
+  owner @{user_share_dirs}/vulkan/implicit_layer.d/{,*.json} r,
+
+  /usr/share/drirc.d/{,*} r,
+
+  /dev/dri/ r,
+  /dev/dri/renderD@{int} rw,
+
   @{sys}/bus/pci/devices/ r,
   @{sys}/devices/@{pci}/config r,
+  @{sys}/devices/@{pci}/boot_vga r,
+  @{sys}/devices/@{pci}/uevent r,
+  @{sys}/devices/@{pci}/vendor r,
+  @{sys}/devices/@{pci}/device r,
+  @{sys}/devices/@{pci}/subsystem_vendor r,
+  @{sys}/devices/@{pci}/subsystem_device r,
+  @{sys}/devices/@{pci}/revision r,
   @{sys}/devices/system/node/ r,
   @{sys}/devices/system/node/node@{int}/cpumap r,
+  @{sys}/devices/system/cpu/cpu@{int}/cpu_capacity r,
+  @{sys}/devices/system/cpu/cpu@{int}/cache/index@{int}/level r,
+  @{sys}/devices/system/cpu/cpu@{int}/cache/index@{int}/id r,
+  @{sys}/devices/system/cpu/cpu@{int}/topology/physical_package_id r,
+  @{sys}/devices/system/cpu/cpu@{int}/topology/core_cpus r,
+  @{sys}/devices/system/cpu/cpu@{int}/topology/thread_siblings r,
 
         @{PROC}/devices r,
+        @{PROC}/sys/kernel/modprobe r,
+        @{PROC}/sys/dev/i915/perf_stream_paranoid r,
         @{PROC}/driver/nvidia/capabilities/mig/config r,
         @{PROC}/driver/nvidia/capabilities/mig/monitor r,
   owner @{PROC}/@{pid}/cmdline r,
   owner @{PROC}/@{pid}/task/@{tid}/comm rw,
+  owner @{PROC}/@{pid}/mountinfo r,
+  owner @{PROC}/@{pid}/mounts r,
+  @{PROC}/[0-9]*/stat r,
+
+  /etc/fstab r,
+
+  # GTK save/open dialog defaults to $HOME and mime-sniffs visible entries,
+  # and also supports rename/delete from within the dialog
+  owner @{HOME}/{,**} rw,
+  owner @{HOME}/.steam/steam.pid r,
+
+  @{MOUNTDIRS}/ r,
+  @{MOUNTS}/{,**} rw,
+
+  @{run}/mount/utab r,
+
+  owner @{user_cache_dirs}/mesa_shader_cache/index rwk,
+  owner @{user_config_dirs}/lsfg-vk/conf.toml r,
+
+  /dev/pts/[0-9]* rw,
 
   /dev/char/@{dynamic}:@{int} w,          # For dynamic assignment range 234 to 254, 384 to 511
   /dev/nvidia-caps/ rw,
-  /dev/nvidia-caps/nvidia-cap@{int} r,
+  /dev/nvidia-caps/nvidia-cap@{int} rw,
 
   include if exists <local/nvidia-settings>
 }

--- a/apparmor.d/profiles-m-r/nvme-cli
+++ b/apparmor.d/profiles-m-r/nvme-cli
@@ -1,0 +1,27 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{sbin}/nvme
+profile nvme-cli @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+
+  capability sys_admin sys_rawio,
+
+  @{exec_path} mr,
+
+  /dev/nvme{,*} rw,
+
+  @{sys}/class/nvme/{,**} r,
+  @{sys}/devices/**/nvme/{,**} r,
+
+  @{PROC}/mounts r,
+
+  include if exists <local/nvme-cli>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/nvtop
+++ b/apparmor.d/profiles-m-r/nvtop
@@ -21,6 +21,8 @@ profile nvtop @{exec_path} flags=(attach_disconnected) {
 
   ptrace read,
 
+  signal (receive) set=hup peer=konsole,
+
   @{exec_path} mr,
 
   /usr/share/terminfo/** r,

--- a/apparmor.d/profiles-m-r/packagekitd
+++ b/apparmor.d/profiles-m-r/packagekitd
@@ -21,6 +21,7 @@ profile packagekitd @{exec_path} flags=(attach_disconnected) {
   capability dac_override,
   capability dac_read_search,
   capability fowner,
+  capability fsetid,
   capability kill,
   capability mknod,
   capability net_admin,
@@ -42,9 +43,11 @@ profile packagekitd @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
-  @{bin}/gpg{,2}         Cx -> gpg,
-  @{bin}/gpgconf         Cx -> gpg,
-  @{bin}/gpgsm           Cx -> gpg,
+  # &packagekitd//gpg, not bare gpg: a bare name is ambiguous with the
+  # unrelated top-level groups/gpg/gpg profile of the same name
+  @{bin}/gpg{,2}         Cx -> &packagekitd//gpg,
+  @{bin}/gpgconf         Cx -> &packagekitd//gpg,
+  @{bin}/gpgsm           Cx -> &packagekitd//gpg,
 
   @{sh_path}            rix,
   @{bin}/cp             rix,
@@ -109,6 +112,18 @@ profile packagekitd @{exec_path} flags=(attach_disconnected) {
         /tmp/apt-dpkg-install-@{rand6}/ rw,
   owner @{tmp}/apt-changelog-@{rand6}/.apt-acquire-privs-test.@{rand6} rw,
 
+  # rwlk, not rw: gnupg's dotlock protocol under libdnf5's tmp gnupg home
+  # creates/hardlinks lock files (.#lk0x*, .#lk0x*x, pubring.kbx.lock,
+  # trustdb.gpg.lock) inside this dir - needs the l/k bits too.
+  #aa:only fedora
+  owner @{tmp}/libdnf5.@{rand6}/{,**} rwlk,
+  #aa:only fedora
+  owner @{tmp}/key.@{rand6} rw,
+  #aa:only fedora
+  owner @{tmp}/tmpdir.@{rand6}/{,**} rw,
+  #aa:only fedora
+  owner @{tmp}/librepo-tmp-@{rand6} rw,
+
   @{att}@{run}/systemd/inhibit/@{int}.ref rw,
 
   owner @{run}/systemd/users/@{uid} r,
@@ -139,6 +154,7 @@ profile packagekitd @{exec_path} flags=(attach_disconnected) {
     include <abstractions/nameservice-strict>
 
     capability dac_read_search,
+    capability mknod,
 
     @{bin}/gpg{,2}  mr,
     @{bin}/gpgconf  mr,
@@ -159,6 +175,17 @@ profile packagekitd @{exec_path} flags=(attach_disconnected) {
     #aa:only opensuse
     owner /var/tmp/zypp.*/*/ r,
     owner /var/tmp/zypp.*/*/** rwlk -> /var/tmp/zypp.*/*/**,
+
+    #aa:only fedora
+    owner @{tmp}/key.@{rand6} rw,
+    #aa:only fedora
+    owner @{tmp}/libdnf5.@{rand6}/{,**} rwlk,
+    #aa:only fedora
+    owner @{tmp}/librepo-tmp-@{rand6} rw, # file_inherit
+    #aa:only fedora
+    @{lib}/sysimage/rpm/.rpm.lock w,
+    #aa:only fedora
+    /var/cache/PackageKit/@{int}/metadata/*/{,tmpdir.@{rand6}/}repodata/* rw, # file_inherit
 
     owner @{run}/user/@{uid}/gnupg/ r,
     owner @{run}/user/@{uid}/gnupg/ rwlk -> @{run}/user/@{uid}/gnupg/**,

--- a/apparmor.d/profiles-m-r/parted
+++ b/apparmor.d/profiles-m-r/parted
@@ -10,10 +10,13 @@ include <tunables/global>
 @{exec_path} = @{sbin}/parted
 profile parted @{exec_path} {
   include <abstractions/base>
+  include <abstractions/consoles>
   include <abstractions/disks-write>
 
   capability sys_admin,
   capability sys_rawio,
+  capability dac_override,
+  capability dac_read_search,
 
   ptrace read,
 
@@ -25,6 +28,8 @@ profile parted @{exec_path} {
   @{sbin}/dmidecode rPx,
 
   /etc/inputrc r,
+
+  @{system_share_dirs}/terminfo/{,**} r,
 
   owner @{user_img_dirs}/{,**} rwk,
 

--- a/apparmor.d/profiles-m-r/pavucontrol
+++ b/apparmor.d/profiles-m-r/pavucontrol
@@ -11,9 +11,15 @@ include <tunables/global>
 profile pavucontrol @{exec_path} {
   include <abstractions/base>
   include <abstractions/audio-client>
+  include <abstractions/cgroup-limits>
+  include <abstractions/crypto>
   include <abstractions/dconf-write>
   include <abstractions/desktop>
   include <abstractions/fontconfig-cache-read>
+  include <abstractions/graphics>
+  include <abstractions/nameservice-strict>
+  include <abstractions/ssl_certs>
+  include <abstractions/vulkan>
 
   @{exec_path} mr,
 
@@ -26,6 +32,8 @@ profile pavucontrol @{exec_path} {
   owner @{user_config_dirs}/pavucontrol.ini* rw,
 
   owner @{PROC}/@{pid}/cmdline r,
+  owner @{PROC}/@{pid}/cgroup r,
+  owner @{PROC}/@{pid}/stat r,
 
   # file_inherit
   owner /dev/tty@{u8} rw,

--- a/apparmor.d/profiles-m-r/podman
+++ b/apparmor.d/profiles-m-r/podman
@@ -1,0 +1,56 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/podman
+profile podman @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/bus-session>
+  include <abstractions/bus-system>
+  include <abstractions/nameservice-strict>
+
+  capability chown dac_override dac_read_search fowner fsetid kill mknod net_admin net_bind_service setgid setuid sys_admin sys_chroot sys_ptrace,
+
+  network,
+
+  @{exec_path} mr,
+
+  @{bin}/newuidmap       Px,
+  @{bin}/newgidmap       Px,
+  @{bin}/conmon          Px,
+  @{bin}/crun            Px,
+  @{sbin}/runc            Px,
+  @{bin}/fuse-overlayfs  Px,
+  @{bin}/slirp4netns     Px,
+  @{bin}/pasta           Px,
+
+  /usr/share/containers/{,**} r,
+  @{lib}/podman/{,**} mr,
+
+  @{etc_ro}/containers/{,**} r,
+  @{etc_ro}/subuid r,
+  @{etc_ro}/subgid r,
+
+  owner @{user_config_dirs}/containers/{,**} rw,
+  owner @{user_share_dirs}/containers/{,**} rw,
+  owner @{run}/user/@{uid}/containers/{,**} rw,
+  owner @{run}/user/@{uid}/libpod/{,**} rw,
+
+  /var/lib/containers/{,**} rw,
+  @{run}/containers/{,**} rw,
+
+  owner @{PROC}/@{pids}/status r,
+  owner @{PROC}/@{pids}/ns/ r,
+  owner @{PROC}/@{pids}/ns/* r,
+  @{PROC}/sys/user/max_user_namespaces r,
+
+  @{sys}/fs/cgroup/{,**} r,
+
+  include if exists <local/podman>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/qbittorrent
+++ b/apparmor.d/profiles-m-r/qbittorrent
@@ -13,6 +13,7 @@ profile qbittorrent @{exec_path} {
   include <abstractions/consoles>
   include <abstractions/dconf-write>
   include <abstractions/desktop>
+  include <abstractions/disks-read>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
   include <abstractions/ibus-strict>
@@ -26,6 +27,9 @@ profile qbittorrent @{exec_path} {
 
   signal send set=(term, kill) peer=qbittorrent//python,
 
+  # Qt/KDE session shutdown broadcasts TERM to the whole user session on exit
+  signal (send) set=term,
+
   network inet dgram,
   network inet6 dgram,
   network inet stream,
@@ -37,6 +41,8 @@ profile qbittorrent @{exec_path} {
 
   @{open_path}           rPx -> child-open,
   @{python_path}         rCx -> python, # For "search engine"
+
+  #aa:exec kioworker
 
   # Allowed apps to open
   @{bin}/ebook-viewer    rPx,
@@ -52,19 +58,44 @@ profile qbittorrent @{exec_path} {
 
   /usr/share/GeoIP/GeoIP.dat r,
   /usr/share/gvfs/remote-volume-monitors/{,*} r,
+  /usr/share/templates/ r,
+  /usr/share/thumbnailers/{,*} r,
+
+  /etc/fstab r,
+  /etc/pulse/client.conf r,
+
+  @{sys}/bus/usb/devices/ r,
+
+  #aa:lint ignore=too-wide
+  / r,
+  /*/ r,
+
+  owner @{HOME}/{,**} rw,
+  @{MOUNTDIRS}/ r,
+  @{MOUNTS}/ rw,
+  @{MOUNTS}/** rw,
+  @{run}/mount/utab r,
+  owner @{run}/user/@{uid}/filehelper* rw,
 
   owner @{user_cache_dirs}/qBittorrent/{,**} rw,
+  owner @{user_cache_dirs}/event-sound-cache.tdb.* r,
 
   owner @{user_config_dirs}/qBittorrent/ rw,
   owner @{user_config_dirs}/qBittorrent/** rwlk -> @{user_config_dirs}/qBittorrent/#@{int},
+  owner @{user_config_dirs}/qBittorrentrc.lock rwk,
 
   owner @{user_share_dirs}/{,data/}qBittorrent/ rw,
   owner @{user_share_dirs}/{,data/}qBittorrent/** rwl -> @{user_share_dirs}/{,data/}qBittorrent/**/#@{int},
+  owner @{user_share_dirs}/{,data/}qBittorrent/** rwl -> @{user_share_dirs}/{,data/}qBittorrent/#@{int},
   owner @{user_share_dirs}/data/ rw,
+  owner @{user_share_dirs}/sounds/{,**} r,
 
-  owner @{user_torrents_dirs}/ r,
-  owner @{user_torrents_dirs}/** rw,
+  owner @{user_share_dirs}/user-places.xbel r,
+  owner @{user_share_dirs}/user-places.xbel.bak rw,
+  owner @{user_share_dirs}/user-places.xbel.@{rand6} rwl -> @{user_share_dirs}/user-places.xbel,
+  owner @{user_share_dirs}/user-places.xbel.tbcache.@{rand6} rwl -> @{user_share_dirs}/user-places.xbel,
 
+  /dev/shm/ r,
   owner /dev/shm/#@{int} rw,
   owner @{tmp}/.*/{,s} rw,
   owner @{tmp}/.qBittorrent/ rw,
@@ -82,6 +113,13 @@ profile qbittorrent @{exec_path} {
   owner @{PROC}/@{pids}/mounts r,
 
   owner /dev/tty@{u8} rw,
+
+  owner @{run}/user/@{uid}/#@{int} rw,
+  owner @{run}/user/@{uid}/pulse/ rw,
+  owner @{run}/user/@{uid}/qBittorrent@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
+
+  owner @{user_config_dirs}/pulse/ rw,
+  owner @{user_config_dirs}/pulse/cookie r,
 
   profile python {
     include <abstractions/base>

--- a/apparmor.d/profiles-m-r/rtkit-daemon
+++ b/apparmor.d/profiles-m-r/rtkit-daemon
@@ -25,6 +25,8 @@ profile rtkit-daemon @{exec_path} flags=(attach_disconnected) {
   capability sys_nice,
   capability sys_ptrace,
 
+  ptrace read,
+
   #aa:dbus own bus=system name=org.freedesktop.RealtimeKit1
 
   @{exec_path} mr,

--- a/apparmor.d/profiles-s-z/smartd
+++ b/apparmor.d/profiles-s-z/smartd
@@ -32,6 +32,9 @@ profile smartd @{exec_path} {
 
   /etc/smart_drivedb.h r,
   /etc/smartd.conf r,
+  #aa:only fedora
+  /etc/smartmontools/smartd.conf r,
+
   /etc/smartmontools/smartd_warning.d/{,*} r,
   /usr/share/smartmontools/drivedb.h r,
   /var/lib/smartmontools/drivedb/drivedb.h r,

--- a/apparmor.d/profiles-s-z/smplayer
+++ b/apparmor.d/profiles-s-z/smplayer
@@ -12,12 +12,16 @@ profile smplayer @{exec_path} {
   include <abstractions/base>
   include <abstractions/audio-client>
   include <abstractions/consoles>
+  include <abstractions/devices-usb-read>
+  include <abstractions/disks-read>
   include <abstractions/graphics>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/desktop>
   include <abstractions/nameservice-strict>
   include <abstractions/qt5-compose-cache-write>
   include <abstractions/qt5-settings-write>
+  include <abstractions/thumbnails-cache-read>
+  include <abstractions/thumbnails-cache-write>
   include <abstractions/user-download-strict>
 
   signal (send) set=(term, kill),
@@ -28,30 +32,73 @@ profile smplayer @{exec_path} {
   network inet stream,
   network inet6 stream,
   network netlink dgram,
+  network netlink raw,
 
   @{exec_path} mrix,
 
   @{bin}/mpv        rPx,
   @{bin}/pacmd      rPx,
+  @{bin}/pgrep      rix,
+
+  #aa:exec kioworker
+
+  @{PROC}/ r,
+  @{PROC}/@{pids}/ r,
+  @{PROC}/@{pids}/cgroup r,
+  @{PROC}/@{pids}/stat r,
+  @{PROC}/@{pids}/status r,
+  @{PROC}/tty/drivers r,
   @{bin}/smtube     rPx,
   @{bin}/youtube-dl rPx,
   @{bin}/{y,}t-dlp  rPx,
 
   /usr/share/hwdata/pnp.ids r,
+  /usr/share/kservices5/{,**} r,
+  /usr/share/kservicetypes5/{,*} r,
+  /usr/share/smplayer/{,**} r,
+  /usr/share/templates/ r,
 
   /etc/fstab r,
 
   /etc/machine-id r,
   /var/lib/dbus/machine-id r,
 
-  owner @{HOME}/ r,
+  #aa:lint ignore=too-wide
+  / r,
+  /*/ r,
+  # PATH-style probing of mpv/youtube-dl/yt-dlp across bin/lib dirs, including
+  # arbitrary third-party install dirs under /opt
+  /*/*/ r,
+
+  owner @{HOME}/{,**} rw,
+  @{MOUNTDIRS}/ r,
+  @{MOUNTS}/ rw,
+  @{MOUNTS}/** rw,
+  @{run}/mount/utab r,
+  owner @{run}/user/@{uid}/filehelper* rw,
+
   owner @{user_music_dirs}/{,**} rw,
   owner @{user_pictures_dirs}/{,**} rw,
   owner @{user_torrents_dirs}/{,**} rw,
   owner @{user_videos_dirs}/{,**} rw,
 
+  owner @{user_config_dirs}/menus/applications-kmenuedit.menu r,
+
+  owner @{user_share_dirs}/user-places.xbel{,*} rwl,
+  owner @{user_share_dirs}/RecentDocuments/ r,
+  owner @{user_share_dirs}/RecentDocuments/#@{int} rw,
+  owner @{user_share_dirs}/RecentDocuments/*.desktop rw,
+  owner @{user_share_dirs}/RecentDocuments/*.desktop.lock rwk,
+
   owner @{user_config_dirs}/smplayer/ rw,
   owner @{user_config_dirs}/smplayer/* rwlk -> @{user_config_dirs}/smplayer/#@{int},
+  owner @{user_config_dirs}/smplayer/file_settings/**.ini rw,
+  owner @{user_config_dirs}/smplayer/file_settings/**.ini.lock rwk,
+  owner @{user_config_dirs}/smplayer/file_settings/*/*.ini.@{rand6} rwl -> @{user_config_dirs}/smplayer/file_settings/*/#@{int},
+  owner @{user_config_dirs}/smplayer/file_settings/*/#@{int} rw,
+  owner @{user_config_dirs}/smplayerrc rw,
+  owner @{user_config_dirs}/smplayerrc.lock rwk,
+  owner @{user_config_dirs}/smplayerrc.@{rand6} rwl -> @{user_config_dirs}/#@{int},
 
   owner @{tmp}/qtsingleapp-smplay-* rw,
   owner @{tmp}/qtsingleapp-smplay-*-lockfile rwk,
@@ -61,8 +108,13 @@ profile smplayer @{exec_path} {
 
   owner @{run}/user/@{uid}/gvfs/smb-share:server=*,share=**/ r,
   owner @{run}/user/@{uid}/gvfs/smb-share:server=*,share=** r,
+  owner @{run}/user/@{uid}/#@{int} rw,
+  owner @{run}/user/@{uid}/smplayer@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
 
   owner /dev/shm/#@{int} rw,
+
+  deny capability sys_ptrace,
+  deny ptrace (trace, read),
 
   deny owner @{PROC}/@{pid}/stat r,
   deny owner @{PROC}/@{pid}/cmdline r,

--- a/apparmor.d/profiles-s-z/sudo
+++ b/apparmor.d/profiles-s-z/sudo
@@ -48,6 +48,13 @@ profile sudo @{exec_path} flags=(attach_disconnected) {
 
   @{sys}/fs/cgroup/*.slice{,/*.slice}/*.service/cgroup.procs r,
 
+  @{PROC}/@{pid}/cgroup r,
+
+  # pam_unix execs this setuid helper to verify the password. priority=1 rPx
+  # still denied the exec under real kernel enforcement despite compiling
+  # clean; Ux sidesteps the transition-table lookup entirely.
+  priority=1 @{sbin}/unix_chkpwd rUx,
+
   include if exists <local/sudo>
 }
 

--- a/apparmor.d/profiles-s-z/thermald
+++ b/apparmor.d/profiles-s-z/thermald
@@ -42,6 +42,7 @@ profile thermald @{exec_path} flags=(attach_disconnected) {
   @{sys}/devices/@{pci}/power_limits/power_limit_@{int}_min_uw r,
   @{sys}/devices/@{pci}/power_limits/power_limit_@{int}_tmax_us r,
   @{sys}/devices/@{pci}/power_limits/power_limit_@{int}_tmin_us r,
+  @{sys}/devices/@{pci}/tcc_offset_degree_celsius w,
 
   @{sys}/devices/**/path r,
 

--- a/apparmor.d/profiles-s-z/tune2fs
+++ b/apparmor.d/profiles-s-z/tune2fs
@@ -23,6 +23,8 @@ profile tune2fs @{exec_path} {
 
   /.ismount-test-file rw,
 
+  @{efi}/ r,
+
   # Image files
   owner @{user_img_dirs}/{,**} rw,
 

--- a/apparmor.d/profiles-s-z/visudo
+++ b/apparmor.d/profiles-s-z/visudo
@@ -1,0 +1,37 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{sbin}/visudo @{bin}/visudo-rs
+profile visudo @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/consoles>
+  include <abstractions/nameservice-strict>
+
+  capability dac_override,
+  capability dac_read_search,
+  capability setuid,
+  capability setgid,
+
+  @{exec_path} mr,
+
+  @{bin}/vi          rPUx,
+  @{bin}/vim         rPUx,
+  @{bin}/nano        rPUx,
+  @{bin}/emacs       rPUx,
+
+  @{etc_ro}/sudoers r,
+  @{etc_ro}/sudoers.d/{,*} r,
+  /etc/sudoers.tmp rw,
+  /etc/sudoers.d/ rw,
+
+  owner @{tmp}/visudo-* rw,
+
+  include if exists <local/visudo>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-s-z/whoami
+++ b/apparmor.d/profiles-s-z/whoami
@@ -15,6 +15,8 @@ profile whoami @{exec_path} flags=(attach_disconnected) {
 
   @{exec_path} mr,
 
+  /dev/pts/[0-9]* rwk,
+
   include if exists <local/whoami>
 }
 

--- a/apparmor.d/profiles-s-z/xauth
+++ b/apparmor.d/profiles-s-z/xauth
@@ -13,6 +13,9 @@ profile xauth @{exec_path} {
   include <abstractions/consoles>
   include <abstractions/nameservice-strict>
 
+  capability dac_override,
+  capability dac_read_search,
+
   @{exec_path} mr,
 
   /Xauthority-c w,
@@ -36,7 +39,10 @@ profile xauth @{exec_path} {
   owner @{tmp}/xauth_@{rand6} r,
   owner @{tmp}/xauth_@{rand6}-c w,
   owner @{tmp}/xauth_@{rand6}-l wl,
+  owner @{tmp}/xauth.@{rand10} rwl -> @{tmp}/xauth.@{rand10}-n,
   owner @{tmp}/xauth.@{rand10}-c w,
+  owner @{tmp}/xauth.@{rand10}-l wl -> @{tmp}/xauth.@{rand10}-c,
+  owner @{tmp}/xauth.@{rand10}-n rw,
 
   owner @{run}/user/@{uid}/xauth_@{rand6} rw,
   owner @{run}/user/@{uid}/xauth_@{rand6}-c w,

--- a/apparmor.d/profiles-s-z/yubikey-manager
+++ b/apparmor.d/profiles-s-z/yubikey-manager
@@ -1,0 +1,29 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Alexandre Pujol <alexandre@pujol.io>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/ykman
+profile yubikey-manager @{exec_path} flags=(attach_disconnected,mediate_deleted) {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  @{exec_path} mr,
+
+  /dev/bus/usb/{,**} rw,
+  /dev/hidraw* rw,
+  /dev/ttyUSB* rw,
+
+  @{sys}/bus/usb/{,**} r,
+  @{sys}/class/hidraw/{,**} r,
+  @{sys}/devices/**/usb*/{,**} r,
+
+  /usr/share/yubikey-manager/{,**} r,
+
+  include if exists <local/yubikey-manager>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/tunables/home.d/apparmor.d
+++ b/apparmor.d/tunables/home.d/apparmor.d
@@ -3,6 +3,14 @@
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
+# ostree/bootc-based Fedora Atomic variants (Silverblue, Kinoite, IoT, CoreOS)
+# keep real user home directories at /var/home/<user>/, with /home a symlink
+# to /var/home - AppArmor matches the resolved path, not through the symlink,
+# so without this, @{HOME} (and everything derived from it: user_config_dirs,
+# user_cache_dirs, etc.) never matches on those variants.
+#aa:only fedora
+@{HOMEDIRS}+=/var/home/
+
 # To allow extended personalisation by the user without breaking everything.
 # All apparmor profiles should always use the variables defined here.
 

--- a/apparmor.d/tunables/multiarch.d/system
+++ b/apparmor.d/tunables/multiarch.d/system
@@ -16,7 +16,7 @@
 # Common places for binaries and libraries across distributions
 @{bin}=/{,usr/}bin
 @{sbin}=/{,usr/}sbin     #aa:only apt zypper
-@{sbin}=/{,usr/}{,s}bin  #aa:only pacman
+@{sbin}=/{,usr/}{,s}bin  #aa:only pacman fedora
 @{lib}=/{,usr/}lib{,exec,32,64}
 
 # Common places for temporary files
@@ -57,6 +57,10 @@
 #aa:only opensuse
 # OpenSUSE does not have the same multiarch structure
 @{multiarch}+=*-suse-linux*
+
+#aa:only fedora
+# Fedora/RHEL does not have the same multiarch structure (no "-gnu" suffix)
+@{multiarch}+=*-redhat-linux*
 
 
 # System Internal

--- a/dists/copr-apparmor.d.spec
+++ b/dists/copr-apparmor.d.spec
@@ -1,0 +1,94 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2023 Christian Boltz
+# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (c) 2026 CatPieLeaf <catpieleaf@proton.me>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Warning: for development only, use https://copr.fedorainfracloud.org/coprs/catpieleaf/apparmor.d for production use.
+
+%define _complain 0
+
+%define _disable_source_fetch 0
+
+Name:           apparmor.d
+Version:        0.4910.0
+Release:        1%{?dist}
+Summary:        Full set of AppArmor policies
+License:        GPL-2.0-only
+URL:            https://github.com/CatPieLeaf/apparmor.d-fedora
+Source0:        %{url}/archive/refs/heads/main.tar.gz
+
+Requires:       apparmor-profiles
+Requires:       apparmor-parser
+Requires:       apparmor-utils
+BuildRequires:  just
+BuildRequires:  golang
+BuildRequires:  systemd-rpm-macros
+
+%description
+AppArmor.d is a set of over 1500 AppArmor profiles whose aim is to
+confine most Linux based applications and processes.
+
+%if %{_complain}
+Built in COMPLAIN mode: violations are logged but not blocked.
+Use this mode with aa-logprof for fixing profiles.
+%else
+Built in ENFORCE mode: violations are actively blocked. Make sure
+you have already validated this profile set in complain mode.
+%endif
+
+%prep
+%autosetup -n %{name}-fedora-main
+
+%build
+%if %{_complain} == 1
+just complain
+%else
+just enforce
+%endif
+
+%install
+just destdir="%{buildroot}" install-prebuilt
+just destdir="%{buildroot}" install-base
+just destdir="%{buildroot}" install-tools
+
+# Do not force dbus(-broker).service under AppArmorProfile= via systemd
+# drop-in. RakuOS (a Fedora-based distro shipping this same profile set)
+# tried this repeatedly and gave up on it: "still causing boot/service
+# problems after repeated re-enable attempts" (their git history has several
+# enable/disable round-trips ending in permanently disabled). dbus underlies
+# PAM's session bus, kwallet registration, and polkit, so a boot-time dbus
+# confinement race cascades into exactly this kind of hard-to-diagnose
+# auth/wallet breakage.
+rm -rf %{buildroot}/usr/lib/systemd/system/*.service.d
+rm -rf %{buildroot}/usr/lib/systemd/user/*.service.d
+
+%posttrans
+apparmor_parser --purge-cache || :
+systemctl daemon-reload || :
+if systemctl is-active --quiet apparmor.service 2>/dev/null; then
+    systemctl try-restart apparmor.service || :
+fi
+
+%postun
+systemctl daemon-reload || :
+if [ $1 -eq 0 ] ; then
+    apparmor_parser --purge-cache || :
+fi
+
+%files
+%license LICENSE
+%doc README.md
+%config /etc/apparmor.d/
+%{_bindir}/aa-log
+%{_bindir}/aa-mode
+
+%dir %{_datadir}/zsh
+%dir %{_datadir}/zsh/site-functions
+%{_datadir}/zsh/site-functions/_aa-*.zsh
+%{_datadir}/bash-completion/completions/aa-*
+%doc %{_mandir}/man1/aa-*.1.gz
+%doc %{_mandir}/man8/aa-*.8.gz
+
+%changelog

--- a/dists/flags/fedora.flags
+++ b/dists/flags/fedora.flags
@@ -1,0 +1,24 @@
+# Common profile mode for all distributions
+# File format: one profile mode by line using the format: '<profile> <mode>'
+
+dnf complain
+dnf5 complain
+aria2 complain
+doas complain
+heroic complain
+mangoapp complain
+nvme-cli complain
+podman complain
+visudo complain
+yubikey-manager complain
+systemd-run complain
+brave-origin complain
+claude-desktop complain
+helium-bin complain
+ark complain
+gwenview complain
+kate complain
+kcalc complain
+kinfocenter complain
+kmenuedit complain
+spectacle complain

--- a/dists/ignore/arch.ignore
+++ b/dists/ignore/arch.ignore
@@ -1,7 +1,10 @@
 # Debian specific definition
 apparmor.d/groups/apt
 
-# Ubuntu specific definition 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
+# Ubuntu specific definition
 apparmor.d/groups/ubuntu
 
 # OpenSUSE specific definition

--- a/dists/ignore/debian.ignore
+++ b/dists/ignore/debian.ignore
@@ -2,7 +2,10 @@
 apparmor.d/groups/pacman
 share/libalpm
 
-# Ubuntu specific definition 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
+# Ubuntu specific definition
 apparmor.d/groups/ubuntu
 
 # OpenSUSE specific definition

--- a/dists/ignore/fedora.ignore
+++ b/dists/ignore/fedora.ignore
@@ -1,0 +1,12 @@
+# Debian specific definition
+apparmor.d/groups/apt
+
+# Archlinux specific definition
+apparmor.d/groups/pacman
+share/libalpm
+
+# Ubuntu specific definition
+apparmor.d/groups/ubuntu
+
+# OpenSUSE specific definition
+apparmor.d/groups/suse

--- a/dists/ignore/opensuse.ignore
+++ b/dists/ignore/opensuse.ignore
@@ -5,7 +5,10 @@ share/libalpm
 # Debian specific definition
 apparmor.d/groups/apt
 
-# Ubuntu specific definition 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
+# Ubuntu specific definition
 apparmor.d/groups/ubuntu
 
 # Profiles provided by they own package

--- a/dists/ignore/ubuntu.ignore
+++ b/dists/ignore/ubuntu.ignore
@@ -2,6 +2,9 @@
 apparmor.d/groups/pacman
 share/libalpm
 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
 # OpenSUSE specific definition
 apparmor.d/groups/suse
 

--- a/docs/development/directives.md
+++ b/docs/development/directives.md
@@ -38,8 +38,8 @@ The `only` and `exclude` directives can be used to filter individual rule or rul
 
 :   The filter to apply. Can be:
 
-    - A supported target distribution: `arch`, `debian`, `ubuntu`, `opensuse`.
-    - A supported distribution family: `apt`, `pacman`, `zypper`.
+    - A supported target distribution: `arch`, `debian`, `ubuntu`, `opensuse`, `fedora`.
+    - A supported distribution family: `apt`, `pacman`, `zypper`, `dnf`.
     - A supported ABI: `abi3`, `abi4`.
 
 **Example**

--- a/pkg/builder/attach.go
+++ b/pkg/builder/attach.go
@@ -26,6 +26,23 @@ func NewAttach() *ReAttach {
 	}
 }
 
+// reAttachExclude lists profiles that must keep their plain attach_disconnected
+// flag without the attach_disconnected.path=@{att} extension or the attached/*
+// abstraction swap. These profiles Px-transition into small setuid PAM helpers
+// (unix_chkpwd) to authenticate the user, and the disconnected-path reattachment
+// mechanism breaks that exec transition under real kernel enforcement even though
+// it compiles and merges cleanly - confirmed by comparing against the pristine
+// (non-reattached) profiles shipped by rakuos-apparmor-profiles, which use the
+// exact same rules and priority directives without this transformation and do
+// not exhibit the bug.
+var reAttachExclude = map[string]bool{
+	"sudo":        true,
+	"sudo-rs":     true,
+	"su":          true,
+	"su-rs":       true,
+	"unix-chkpwd": true,
+}
+
 // Apply will re-attach the disconnected path
 //   - Add the attach_disconnected.path flag on all profile with the attach_disconnected flag
 //   - Replace the base abstraction by attached/base
@@ -43,7 +60,7 @@ func (b ReAttach) Apply(opt *Option, profile string) (string, error) {
 		return profile, nil // Do not re-attach twice
 	}
 
-	if strings.Contains(profile, "attach_disconnected") {
+	if strings.Contains(profile, "attach_disconnected") && !reAttachExclude[opt.Name] {
 		if opt.Kind == aa.ProfileKind {
 			if strings.Contains(opt.Name, ":") {
 				parts := strings.Split(opt.Name, ":")

--- a/pkg/builder/userspace.go
+++ b/pkg/builder/userspace.go
@@ -41,7 +41,7 @@ func (b Userspace) Apply(opt *Option, profile string) (string, error) {
 	}
 
 	f := aa.DefaultTunables()
-	if tasks.Distribution == "arch" {
+	if tasks.Distribution == "arch" || tasks.Distribution == "fedora" {
 		f.Preamble = append(f.Preamble, &aa.Variable{
 			Name: "sbin", Values: []string{"/{,usr/}{,s}bin"}, Define: true,
 		})

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -71,6 +71,8 @@ func (p Configure) Apply() ([]string, error) {
 			return res, err
 		}
 
+	case "fedora":
+
 	default:
 		return []string{}, fmt.Errorf("%s is not a supported distribution", tasks.Distribution)
 

--- a/pkg/tasks/os.go
+++ b/pkg/tasks/os.go
@@ -39,6 +39,7 @@ var (
 		"apt":    {"debian", "ubuntu"},
 		"pacman": {"arch"},
 		"zypper": {"opensuse"},
+		"dnf":    {"fedora"},
 	}
 )
 


### PR DESCRIPTION
# This PR is CHONKY. >:)

This adds Fedora as a supported distribution, following the same pattern as the existing arch/debian/ubuntu/opensuse support. It also folds in a bunch of contributions from [RakuOS](https://rakuos.org/), an atomic/ostree-based Fedora distro that recently adopted Apparmor and Apparmor.d, since a lot of what they needed overlaps with what any Fedora system needs. This might also help Nobara, since they also use apparmor but without apparmor.d.... basically unprotected.

I've also set-up a COPR with testing builds for anyone to try.
https://copr.fedorainfracloud.org/coprs/catpieleaf/apparmor.d/

It's not perfect and I'll probably keep sending fixes as I find more denials, but the base is solid. Most of what you need for a Fedora desktop to actually work under AppArmor without constant denials is already here. I've been running this on Fedora KDE (not Workstation/GNOME) day to day and iterating on real AVC logs from my own machine, so KDE-specific stuff got a lot more mileage than GNOME did. GNOME should mostly work since a lot of the fixes are generic (dbus, flatpak, xdg-portal stuff), but I haven't hammered on it the way I have KDE.

What's in here is..

Core distro stuff:
- "fedora" recognized as a distribution (it already fell through to the right ID via /etc/os-release, this just wires up the family mapping so #aa:only dnf works)
- Fixed the sudo/sudo-rs double-attachment bug that was previously reverted upstream for Ubuntu - Fedora ships sudo-rs as the real /usr/bin/sudo binary same as recent Ubuntu, and both profiles were claiming that path
- @{sbin} merged-usr tunable extended to cover Fedora (same shape as Arch)
- Fedora KDE spin's default kdeglobals path added
- New dists/ignore/fedora.ignore and dists/flags/fedora.flags following the existing per-distro convention

New profiles:-
- groups/dnf/{dnf,dnf5} - was completely missing before, dnf5 in particular needed a fair amount of work (ca-trust, crypto-policies, sysimage paths, librepo tmp files, gpg subprocess handling)
- A handful of generic app profiles that just didn't exist yet: aria2, doas, heroic, mangoapp, nvme-cli, podman, visudo, yubikey-manager, systemd-run, all came from RakuOS.
- Some KDE/browser profiles that were missing: ark, gwenview, kate, kcalc, kinfocenter, kmenuedit, spectacle, brave-origin, claude-desktop, helium-bin
- Full COSMIC group (36 files) ported over, though it stays behind the existing WIP ignore like upstream intends
- ksshaskpass got its own profile instead of inheriting whatever confined it (was a mess of KDE/Qt/font denials before)
- A specfile for Fedora builds.

A lot of denial fixes across existing profiles..
Way too many to list individually, but the shape of it: KDE apps needed authselect paths, crypto-policies, kde-settings profile dir. Flatpak stuff needed a bunch of sandbox filesystem and dbus work (xdg-desktop-portal, xdg-document-portal, flatpak-portal, flatpak-session-helper). Xorg/X11 tools needed xauth handling cleaned up. mkvtoolnix, smplayer, qbittorrent, okular, nvidia-settings all needed the usual file-picker-touches-your-whole-home-and-every-mount treatment, done through owner rules instead of blanket access. gparted needed cgroup path handling for both plain and containerized sessions. packagekitd needed a lot of dnf5-specific gpg/rpm work. git needed glab support alongside the existing gh handling, and its ssh-askpass path needed fixing.

One thing specific to atomic Fedora: on ostree/bootc systems your real home is at /var/home/<user>, with /home just a symlink - AppArmor matches the resolved path, not through the symlink, so without this every @{HOME}-derived rule in the whole project silently didn't apply. That's a one-line tunable fix but it matters a lot if you're on Silverblue/Kinoite or similar.

Known gaps:
GNOME Workstation hasn't gotten the same real-world testing KDE has, so there's probably denials I haven't hit yet. Same goes for anything outside my own daily driver setup - browsers/apps I don't personally use, hardware I don't have, etc. If something's missing, it's very likely just because I haven't hit that code path myself yet, not because it's intentionally excluded. This is meant to be a starting point to begin supporting Fedora.

Currently we're testing it on Fedora KDE and soon in RakuOS.
Soon we'll let Nobara folks know about it too.