### PR TITLE
Draft: fix(calibre) adding permissions for TTS functions, saving data from viewer and full confiment of binary release

### DIFF
--- a/apparmor.d/profiles-a-f/calibre
+++ b/apparmor.d/profiles-a-f/calibre
@@ -34,7 +34,7 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/qt5-settings-write>
   include <abstractions/qt5-shader-cache>
   include <abstractions/ssl_certs>
-  include <abstractions/thumbnails-cache-read>
+  include <abstractions/thumbnails-cache-write>
   include <abstractions/trash-strict>
   include <abstractions/user-download-strict>
 
@@ -53,6 +53,7 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   # unix (send, receive) type=stream peer=(addr=none, label=xorg),
   unix (bind, listen)  type=stream addr="@*-calibre-gui.socket",
   unix (bind)          type=stream addr="@calibre-*",
+  unix type=seqpacket  peer=(label=calibre//webengine),
 
   @{exec_path} mrix,
 
@@ -61,18 +62,22 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   @{bin}/env               r,
   @{bin}/file              rix,
   @{bin}/jpegtran          rix,
+  @{bin}/kdialog           rix, # used on KDE, if available
   @{bin}/net               rix,
+  @{bin}/speech-dispatcher Px,
+  @{bin}/testparm          rix,
   @{bin}/uname             rix,
+  @{bin}/zenity            mrix, # used on Gnome, if available
   @{sbin}/ldconfig{,.real} rix,
 
   #aa:exec kioworker
 
-  @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess rPx -> calibre//&calibre//webengine,
-  /opt/calibre/libexec/QtWebEngineProcess                      rPx -> calibre//&calibre//webengine,
+  @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess mrPx -> calibre//&calibre//webengine,
+  /opt/calibre/libexec/QtWebEngineProcess                      mrPx -> calibre//&calibre//webengine,
 
-  @{bin_dirs}/pdftoppm        Cx -> poppler,
-  @{bin_dirs}/pdfinfo         Cx -> poppler,
-  @{bin_dirs}/pdftohtml       Cx -> poppler,
+  @{bin_dirs}/pdftoppm        mrCx -> poppler,
+  @{bin_dirs}/pdfinfo         mrCx -> poppler,
+  @{bin_dirs}/pdftohtml       mrCx -> poppler,
 
   @{open_path}            rPx -> child-open,
 
@@ -87,12 +92,21 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   # required for access to resources normally in /usr/share/calibre
   /opt/calibre/{,**} r,
 
+  /etc/exports r,
   /etc/fstab r,
   /etc/inputrc r,
   /etc/krb5.conf r,
+  /etc/krb5.conf.d/ r,
   /etc/magic r,
+  /etc/samba/smb.conf r,
+  /etc/xdg/dolphinrc r,
+  @{etc_ro}/krb5.conf r,
+  @{etc_ro}/vdpau_wrapper.cfg r,
 
   owner /var/cache/samba/ w,
+
+  @{lib}/ r,
+  /usr/local/lib{,64}/ r,
 
   @{MOUNTDIRS} r,
   owner @{MOUNTS}/ r,
@@ -100,9 +114,10 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
         /home/ r,
   owner @{HOME}/ r,
-  owner @{HOME}/*.{pdf,@{image_ext}} rw, # for printing pdfs and images in the viewer
-  owner "@{HOME}/Calibre Library/{,**}" rw,
+  owner @{HOME}/*.{pdf,@{image_ext}} w,              # for printing pdfs and images in the viewer
+  owner "@{HOME}/Calibre Library/{,**}" rwl,
   owner "@{HOME}/Calibre Library/**.{db,sqlite}" k,
+  owner @{HOME}/*{,/} r,                             # ToDo: no idea how to silence uneccesery access by using deny, left this way
 
   owner @{user_books_dirs}/{,**} rwl,
   owner @{user_books_dirs}/Calibre/** rwk,
@@ -121,9 +136,11 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_config_dirs}/calibre/ rw,
   owner @{user_config_dirs}/calibre/** rwk,
   owner @{user_config_dirs}/calibrerc.lock        rwk,
+  owner @{user_config_dirs}/ibus/bus/@{hex32}-unix-wayland-0 r,
   owner @{user_config_dirs}/kdeglobals*           rw,
   owner link @{user_config_dirs}/kdeglobals.@{rand6} -> @{user_config_dirs}/#@{int},
   owner @{user_config_dirs}/kdeglobals.lock k,
+  owner @{user_config_dirs}/kdialogrc.lock rwk,
   owner @{user_config_dirs}/kservicemenurc r,
   owner @{user_config_dirs}/kioslaverc r,
   owner link @{user_config_dirs}/QtProject.conf.@{rand6} -> @{user_config_dirs}/#@{int},
@@ -131,8 +148,11 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_share_dirs}/calibre-ebook.com/ rw,
   owner @{user_share_dirs}/calibre-ebook.com/** rwk,
   owner @{user_state_dirs}/calibrestaterc* rw,
-  owner link @{user_state_dirs}/calibrestaterc.@{rand6} -> @{user_state_dirs}/#@{int},
+  owner link @{user_state_dirs}/calibrestaterc{,.@{rand6}} -> @{user_state_dirs}/#@{int},
   owner @{user_state_dirs}/calibrestaterc.lock k,
+  owner @{user_state_dirs}/kdialogstaterc* rw,
+  owner link @{user_state_dirs}/kdialogstaterc.@{rand6} -> @{user_state_dirs}/#@{int},
+  owner @{user_state_dirs}/kdialogstaterc.lock k,
   owner @{user_share_dirs}/user-places.xbel r,
 
   owner @{tmp}/@{word8} rwl,
@@ -141,11 +161,17 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{tmp}/calibre-@{word8}/{,**} rw,
   owner @{tmp}/calibre-@{rand6}/{,**} rw,
 
-        @{run}/udev/data/b8:@{int} r,  # for /dev/sd*
+        @{run}/udev/data/b8:@{int} r,      # for /dev/sd*
+        @{run}/udev/data/b254:@{int} r,    # for /dev/zram*4
 
+        @{run}/mount/utab r,
         @{run}/user/@{uid}/gvfs/ r,
   owner @{run}/user/@{uid}/calibre@{rand6}.@{int}.kioworker.socket w,
+  owner @{run}/user/@{uid}/kdialog@{rand6}.@{int}.kioworker.socket w,
   owner link @{run}/user/@{uid}/calibre@{rand6}.@{int}.kioworker.socket -> @{run}/user/@{uid}/#@{int},
+  owner link @{run}/user/@{uid}/kdialog@{rand6}.@{int}.kioworker.socket -> @{run}/user/@{uid}/#@{int},
+  owner @{run}/user/@{uid}/gvfsd/socket-@{word8} rw,                       # needed at least on ubuntu
+  owner @{run}/user/@{uid}/speech-dispatcher/speechd.sock rw,              # needed at least on ubuntu
 
   owner /dev/shm/#@{int} rw,
   owner /dev/shm/sem.@{rand6} rw,
@@ -153,7 +179,7 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner link /dev/shm/sem.mp-@{word8} -> /dev/shm/sem.@{rand6},
 
         @{sys}/class/accel/ r,
-        @{sys}/devices/{,**/} r, # all of it is required for calibre's DeviceManager to work
+        @{sys}/devices/{,**/} r,            # all of it is required for calibre's DeviceManager to work
 
         @{PROC}/ r,
         @{PROC}/@{pids}/stat r,
@@ -179,8 +205,9 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner /dev/tty@{u8} rw,
 
   # Silencer
-  deny owner @{HOME}/.bash* r,
+  #deny owner @{HOME}/.bash* r,          # ToDo: extending it to all hidden files in user's directory causes sometimes problems with viewer operations
   deny owner /usr/share/qt6/resources/locales/ w,
+  deny owner @{lib}/**/__pycache__/{,**} w,
 
   profile poppler {
     include <abstractions/base>
@@ -206,16 +233,20 @@ profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   # only to be used stacked
   profile webengine {
     include <abstractions/base>
-    include <abstractions/gstreamer>  # needed on Gnome (to directly access glycin)
+    include <abstractions/gstreamer>        # needed on Gnome (to directly access glycin)
     include <abstractions/common/chromium>
 
     signal receive set=term peer=calibre,
     signal (send receive) set=kill peer=calibre//&calibre//webengine,
 
-    @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess r,
-    /opt/calibre/libexec/QtWebEngineProcess                      r,
+    unix type=seqpacket peer=(label=calibre),
+    unix type=stream    peer=(label=calibre),
+
+    @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess mr,
+    /opt/calibre/libexec/QtWebEngineProcess                      mr,
 
     /usr/share/fonts/** r,
+    /usr/share/icu/** r,
     /usr/share/qt6/** r,
 
     /opt/calibre/{lib,resources,translations}/** r,

--- a/apparmor.d/profiles-a-f/calibre
+++ b/apparmor.d/profiles-a-f/calibre
@@ -11,11 +11,14 @@ include <tunables/global>
 
 @{bin_dirs} = @{bin} /opt/calibre{,/bin}
 
-@{exec_path}  = @{bin_dirs}/calibre{,-*} @{bin_dirs}/calibredb @{bin_dirs}/ebook{,-*}
-@{exec_path} += @{bin_dirs}/fetch-ebook-metadata
-@{exec_path} += @{bin_dirs}/lrs2lrf @{bin_dirs}/lrf2lrs @{bin_dirs}/lrfviewer @{bin_dirs}/web2disk
-profile calibre @{exec_path} {
+@{name} = calibre{,db} calibre-{customize,debug,parallel,server,smtp}
+@{name} += ebook-{convert,device,edit,meta,polish,viewer}
+@{name} += fetch-ebook-metadata lrf2lrs lrfviewer lrs2lrf markdown-calibre web2disk
+
+@{exec_path} = @{bin_dirs}/@{name}
+profile calibre @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
+  include <abstractions/audio-client>
   include <abstractions/bus/session/org.kde.StatusNotifierWatcher>
   include <abstractions/bus/system/org.freedesktop.UDisks2>
   include <abstractions/common/chromium>
@@ -43,26 +46,29 @@ profile calibre @{exec_path} {
   network inet6 stream,
   network netlink raw,
 
+  ptrace read peer=calibre//&calibre//webengine,
+
+  signal send set=term peer=kioworker,
+
   # unix (send, receive) type=stream peer=(addr=none, label=xorg),
   unix (bind, listen)  type=stream addr="@*-calibre-gui.socket",
   unix (bind)          type=stream addr="@calibre-*",
 
   @{exec_path} mrix,
 
-  @{sh_path}              rix,
-  @{python_path}          rix,
-  @{bin}/env                r,
-  @{bin}/file             rix,
-  @{bin}/jpegtran         rix,
-  @{bin}/uname            rix,
+  @{sh_path}               rix,
+  @{python_path}           rix,
+  @{bin}/env               r,
+  @{bin}/file              rix,
+  @{bin}/jpegtran          rix,
+  @{bin}/net               rix,
+  @{bin}/uname             rix,
   @{sbin}/ldconfig{,.real} rix,
 
   #aa:exec kioworker
 
-  # both are run with no new privileges flag
-  # changing to child profile is impossible without include chromium abstraction in the parent profile
-  @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess rix,
-  /opt/calibre/libexec/QtWebEngineProcess   rix,
+  @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess rPx -> calibre//&calibre//webengine,
+  /opt/calibre/libexec/QtWebEngineProcess                      rPx -> calibre//&calibre//webengine,
 
   @{bin_dirs}/pdftoppm        Cx -> poppler,
   @{bin_dirs}/pdfinfo         Cx -> poppler,
@@ -73,22 +79,30 @@ profile calibre @{exec_path} {
   /opt/calibre/{lib,plugins}/**.so{,.*} rm,
 
   /usr/share/calibre/{,**} r,
+  /usr/share/espeak-ng-data/{,**} r,
+  /usr/share/file/misc/magic.mgc r,
   /usr/share/qt6/resources/**  r,
+  /usr/share/thumbnailers/{,*.thumbnailer} r,
 
   # required for access to resources normally in /usr/share/calibre
-  /opt/calibre/**/{,*} r,
+  /opt/calibre/{,**} r,
 
   /etc/fstab r,
   /etc/inputrc r,
+  /etc/krb5.conf r,
   /etc/magic r,
+
+  owner /var/cache/samba/ w,
 
   @{MOUNTDIRS} r,
   owner @{MOUNTS}/ r,
   owner @{MOUNTS}/** rw,
 
+        /home/ r,
   owner @{HOME}/ r,
+  owner @{HOME}/*.{pdf,@{image_ext}} rw, # for printing pdfs and images in the viewer
   owner "@{HOME}/Calibre Library/{,**}" rw,
-  owner "@{HOME}/Calibre Library/metadata.db" rwk,
+  owner "@{HOME}/Calibre Library/**.{db,sqlite}" k,
 
   owner @{user_books_dirs}/{,**} rwl,
   owner @{user_books_dirs}/Calibre/** rwk,
@@ -99,44 +113,57 @@ profile calibre @{exec_path} {
   owner @{user_work_dirs}/{,**} rwl,
   owner @{user_work_dirs}/Calibre/** rwk,
 
-  owner @{user_config_dirs}/#@{int}               rw,
-  owner @{user_config_dirs}/calibrerc.lock        rwk,
-  owner @{user_config_dirs}/kdeglobals            w,
-  owner @{user_config_dirs}/kdeglobals.@{rand6}   rw,
-  owner link @{user_config_dirs}/kdeglobals.@{rand6} -> @{user_config_dirs}/#@{int},
-  owner @{user_config_dirs}/kdeglobals.lock          rwk,
-  owner @{user_config_dirs}/kioslaverc               r,
+  owner @{user_cache_dirs}/calibre/ rw,
+  owner @{user_cache_dirs}/calibre/** rwlk -> @{user_cache_dirs}/calibre/**,
+  owner @{user_cache_dirs}/calibre-ebook.com/{,**} rw,
 
+  owner @{user_config_dirs}/#@{int}               rw,
   owner @{user_config_dirs}/calibre/ rw,
   owner @{user_config_dirs}/calibre/** rwk,
+  owner @{user_config_dirs}/calibrerc.lock        rwk,
+  owner @{user_config_dirs}/kdeglobals*           rw,
+  owner link @{user_config_dirs}/kdeglobals.@{rand6} -> @{user_config_dirs}/#@{int},
+  owner @{user_config_dirs}/kdeglobals.lock k,
+  owner @{user_config_dirs}/kservicemenurc r,
+  owner @{user_config_dirs}/kioslaverc r,
+  owner link @{user_config_dirs}/QtProject.conf.@{rand6} -> @{user_config_dirs}/#@{int},
 
   owner @{user_share_dirs}/calibre-ebook.com/ rw,
   owner @{user_share_dirs}/calibre-ebook.com/** rwk,
-
-  owner @{user_cache_dirs}/calibre/ rw,
-  owner @{user_cache_dirs}/calibre/** rwlk -> @{user_cache_dirs}/calibre/**,
+  owner @{user_state_dirs}/calibrestaterc* rw,
+  owner link @{user_state_dirs}/calibrestaterc.@{rand6} -> @{user_state_dirs}/#@{int},
+  owner @{user_state_dirs}/calibrestaterc.lock k,
+  owner @{user_share_dirs}/user-places.xbel r,
 
   owner @{tmp}/@{word8} rwl,
   audit owner @{tmp}/@{int}-*/ rw,
   audit owner @{tmp}/@{int}-*/** rwl,
   owner @{tmp}/calibre-@{word8}/{,**} rw,
+  owner @{tmp}/calibre-@{rand6}/{,**} rw,
+
+        @{run}/udev/data/b8:@{int} r,  # for /dev/sd*
+
+        @{run}/user/@{uid}/gvfs/ r,
+  owner @{run}/user/@{uid}/calibre@{rand6}.@{int}.kioworker.socket w,
+  owner link @{run}/user/@{uid}/calibre@{rand6}.@{int}.kioworker.socket -> @{run}/user/@{uid}/#@{int},
 
   owner /dev/shm/#@{int} rw,
   owner /dev/shm/sem.@{rand6} rw,
   owner /dev/shm/sem.mp-@{word8} w,
   owner link /dev/shm/sem.mp-@{word8} -> /dev/shm/sem.@{rand6},
 
-  @{sys}/devices/ r,
-  @{sys}/devices/**/ r,        # ToDo: probably should be checked in calibre source what is really needed
-  @{sys}/devices/@{pci}/irq r,
+        @{sys}/class/accel/ r,
+        @{sys}/devices/{,**/} r, # all of it is required for calibre's DeviceManager to work
 
         @{PROC}/ r,
+        @{PROC}/@{pids}/stat r,
         @{PROC}/@{pids}/net/route r,
         @{PROC}/sys/fs/inotify/max_user_watches r,
         @{PROC}/sys/kernel/random/boot_id r,
         @{PROC}/sys/kernel/yama/ptrace_scope r,
         @{PROC}/vmstat r,
   owner @{PROC}/@{pid}/cmdline r,
+  owner @{PROC}/@{pid}/cgroup r,
   owner @{PROC}/@{pid}/comm r,
   owner @{PROC}/@{pid}/fd/ r,
   owner @{PROC}/@{pid}/mountinfo r,
@@ -147,8 +174,13 @@ profile calibre @{exec_path} {
   owner @{PROC}/@{pid}/task/@{tid}/comm rw,
   owner @{PROC}/@{pid}/task/@{tid}/status r,
 
+        /dev/disk/by-label/ r,
         /dev/tty r,
   owner /dev/tty@{u8} rw,
+
+  # Silencer
+  deny owner @{HOME}/.bash* r,
+  deny owner /usr/share/qt6/resources/locales/ w,
 
   profile poppler {
     include <abstractions/base>
@@ -163,12 +195,49 @@ profile calibre @{exec_path} {
 
     /usr/share/poppler/{,**} r,
 
-    owner @{tmp}/calibre-@{word8}/**.{jpg,png} w,
+    owner @{tmp}/calibre-@{word8}/**.@{image_ext} w,
     owner @{tmp}/calibre-@{word8}/**log rw,
     owner @{tmp}/calibre-@{word8}/*/src.pdf r,
     owner @{tmp}/calibre-@{word8}/*/index.xml w,
 
     include if exists <local/calibre_poppler>
+  }
+
+  # only to be used stacked
+  profile webengine {
+    include <abstractions/base>
+    include <abstractions/gstreamer>  # needed on Gnome (to directly access glycin)
+    include <abstractions/common/chromium>
+
+    signal receive set=term peer=calibre,
+    signal (send receive) set=kill peer=calibre//&calibre//webengine,
+
+    @{lib}/{,@{multiarch}/}qt{5,6}/{,libexec/}QtWebEngineProcess r,
+    /opt/calibre/libexec/QtWebEngineProcess                      r,
+
+    /usr/share/fonts/** r,
+    /usr/share/qt6/** r,
+
+    /opt/calibre/{lib,resources,translations}/** r,
+    /opt/calibre/lib/*.so*   m,
+
+    owner @{tmp}/calibre-@{word8}/*  rw,
+
+    @{sys}/devices/system/cpu/present r,
+    @{sys}/devices/system/cpu/cpufreq/policy@{u8}/cpuinfo_max_freq r,
+
+          @{PROC}/ r,
+          @{PROC}/sys/fs/inotify/max_user_watches r,
+          @{PROC}/sys/kernel/yama/ptrace_scope r,
+    owner @{PROC}/@{pid}/cmdline r,
+    owner @{PROC}/@{pid}/fd/ r,
+    owner @{PROC}/@{pid}/statm r,
+
+    # Silencer
+    deny @{HOME}/{,**} rw,
+    deny owner /usr/share/qt6/resources/locales/ w,
+
+    include if exists <local/calibre_webengine>
   }
 
   include if exists <local/calibre>

--- a/apparmor.d/profiles-a-f/calibre-uninstall
+++ b/apparmor.d/profiles-a-f/calibre-uninstall
@@ -1,0 +1,66 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# An uninstaller shared with the official binary release
+# https://calibre-ebook.com/download_linux (The third point in the notes)
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{name} = calibre{,db} calibre-{customize,debug,parallel,server,smtp}
+@{name} += ebook-{convert,device,edit,meta,polish,viewer}
+@{name} += fetch-ebook-metadata lrf2lrs lrfviewer lrs2lrf markdown-calibre web2disk
+
+@{exec_path} = @{bin}/calibre-uninstall
+profile calibre-uninstall @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/consoles>
+  include <abstractions/icons>
+  include <abstractions/mime>
+  include <abstractions/nameservice-strict>
+  include <abstractions/python>
+  include <abstractions/common/xdg>
+
+  capability dac_read_search,
+  #aa:only opensuse
+  capability dac_override, # required on OpenSUSE
+
+  @{exec_path} mr,
+  @{sh_path} r,
+
+  @{python_path}                   rix,
+  @{bin}/id                        rPx,
+  @{bin}/gtk{,4}-update-icon-cache Px,
+  @{bin}/update-desktop-database   Px,
+  @{bin}/update-mime-database      Px,
+  @{bin}/xdg-desktop-menu          rix,
+  @{bin}/xdg-icon-resource         rix,
+  @{bin}/xdg-mime                  rix,
+
+  # binaries and symlinks to be deleted
+  @{bin}/@{name} w,
+  @{bin}/calibre-uninstall w,
+
+  /usr/share/applications/calibre-*.desktop w,
+  /usr/share/bash-completion/completions/@{name} w,
+  /usr/share/icons/hicolor/.xdg-icon-resource-dummy w,
+  /usr/share/icons/hicolor/**.png w,
+  /usr/share/metainfo/calibre-*.metainfo.xml w,
+  /usr/share/zsh/site-functions/_calibre w,
+  /usr/share/zsh/vendor-completions/_calibre w,
+
+  /opt/calibre/{,**}    rw,
+
+  @{tmp}/@{word8} rw,
+  @{tmp}/mime-hack.@{word8}/ rw,
+  @{tmp}/mime-hack.@{word8}/calibre-mimetypes.xml rw,
+
+  # Silencer
+  deny @{HOME}/{,**} rw,
+
+  include if exists <local/calibre-uninstall>
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Filling of the calibre profile works out pretty fine. So far I haven't seen any major new issues and I focused on finishing confining binary release and trying to improve QtWebEngine confinement. At this point I have a few ideas, but I think it's best to check it out on public.

So far I haven't seen QtWebEngine used in any way besides the preview, I checked it in the source code as well. Everything else seems to be performed inside calibre's own processes, chromium process won't need any access to additional user's files, besides /tmp.

For this draft everything was left in the calibre file, as it was simpler to work on it this way. I think it's easiest to look at it commit by commit, as they represent different possibilities.

Ignoring the first commit, the points are:
1. Does calibre-uninstall require this fine-tuned confinement or can it be let much looser?
2. Should simplified version of the calibre-uninstall be used (with inherited xdg-* execs) or version with children profiles (they are needed, as avoiding them would require expanding the main profiles)
3. Can @{name} (inspired by the Firefox profile) variable be used and can calibre-uninstall profile stay in the same file? The second simplifies matter with using the variable (I used to it limit possible files, which could be modified by calibre-uninstall), but moving everything to separate profiles is not such a big of a deal - we could go back to the old confinement of calibre processes and just list all the links to the binaries in uninstaller (at least in my mind, broader confinement in calibre profile is better, but allowing a process, which in reality is a python script to modify too much in /usr/bin is a danger)
4. Should webengine profile be moved outside to ie. calibre-webengine file or can it stay inside calibre profile with this nonstandard path? (calibre//&calibre//webengine)

With these cleared, I'll merge the final version with the rest of the changes found on Arch, Debian, Gnome and binary release, upload logs and more or less up-to-date profile for calibre would be ready.