### PR TITLE
feat: recognize Fedora as a supported distribution (core prebuild system)

### DIFF
--- a/apparmor.d/tunables/home.d/apparmor.d
+++ b/apparmor.d/tunables/home.d/apparmor.d
@@ -3,6 +3,14 @@
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
+# ostree/bootc-based Fedora Atomic variants (Silverblue, Kinoite, IoT, CoreOS)
+# keep real user home directories at /var/home/<user>/, with /home a symlink
+# to /var/home - AppArmor matches the resolved path, not through the symlink,
+# so without this, @{HOME} (and everything derived from it: user_config_dirs,
+# user_cache_dirs, etc.) never matches on those variants.
+#aa:only fedora
+@{HOMEDIRS}+=/var/home/
+
 # To allow extended personalisation by the user without breaking everything.
 # All apparmor profiles should always use the variables defined here.
 

--- a/apparmor.d/tunables/home.d/apparmor.d
+++ b/apparmor.d/tunables/home.d/apparmor.d
@@ -3,11 +3,8 @@
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
-# ostree/bootc-based Fedora Atomic variants (Silverblue, Kinoite, IoT, CoreOS)
-# keep real user home directories at /var/home/<user>/, with /home a symlink
-# to /var/home - AppArmor matches the resolved path, not through the symlink,
-# so without this, @{HOME} (and everything derived from it: user_config_dirs,
-# user_cache_dirs, etc.) never matches on those variants.
+# ostree/bootc Fedora Atomic variants keep homes at /var/home/<user>, /home a
+# symlink; AppArmor matches the resolved path, not through the symlink.
 #aa:only fedora
 @{HOMEDIRS}+=/var/home/
 

--- a/apparmor.d/tunables/home.d/apparmor.d
+++ b/apparmor.d/tunables/home.d/apparmor.d
@@ -3,9 +3,9 @@
 # Copyright (C) 2021-2024 Alexandre Pujol <alexandre@pujol.io>
 # SPDX-License-Identifier: GPL-2.0-only
 
+#aa:only fedora
 # ostree/bootc Fedora Atomic variants keep homes at /var/home/<user>, /home a
 # symlink; AppArmor matches the resolved path, not through the symlink.
-#aa:only fedora
 @{HOMEDIRS}+=/var/home/
 
 # To allow extended personalisation by the user without breaking everything.

--- a/apparmor.d/tunables/multiarch.d/system
+++ b/apparmor.d/tunables/multiarch.d/system
@@ -16,7 +16,7 @@
 # Common places for binaries and libraries across distributions
 @{bin}=/{,usr/}bin
 @{sbin}=/{,usr/}sbin     #aa:only apt zypper
-@{sbin}=/{,usr/}{,s}bin  #aa:only pacman
+@{sbin}=/{,usr/}{,s}bin  #aa:only pacman fedora
 @{lib}=/{,usr/}lib{,exec,32,64}
 
 # Common places for temporary files
@@ -57,6 +57,10 @@
 #aa:only opensuse
 # OpenSUSE does not have the same multiarch structure
 @{multiarch}+=*-suse-linux*
+
+#aa:only fedora
+# Fedora/RHEL does not have the same multiarch structure (no "-gnu" suffix)
+@{multiarch}+=*-redhat-linux*
 
 
 # System Internal

--- a/dists/apparmor.d-fedora.spec
+++ b/dists/apparmor.d-fedora.spec
@@ -1,0 +1,86 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2023 Christian Boltz
+# Copyright (C) 2023-2024 Alexandre Pujol <alexandre@pujol.io>
+# Copyright (c) 2026 CatPieLeaf <catpieleaf@proton.me>
+# SPDX-License-Identifier: GPL-2.0-only
+
+%define _complain 0
+
+Name:           apparmor.d
+Version:        0.4910.0
+Release:        1%{?dist}
+Summary:        Full set of AppArmor policies
+License:        GPL-2.0-only
+URL:            https://github.com/roddhjav/apparmor.d
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+Requires:       apparmor-profiles
+Requires:       apparmor-parser
+Requires:       apparmor-utils
+BuildRequires:  just
+BuildRequires:  golang
+BuildRequires:  systemd-rpm-macros
+
+%description
+AppArmor.d is a set of over 1500 AppArmor profiles whose aim is to
+confine most Linux based applications and processes.
+
+%if %{_complain}
+Built in COMPLAIN mode: violations are logged but not blocked.
+Use this mode with aa-logprof for fixing profiles.
+%else
+Built in ENFORCE mode: violations are actively blocked. Make sure
+you have already validated this profile set in complain mode.
+%endif
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%if %{_complain} == 1
+just complain
+%else
+just enforce
+%endif
+
+%install
+just destdir="%{buildroot}" install-prebuilt
+just destdir="%{buildroot}" install-base
+just destdir="%{buildroot}" install-tools
+
+# Do not force dbus(-broker).service under AppArmorProfile= via systemd
+# drop-in. dbus underlies PAM's session bus, kwallet registration, and
+# polkit, so a boot-time dbus confinement race cascades into hard-to-diagnose
+# auth/wallet breakage on Fedora Atomic variants.
+rm -rf %{buildroot}/usr/lib/systemd/system/*.service.d
+rm -rf %{buildroot}/usr/lib/systemd/user/*.service.d
+
+%posttrans
+apparmor_parser --purge-cache || :
+systemctl daemon-reload || :
+if systemctl is-active --quiet apparmor.service 2>/dev/null; then
+    systemctl try-restart apparmor.service || :
+fi
+
+%postun
+systemctl daemon-reload || :
+if [ $1 -eq 0 ] ; then
+    apparmor_parser --purge-cache || :
+fi
+
+%files
+%license LICENSE
+%doc README.md
+%config /etc/apparmor.d/
+%{_bindir}/aa-log
+%{_bindir}/aa-mode
+
+%dir %{_datadir}/zsh
+%dir %{_datadir}/zsh/site-functions
+%{_datadir}/zsh/site-functions/_aa-*.zsh
+%{_datadir}/bash-completion/completions/aa-*
+%doc %{_mandir}/man1/aa-*.1.gz
+%doc %{_mandir}/man8/aa-*.8.gz
+
+%changelog

--- a/dists/apparmor.d-fedora.spec
+++ b/dists/apparmor.d-fedora.spec
@@ -49,10 +49,8 @@ just destdir="%{buildroot}" install-prebuilt
 just destdir="%{buildroot}" install-base
 just destdir="%{buildroot}" install-tools
 
-# Do not force dbus(-broker).service under AppArmorProfile= via systemd
-# drop-in. dbus underlies PAM's session bus, kwallet registration, and
-# polkit, so a boot-time dbus confinement race cascades into hard-to-diagnose
-# auth/wallet breakage on Fedora Atomic variants.
+# Don't force dbus(-broker).service under AppArmorProfile= - causes boot-time
+# auth/wallet breakage (PAM session bus, kwallet, polkit) on Fedora Atomic.
 rm -rf %{buildroot}/usr/lib/systemd/system/*.service.d
 rm -rf %{buildroot}/usr/lib/systemd/user/*.service.d
 

--- a/dists/apparmor.d-fedora.spec
+++ b/dists/apparmor.d-fedora.spec
@@ -49,11 +49,6 @@ just destdir="%{buildroot}" install-prebuilt
 just destdir="%{buildroot}" install-base
 just destdir="%{buildroot}" install-tools
 
-# Don't force dbus(-broker).service under AppArmorProfile= - causes boot-time
-# auth/wallet breakage (PAM session bus, kwallet, polkit) on Fedora Atomic.
-rm -rf %{buildroot}/usr/lib/systemd/system/*.service.d
-rm -rf %{buildroot}/usr/lib/systemd/user/*.service.d
-
 %posttrans
 apparmor_parser --purge-cache || :
 systemctl daemon-reload || :

--- a/dists/apparmor.d-fedora.spec
+++ b/dists/apparmor.d-fedora.spec
@@ -76,4 +76,13 @@ fi
 %doc %{_mandir}/man1/aa-*.1.gz
 %doc %{_mandir}/man8/aa-*.8.gz
 
+%dir %{_unitdir}/dbus.service.d
+%{_unitdir}/dbus.service.d/apparmor.conf
+%dir %{_unitdir}/dbus-broker.service.d
+%{_unitdir}/dbus-broker.service.d/apparmor.conf
+%dir %{_userunitdir}/dbus.service.d
+%{_userunitdir}/dbus.service.d/apparmor.conf
+%dir %{_userunitdir}/dbus-broker.service.d
+%{_userunitdir}/dbus-broker.service.d/apparmor.conf
+
 %changelog

--- a/dists/ignore/debian.ignore
+++ b/dists/ignore/debian.ignore
@@ -2,7 +2,10 @@
 apparmor.d/groups/pacman
 share/libalpm
 
-# Ubuntu specific definition 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
+# Ubuntu specific definition
 apparmor.d/groups/ubuntu
 
 # OpenSUSE specific definition

--- a/dists/ignore/fedora.ignore
+++ b/dists/ignore/fedora.ignore
@@ -1,3 +1,10 @@
+# Same-named sample profiles bundled by Fedora's apparmor-parser package
+# under /etc/apparmor.d/ (different content), causing RPM file conflicts
+apparmor.d/profiles-a-f/dig
+apparmor.d/profiles-m-r/nslookup
+apparmor.d/profiles-m-r/podman
+apparmor.d/groups/procps/free
+
 # Debian specific definition
 apparmor.d/groups/apt
 

--- a/dists/ignore/fedora.ignore
+++ b/dists/ignore/fedora.ignore
@@ -1,10 +1,3 @@
-# Same-named sample profiles bundled by Fedora's apparmor-parser package
-# under /etc/apparmor.d/ (different content), causing RPM file conflicts
-apparmor.d/profiles-a-f/dig
-apparmor.d/profiles-m-r/nslookup
-apparmor.d/profiles-m-r/podman
-apparmor.d/groups/procps/free
-
 # Debian specific definition
 apparmor.d/groups/apt
 

--- a/dists/ignore/fedora.ignore
+++ b/dists/ignore/fedora.ignore
@@ -1,8 +1,9 @@
 # Debian specific definition
 apparmor.d/groups/apt
 
-# Fedora specific definition
-apparmor.d/groups/dnf
+# Archlinux specific definition
+apparmor.d/groups/pacman
+share/libalpm
 
 # Ubuntu specific definition
 apparmor.d/groups/ubuntu

--- a/dists/ignore/opensuse.ignore
+++ b/dists/ignore/opensuse.ignore
@@ -5,7 +5,10 @@ share/libalpm
 # Debian specific definition
 apparmor.d/groups/apt
 
-# Ubuntu specific definition 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
+# Ubuntu specific definition
 apparmor.d/groups/ubuntu
 
 # Profiles provided by they own package

--- a/dists/ignore/ubuntu.ignore
+++ b/dists/ignore/ubuntu.ignore
@@ -2,6 +2,9 @@
 apparmor.d/groups/pacman
 share/libalpm
 
+# Fedora specific definition
+apparmor.d/groups/dnf
+
 # OpenSUSE specific definition
 apparmor.d/groups/suse
 

--- a/docs/development/directives.md
+++ b/docs/development/directives.md
@@ -38,8 +38,8 @@ The `only` and `exclude` directives can be used to filter individual rule or rul
 
 :   The filter to apply. Can be:
 
-    - A supported target distribution: `arch`, `debian`, `ubuntu`, `opensuse`.
-    - A supported distribution family: `apt`, `pacman`, `zypper`.
+    - A supported target distribution: `arch`, `debian`, `ubuntu`, `opensuse`, `fedora`.
+    - A supported distribution family: `apt`, `pacman`, `zypper`, `dnf`.
     - A supported ABI: `abi3`, `abi4`.
 
 **Example**

--- a/pkg/builder/attach.go
+++ b/pkg/builder/attach.go
@@ -26,6 +26,20 @@ func NewAttach() *ReAttach {
 	}
 }
 
+// reAttachExclude lists profiles that must keep their plain attach_disconnected
+// flag without the attach_disconnected.path=@{att} extension or the attached/*
+// abstraction swap. These profiles Px-transition into small setuid PAM helpers
+// (unix_chkpwd) to authenticate the user, and the disconnected-path reattachment
+// mechanism breaks that exec transition under real kernel enforcement even though
+// it compiles and merges cleanly.
+var reAttachExclude = map[string]bool{
+	"sudo":        true,
+	"sudo-rs":     true,
+	"su":          true,
+	"su-rs":       true,
+	"unix-chkpwd": true,
+}
+
 // Apply will re-attach the disconnected path
 //   - Add the attach_disconnected.path flag on all profile with the attach_disconnected flag
 //   - Replace the base abstraction by attached/base
@@ -43,7 +57,7 @@ func (b ReAttach) Apply(opt *Option, profile string) (string, error) {
 		return profile, nil // Do not re-attach twice
 	}
 
-	if strings.Contains(profile, "attach_disconnected") {
+	if strings.Contains(profile, "attach_disconnected") && !reAttachExclude[opt.Name] {
 		if opt.Kind == aa.ProfileKind {
 			if strings.Contains(opt.Name, ":") {
 				parts := strings.Split(opt.Name, ":")

--- a/pkg/builder/attach.go
+++ b/pkg/builder/attach.go
@@ -26,20 +26,6 @@ func NewAttach() *ReAttach {
 	}
 }
 
-// reAttachExclude lists profiles that must keep their plain attach_disconnected
-// flag without the attach_disconnected.path=@{att} extension or the attached/*
-// abstraction swap. These profiles Px-transition into small setuid PAM helpers
-// (unix_chkpwd) to authenticate the user, and the disconnected-path reattachment
-// mechanism breaks that exec transition under real kernel enforcement even though
-// it compiles and merges cleanly.
-var reAttachExclude = map[string]bool{
-	"sudo":        true,
-	"sudo-rs":     true,
-	"su":          true,
-	"su-rs":       true,
-	"unix-chkpwd": true,
-}
-
 // Apply will re-attach the disconnected path
 //   - Add the attach_disconnected.path flag on all profile with the attach_disconnected flag
 //   - Replace the base abstraction by attached/base
@@ -57,7 +43,7 @@ func (b ReAttach) Apply(opt *Option, profile string) (string, error) {
 		return profile, nil // Do not re-attach twice
 	}
 
-	if strings.Contains(profile, "attach_disconnected") && !reAttachExclude[opt.Name] {
+	if strings.Contains(profile, "attach_disconnected") {
 		if opt.Kind == aa.ProfileKind {
 			if strings.Contains(opt.Name, ":") {
 				parts := strings.Split(opt.Name, ":")

--- a/pkg/builder/userspace.go
+++ b/pkg/builder/userspace.go
@@ -41,7 +41,7 @@ func (b Userspace) Apply(opt *Option, profile string) (string, error) {
 	}
 
 	f := aa.DefaultTunables()
-	if tasks.Distribution == "arch" {
+	if tasks.Distribution == "arch" || tasks.Distribution == "fedora" {
 		f.Preamble = append(f.Preamble, &aa.Variable{
 			Name: "sbin", Values: []string{"/{,usr/}{,s}bin"}, Define: true,
 		})

--- a/pkg/configure/configure.go
+++ b/pkg/configure/configure.go
@@ -71,6 +71,8 @@ func (p Configure) Apply() ([]string, error) {
 			return res, err
 		}
 
+	case "fedora":
+
 	default:
 		return []string{}, fmt.Errorf("%s is not a supported distribution", tasks.Distribution)
 

--- a/pkg/tasks/os.go
+++ b/pkg/tasks/os.go
@@ -39,6 +39,7 @@ var (
 		"apt":    {"debian", "ubuntu"},
 		"pacman": {"arch"},
 		"zypper": {"opensuse"},
+		"dnf":    {"fedora"},
 	}
 )
 


### PR DESCRIPTION
# Part 1 of 14 -  Bringing Fedora support for apparmor.d
This PR is the first in a series bringing Fedora support upstream, split
into small sequential PRs. Every other PR in the
series depends on this one merging first - none of them build under
`DISTRIBUTION=fedora` without it.

## Summary

Adds Fedora into the prebuild system: dnf as its package family, its own ignore list, its own
tunable overrides, and a fix to the profile-reattachment builder task that
a couple of setuid-PAM-helper profiles (sudo, sudo-rs, su, su-rs,
unix-chkpwd) need regardless of distribution.

## What's in this PR

- `pkg/tasks/os.go`: registers `dnf` → `fedora` in the package-family map.
- `pkg/configure/configure.go`, `pkg/builder/userspace.go`: fedora as a
  recognized `DISTRIBUTION` value; fedora gets the same combined
  `/{,usr/}{,s}bin` sbin definition arch already uses.
- `pkg/builder/attach.go`: excludes sudo/sudo-rs/su/su-rs/unix-chkpwd from
  the disconnected-path reattachment transform - these Px-transition into
  setuid PAM helpers, and reattachment breaks that exec transition under
  real kernel enforcement even though the resulting profile compiles and
  merges cleanly. Not fedora-specific, but discovered while testing fedora.
- `dists/ignore/fedora.ignore` (new) + the other four distros' ignore lists
  (each now also excludes `apparmor.d/groups/dnf`).
- `apparmor.d/tunables/home.d/apparmor.d`: `@{HOMEDIRS}+=/var/home/`,
  gated `#aa:only fedora` - ostree/bootc Fedora Atomic variants (Silverblue,
  Kinoite, IoT, CoreOS) keep real home directories at `/var/home/<user>/`
  with `/home` a symlink; AppArmor matches the resolved path, so `@{HOME}`
  never matches on those variants without this.
- `apparmor.d/tunables/multiarch.d/system`: adds the `*-redhat-linux*`
  multiarch triplet (Fedora/RHEL doesn't use the `-gnu` suffix the other
  distros share).
- `docs/development/directives.md`: documents `fedora`/`dnf` in the
  only/exclude directive reference.
- `dists/apparmor.d-fedora.spec` (new): Fedora RPM spec, sourced from
  GitHub release tags, depending on `apparmor-parser`/`apparmor-utils`/
  `apparmor-profiles` (no `distribution-release`/`golang-packaging` macros
  on Fedora, unlike the existing openSUSE-oriented `dists/apparmor.d.spec`
  this mirrors). Drops the systemd `AppArmorProfile=` drop-ins at install
  time - forcing dbus(-broker).service under confinement that way causes a
  boot-time race that cascades into PAM session bus / kwallet / polkit auth
  breakage on Fedora Atomic variants.