### PR TITLE
test(vm): add Fedora 44 VM test images

### DIFF
--- a/dists/docker.sh
+++ b/dists/docker.sh
@@ -117,6 +117,25 @@ build_in_docker_rpm() {
 	mv "$VOLUME/$PKGNAME/$OUTPUT/$PKGNAME"*.rpm "$OUTPUT"
 }
 
+build_in_docker_fedora() {
+	local img="$PREFIX""fedora"
+
+	if _exist "$img"; then
+		if ! _is_running "$img"; then
+			_start "$img"
+		fi
+	else
+		docker pull registry.fedoraproject.org/fedora:latest
+		docker run -tid --name "$img" --volume "$VOLUME:$BUILDIR" \
+			registry.fedoraproject.org/fedora:latest
+		docker exec "$img" dnf5 install -y rpm-build golang just systemd-rpm-macros curl jq
+	fi
+
+	docker exec --workdir="$BUILDIR/$PKGNAME" "$img" \
+		sh -c "cp dists/$PKGNAME-fedora.spec dists/$PKGNAME.spec && just build-rpm"
+	mv "$VOLUME/$PKGNAME/$OUTPUT/$PKGNAME"*.rpm "$OUTPUT"
+}
+
 main() {
 	case "$DISTRIBUTION" in
 	archlinux)
@@ -132,6 +151,11 @@ main() {
 	opensuse)
 		sync
 		build_in_docker_rpm "$DISTRIBUTION"
+		;;
+
+	fedora)
+		sync
+		build_in_docker_fedora
 		;;
 
 	*) ;;

--- a/tests/cloud-init/common.yml
+++ b/tests/cloud-init/common.yml
@@ -47,6 +47,13 @@ disable-printk-ratelimit: &disable-printk-ratelimit
     kernel.printk_ratelimit=0
     kernel.printk_ratelimit_burst=1000
 
+# Set some bash aliases
+setup-bash-aliases: &setup-bash-aliases
+  path: /etc/skel/.bashrc
+  append: true
+  content: |
+    [[ -f ~/.bash_aliases ]] && source ~/.bash_aliases
+
 # Autopkgtest setup-testbed script
 setup-testbed: &setup-testbed
   source:

--- a/tests/cloud-init/fedora.yml
+++ b/tests/cloud-init/fedora.yml
@@ -83,10 +83,3 @@ kde-packages: &kde-packages
 #  - reboots into kernel-p03 at the end (power_state:, see each
 #    *-user-data.yml) so later apparmor_parser/aa-log checks run against a
 #    kernel that actually has the LSM.
-
-# Set some bash aliases
-setup-bash-aliases: &setup-bash-aliases
-  path: /etc/skel/.bashrc
-  append: true
-  content: |
-    [[ -f ~/.bash_aliases ]] && source ~/.bash_aliases

--- a/tests/cloud-init/fedora.yml
+++ b/tests/cloud-init/fedora.yml
@@ -69,12 +69,12 @@ kde-packages: &kde-packages
 # packages: config module runs before runcmd's final stage, and a YAML
 # sequence-alias can't be spliced into another sequence without becoming an
 # invalid nested list - so each *-user-data.yml below repeats it. It:
-#  - swaps in Rakuos's systemd (systemd, systemd-udev, systemd-libs) - it's
-#    built with AppArmor support, Fedora's stock systemd is not;
 #  - installs the AppArmor userspace stack (apparmor-libs, apparmor-parser,
 #    apparmor-utils, apparmor-profiles, python3-LibAppArmor, python3-apparmor)
-#    from Rakuos (repo.rakuos.org) - Fedora ships no official apparmor
+#    from Terra (repos.fyralabs.com) - Fedora ships no official apparmor
 #    package at all (SELinux is the default LSM);
+#  - swaps in Rakuos's systemd (systemd, systemd-udev, systemd-libs) - it's
+#    built with AppArmor support, Fedora's stock systemd is not;
 #  - installs kernel-p03 from catpieleaf/kernel-p03 (COPR) - the stock
 #    Fedora kernel has no AppArmor LSM built in at all, this custom kernel
 #    does;

--- a/tests/cloud-init/fedora.yml
+++ b/tests/cloud-init/fedora.yml
@@ -1,0 +1,90 @@
+#cloud-config
+
+# Core packages for Fedora
+core-packages: &core-packages
+  - auditd
+  - moby-engine
+  - git
+  - golang
+  - htop
+  - just
+  - qemu-guest-agent
+  - rng-tools
+  - rpm-build
+  - rpmdevtools
+  - rsync
+  - spice-vdagent
+  - vim
+  - wget
+
+gnome-packages: &gnome-packages
+  # Core packages for Fedora
+  - auditd
+  - moby-engine
+  - git
+  - golang
+  - htop
+  - just
+  - qemu-guest-agent
+  - rng-tools
+  - rpm-build
+  - rpmdevtools
+  - rsync
+  - spice-vdagent
+  - vim
+  - wget
+
+  # Desktop packages for Fedora
+  - firefox
+  - terminator
+
+  # Install Graphical Interface
+  - "@workstation-product-environment"
+
+kde-packages: &kde-packages
+  # Core packages for Fedora
+  - auditd
+  - moby-engine
+  - git
+  - golang
+  - htop
+  - just
+  - qemu-guest-agent
+  - rng-tools
+  - rpm-build
+  - rpmdevtools
+  - rsync
+  - spice-vdagent
+  - vim
+  - wget
+
+  # Desktop packages for Fedora
+  - firefox
+  - terminator
+
+  # Install Graphical Interface
+  - "@kde-desktop-environment"
+
+# NOTE: none of this can go in a shared runcmd anchor here, since cloud-init's
+# packages: config module runs before runcmd's final stage, and a YAML
+# sequence-alias can't be spliced into another sequence without becoming an
+# invalid nested list - so each *-user-data.yml below repeats it. It:
+#  - installs the AppArmor userspace stack (apparmor-libs, apparmor-parser,
+#    apparmor-utils, apparmor-profiles, python3-LibAppArmor, python3-apparmor)
+#    from Terra (repos.fyralabs.com) - Fedora ships no official apparmor
+#    package at all (SELinux is the default LSM);
+#  - installs kernel-p03 from catpieleaf/kernel-p03 (COPR) - the stock
+#    Fedora kernel has no AppArmor LSM built in at all, this custom kernel
+#    does;
+#  - sets the AppArmor kernel command line via grubby (applies to all
+#    installed kernels, including kernel-p03);
+#  - reboots into kernel-p03 at the end (power_state:, see each
+#    *-user-data.yml) so later apparmor_parser/aa-log checks run against a
+#    kernel that actually has the LSM.
+
+# Set some bash aliases
+setup-bash-aliases: &setup-bash-aliases
+  path: /etc/skel/.bashrc
+  append: true
+  content: |
+    [[ -f ~/.bash_aliases ]] && source ~/.bash_aliases

--- a/tests/cloud-init/fedora.yml
+++ b/tests/cloud-init/fedora.yml
@@ -69,6 +69,8 @@ kde-packages: &kde-packages
 # packages: config module runs before runcmd's final stage, and a YAML
 # sequence-alias can't be spliced into another sequence without becoming an
 # invalid nested list - so each *-user-data.yml below repeats it. It:
+#  - swaps in Rakuos's systemd (systemd, systemd-udev, systemd-libs) - it's
+#    built with AppArmor support, Fedora's stock systemd is not;
 #  - installs the AppArmor userspace stack (apparmor-libs, apparmor-parser,
 #    apparmor-utils, apparmor-profiles, python3-LibAppArmor, python3-apparmor)
 #    from Rakuos (repo.rakuos.org) - Fedora ships no official apparmor

--- a/tests/cloud-init/fedora.yml
+++ b/tests/cloud-init/fedora.yml
@@ -71,7 +71,7 @@ kde-packages: &kde-packages
 # invalid nested list - so each *-user-data.yml below repeats it. It:
 #  - installs the AppArmor userspace stack (apparmor-libs, apparmor-parser,
 #    apparmor-utils, apparmor-profiles, python3-LibAppArmor, python3-apparmor)
-#    from Terra (repos.fyralabs.com) - Fedora ships no official apparmor
+#    from Rakuos (repo.rakuos.org) - Fedora ships no official apparmor
 #    package at all (SELinux is the default LSM);
 #  - installs kernel-p03 from catpieleaf/kernel-p03 (COPR) - the stock
 #    Fedora kernel has no AppArmor LSM built in at all, this custom kernel

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -8,7 +8,7 @@ runcmd:
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
   # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
-  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
+  - dnf5 -y --repo rakuos distro-sync "systemd*"
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
   - dnf5 -y copr enable catpieleaf/kernel-p03

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -3,11 +3,12 @@
 packages: *gnome-packages
 
 runcmd:
-  # AppArmor userspace tools from Rakuos (no official Fedora package)
-  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
-  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
   - dnf5 -y copr enable catpieleaf/kernel-p03

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -6,7 +6,7 @@ runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
@@ -27,6 +27,7 @@ runcmd:
 # against a kernel that actually has the AppArmor LSM
 power_state:
   mode: reboot
+  delay: 1
   condition: true
 
 write_files:

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -1,0 +1,33 @@
+#cloud-config
+
+packages: *gnome-packages
+
+runcmd:
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+
+  # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
+  - dnf5 -y copr enable catpieleaf/kernel-p03
+  - dnf5 -y install kernel-p03
+
+  # Add AppArmor to the kernel command line (BLS, not a regenerated grub.cfg)
+  - grubby --update-kernel=ALL --args="lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor.debug=1"
+
+  # Enable core services
+  - systemctl enable auditd
+  - systemctl enable rngd
+  - systemctl enable chronyd
+  - systemctl enable gdm
+  - systemctl enable NetworkManager
+
+# Reboot into kernel-p03 so later apparmor_parser/aa-log checks run
+# against a kernel that actually has the AppArmor LSM
+power_state:
+  mode: reboot
+  condition: true
+
+write_files:
+  - *setup-bash-aliases         # Set some bash aliases
+  - *shared-directory           # Setup shared directory
+  - *disable-printk-ratelimit   # Disable printk rate limiting

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -3,8 +3,8 @@
 packages: *gnome-packages
 
 runcmd:
-  # AppArmor userspace tools from Terra (no official Fedora package)
-  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  # AppArmor userspace tools from Rakuos (no official Fedora package)
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-gnome.user-data.yml
+++ b/tests/cloud-init/fedora44-gnome.user-data.yml
@@ -5,6 +5,8 @@ packages: *gnome-packages
 runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-kde.user-data.yml
+++ b/tests/cloud-init/fedora44-kde.user-data.yml
@@ -3,11 +3,12 @@
 packages: *kde-packages
 
 runcmd:
-  # AppArmor userspace tools from Rakuos (no official Fedora package)
-  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
-  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
   - dnf5 -y copr enable catpieleaf/kernel-p03

--- a/tests/cloud-init/fedora44-kde.user-data.yml
+++ b/tests/cloud-init/fedora44-kde.user-data.yml
@@ -3,8 +3,8 @@
 packages: *kde-packages
 
 runcmd:
-  # AppArmor userspace tools from Terra (no official Fedora package)
-  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  # AppArmor userspace tools from Rakuos (no official Fedora package)
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-kde.user-data.yml
+++ b/tests/cloud-init/fedora44-kde.user-data.yml
@@ -6,7 +6,7 @@ runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
@@ -27,6 +27,7 @@ runcmd:
 # against a kernel that actually has the AppArmor LSM
 power_state:
   mode: reboot
+  delay: 1
   condition: true
 
 write_files:

--- a/tests/cloud-init/fedora44-kde.user-data.yml
+++ b/tests/cloud-init/fedora44-kde.user-data.yml
@@ -1,0 +1,33 @@
+#cloud-config
+
+packages: *kde-packages
+
+runcmd:
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+
+  # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
+  - dnf5 -y copr enable catpieleaf/kernel-p03
+  - dnf5 -y install kernel-p03
+
+  # Add AppArmor to the kernel command line (BLS, not a regenerated grub.cfg)
+  - grubby --update-kernel=ALL --args="lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor.debug=1"
+
+  # Enable core services
+  - systemctl enable auditd
+  - systemctl enable rngd
+  - systemctl enable chronyd
+  - systemctl enable sddm
+  - systemctl enable NetworkManager
+
+# Reboot into kernel-p03 so later apparmor_parser/aa-log checks run
+# against a kernel that actually has the AppArmor LSM
+power_state:
+  mode: reboot
+  condition: true
+
+write_files:
+  - *setup-bash-aliases         # Set some bash aliases
+  - *shared-directory           # Setup shared directory
+  - *disable-printk-ratelimit   # Disable printk rate limiting

--- a/tests/cloud-init/fedora44-kde.user-data.yml
+++ b/tests/cloud-init/fedora44-kde.user-data.yml
@@ -5,6 +5,8 @@ packages: *kde-packages
 runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-server.user-data.yml
+++ b/tests/cloud-init/fedora44-server.user-data.yml
@@ -3,11 +3,12 @@
 packages: *core-packages
 
 runcmd:
-  # AppArmor userspace tools from Rakuos (no official Fedora package)
-  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
-  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
   - dnf5 -y copr enable catpieleaf/kernel-p03

--- a/tests/cloud-init/fedora44-server.user-data.yml
+++ b/tests/cloud-init/fedora44-server.user-data.yml
@@ -5,6 +5,8 @@ packages: *core-packages
 runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
+  # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
+  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-server.user-data.yml
+++ b/tests/cloud-init/fedora44-server.user-data.yml
@@ -6,7 +6,7 @@ runcmd:
   # AppArmor userspace tools from Rakuos (no official Fedora package)
   - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   # Rakuos systemd is built with AppArmor support, Fedora's stock one is not
-  - dnf5 -y --repo rakuos distro-sync systemd systemd-udev systemd-libs
+  - dnf5 -y --repo rakuos install systemd systemd-udev systemd-libs
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
@@ -25,6 +25,7 @@ runcmd:
 # against a kernel that actually has the AppArmor LSM
 power_state:
   mode: reboot
+  delay: 1
   condition: true
 
 write_files:

--- a/tests/cloud-init/fedora44-server.user-data.yml
+++ b/tests/cloud-init/fedora44-server.user-data.yml
@@ -3,8 +3,8 @@
 packages: *core-packages
 
 runcmd:
-  # AppArmor userspace tools from Terra (no official Fedora package)
-  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  # AppArmor userspace tools from Rakuos (no official Fedora package)
+  - dnf5 -y config-manager addrepo --from-repofile=https://repo.rakuos.org/rakuos.repo
   - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
 
   # kernel-p03: stock Fedora kernel has no AppArmor LSM built in

--- a/tests/cloud-init/fedora44-server.user-data.yml
+++ b/tests/cloud-init/fedora44-server.user-data.yml
@@ -1,0 +1,31 @@
+#cloud-config
+
+packages: *core-packages
+
+runcmd:
+  # AppArmor userspace tools from Terra (no official Fedora package)
+  - dnf5 -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' install terra-release
+  - dnf5 -y install apparmor-libs apparmor-parser apparmor-utils apparmor-profiles python3-LibAppArmor python3-apparmor
+
+  # kernel-p03: stock Fedora kernel has no AppArmor LSM built in
+  - dnf5 -y copr enable catpieleaf/kernel-p03
+  - dnf5 -y install kernel-p03
+
+  # Add AppArmor to the kernel command line (BLS, not a regenerated grub.cfg)
+  - grubby --update-kernel=ALL --args="lsm=landlock,lockdown,yama,integrity,apparmor,bpf apparmor.debug=1"
+
+  # Enable core services
+  - systemctl enable auditd
+  - systemctl enable rngd
+  - systemctl enable chronyd
+
+# Reboot into kernel-p03 so later apparmor_parser/aa-log checks run
+# against a kernel that actually has the AppArmor LSM
+power_state:
+  mode: reboot
+  condition: true
+
+write_files:
+  - *shared-directory          # Setup shared directory
+  - *systemd-netword           # Network configuration for server
+  - *disable-printk-ratelimit  # Disable printk rate limiting

--- a/tests/packer/builds.pkr.hcl
+++ b/tests/packer/builds.pkr.hcl
@@ -66,13 +66,24 @@ build {
     ]
   }
 
+  # Wait for cloud-init to finish. Some distros (Fedora, to switch onto
+  # kernel-p03) reboot as part of their user-data's own power_state: right
+  # as boot-finished appears, killing this SSH session - expect_disconnect
+  # lets that through instead of failing the build; distros that don't
+  # reboot here just finish this step normally.
+  provisioner "shell" {
+    execute_command   = "echo '${var.password}' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+    expect_disconnect = true
+    inline = [
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for Cloud-Init...'; sleep 20; done",
+    ]
+  }
+
   # Full system provisioning
   provisioner "shell" {
     execute_command = "echo '${var.password}' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+    pause_before    = "30s"
     inline = [
-      # Wait for cloud-init to finish
-      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for Cloud-Init...'; sleep 20; done",
-
       # Ensure cloud-init is successful
       "cloud-init status || cloud-init collect-logs --tarfile /root/cloud-init.tar.gz",
 

--- a/tests/packer/builds.pkr.hcl
+++ b/tests/packer/builds.pkr.hcl
@@ -66,11 +66,7 @@ build {
     ]
   }
 
-  # Wait for cloud-init to finish. Some distros (Fedora, to switch onto
-  # kernel-p03) reboot as part of their user-data's own power_state: right
-  # as boot-finished appears, killing this SSH session - expect_disconnect
-  # lets that through instead of failing the build; distros that don't
-  # reboot here just finish this step normally.
+  # Wait for cloud-init to finish.
   provisioner "shell" {
     execute_command   = "echo '${var.password}' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     expect_disconnect = true

--- a/tests/packer/clean.sh
+++ b/tests/packer/clean.sh
@@ -84,7 +84,7 @@ impersonalize() {
 
 	# Truncate the machine-id
 	truncate --size=0 /etc/machine-id
-	truncate --size=0 /var/lib/dbus/machine-id
+	[[ -e /var/lib/dbus/machine-id ]] && truncate --size=0 /var/lib/dbus/machine-id
 
 	remove=(
 		# Remove history & unique ids

--- a/tests/packer/init.sh
+++ b/tests/packer/init.sh
@@ -40,6 +40,10 @@ main() {
 		rpm -i $SRC/*.rpm || true
 		;;
 
+	fedora)
+		dnf5 -y install --nogpgcheck $SRC/*.rpm || true
+		;;
+
 	esac
 }
 

--- a/tests/packer/variables.pkr.hcl
+++ b/tests/packer/variables.pkr.hcl
@@ -122,6 +122,10 @@ variable "DM" {
     "opensuse" : {
       img_url      = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
       img_checksum = "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2.sha256"
+    },
+    "fedora44" : {
+      img_url      = "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+      img_checksum = "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-44-1.7-x86_64-CHECKSUM"
     }
   }
 }


### PR DESCRIPTION
# Part 2 of 14 — Fedora support for apparmor.d

Adds Fedora 44 server/GNOME/KDE cloud-init configs and a packer distro-map
entry, modeled file-for-file on the existing archlinux/debian/opensuse
patterns in `tests/cloud-init/` and `tests/packer/`. Also carries a couple
of small fixes to the shared `tests/packer/` provisioning/cleanup scripts
that Fedora's boot flow exposed but that apply to any distro image with
similar needs.

## What's in this PR

- `tests/cloud-init/fedora.yml`: shared package anchors for
  server/gnome/kde flavors.
- `tests/cloud-init/fedora44-{server,gnome,kde}.user-data.yml`.
- `tests/packer/variables.pkr.hcl`: Fedora 44 Cloud Base Generic qcow2 +
  its PGP-signed CHECKSUM file (verified reachable at
  download.fedoraproject.org).
- `tests/packer/builds.pkr.hcl`: split the "wait for cloud-init" step into
  its own provisioner with `expect_disconnect = true`, and added a 30s
  `pause_before` on the provisioner that follows.
- `tests/packer/clean.sh`: guard the `/var/lib/dbus/machine-id` truncate
  behind an existence check.

Four things these images need that don't apply to any other distro's
image in this repo:

1. Fedora ships no apparmor package at all (SELinux is the default LSM).
   The AppArmor userspace stack (apparmor-libs, apparmor-parser,
   apparmor-utils, apparmor-profiles, python3-LibAppArmor, python3-apparmor)
   plus an AppArmor-patched systemd (systemd, systemd-udev, systemd-libs)
   are installed from Rakuos (repo.rakuos.org/rakuos.repo), scoped to
   `--repo rakuos install <names>` - never `distro-sync` or a blanket
   upgrade against that repo, only the named packages.
2. The stock Fedora kernel has no AppArmor LSM built in. These images
   install kernel-p03 (RakuOS's default kernel) and reboot into
   it (`power_state: {mode: reboot, delay: 1}` at the end of each
   user-data file) before the grubby kernel-args step means anything. The
   `delay: 1` matters: cloud-init's default `delay: now` reboots the VM
   right as Packer's wait-loop provisioner detects `boot-finished`, racing
   Packer's own cleanup of that provisioner's temp script and failing the
   build with "Timeout during SSH handshake" - a 1-minute delay gives that
   cleanup (and the provisioner split above) room to finish first.
3. Fedora Cloud images use BLS (BootLoaderSpec), not a monolithic
   `grub.cfg` regenerated from `/etc/default/grub` - `grubby
   --update-kernel=ALL` is used instead of `grub2-mkconfig`.
4. Fedora's dbus-broker doesn't maintain `/var/lib/dbus/machine-id` the
   way Debian/Arch/openSUSE do, so `clean.sh`'s unconditional truncate of
   that path fails there - now guarded with an existence check.