### PR TITLE
re-add Terrapkg sample-profile ignore entries

### DIFF
--- a/dists/ignore/fedora.ignore
+++ b/dists/ignore/fedora.ignore
@@ -1,3 +1,10 @@
+# Same-named sample profiles bundled by Terrapkg's apparmor-parser package
+# under /etc/apparmor.d/ (different content), causing RPM file conflicts
+apparmor.d/profiles-a-f/dig
+apparmor.d/profiles-m-r/nslookup
+apparmor.d/profiles-m-r/podman
+apparmor.d/groups/procps/free
+
 # Debian specific definition
 apparmor.d/groups/apt
 


### PR DESCRIPTION
dig/nslookup/podman/free conflict with Terrapkg's apparmor-parser package's own same-named bundled sample profiles (different content, RPM file conflict). Restored from main, where this same revert was previously dropped.