### PR TITLE
overwrite menu item

### DIFF
--- a/apparmor.d/groups/pacman/pacdiff
+++ b/apparmor.d/groups/pacman/pacdiff
@@ -24,6 +24,7 @@ profile pacdiff @{exec_path} flags=(attach_disconnected) {
   @{bin}/cmp           ix,
   @{bin}/find          ix,
   @{bin}/locate        ix,
+  @{bin}/mv            ix,
   @{bin}/pacman        ix,
   @{bin}/pacman-conf   Px,
   @{bin}/pacsort       ix,


### PR DESCRIPTION
If I select the Overwrite menu item, I get “permission denied” and the following log:

```
apparmor="DENIED" operation="create" class="net" info="failed type match" error=-13 profile="pacdiff"  comm="pacman" family="inet6" sock_type="dgram" protocol=0 requested_mask="create" denied_mask="create"
apparmor="DENIED" operation="exec" class="file" profile="pacdiff" name="/usr/bin/mv"  comm="pacdiff" requested_mask="x" denied_mask="x" fsuid=0 ouid=0 FSUID="root" OUID="root"
```