### PR TITLE
Add terminfo abstraction to mtr

### DIFF
--- a/apparmor.d/profiles-m-r/mtr
+++ b/apparmor.d/profiles-m-r/mtr
@@ -12,6 +12,7 @@ profile mtr @{exec_path} {
   include <abstractions/base>
   include <abstractions/desktop>
   include <abstractions/nameservice-strict>
+  include <abstractions/terminfo>
 
   network inet dgram,
   network inet6 dgram,


### PR DESCRIPTION
mtr is capable of working both as a graphical and terminal-based application, and only is built as a graphical one when using the mtr (rather than mtr-tiny) package on Debian or in other similar scenarios, being explicitly not built as a graphical application on Arch. Therefore, the terminfo abstraction is necessary for mtr to work in non-graphical (by various meanings of the word) environments.