### PR TITLE
feat(firefox) introducing firefox-gfxtest profile

### DIFF
--- a/apparmor.d/groups/browsers/firefox
+++ b/apparmor.d/groups/browsers/firefox
@@ -43,6 +43,7 @@ profile firefox @{exec_path} flags=(attach_disconnected) {
   @{lib_dirs}/crashhelper rPx -> firefox//&firefox-crashhelper,
   @{lib_dirs}/glxtest     rPx -> firefox//&firefox-glxtest,
   @{lib_dirs}/vaapitest   rPx -> firefox//&firefox-vaapitest,
+  @{lib_dirs}/gfxtest     rPx -> firefox//&firefox-gfxtest,
 
   #aa:only apparmor<5.0
   # glycin-loaders sandboxed profile stack

--- a/apparmor.d/groups/browsers/firefox-gfxtest
+++ b/apparmor.d/groups/browsers/firefox-gfxtest
@@ -1,0 +1,42 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{name} = firefox{,-esr,-beta,-devedition,-nightly,.sh}
+@{lib_dirs} = @{lib}/@{name} /opt/@{name}
+@{config_dirs} = @{HOME}/.mozilla/
+@{config_dirs} += @{user_config_dirs}/mozilla/
+@{cache_dirs} = @{user_cache_dirs}/mozilla/
+
+@{exec_path} = @{lib_dirs}/gfxtest
+profile firefox-gfxtest @{exec_path} flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/graphics>
+
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  / r,
+
+  owner @{cache_dirs}/firefox/*/startupCache/scriptCache-* r,
+  owner @{cache_dirs}/firefox/*/startupCache/startupCache* r,
+
+  owner @{config_dirs}/firefox/*/.parentlock rw,
+
+  owner @{tmp}/@{name}/.parentlock rw,
+
+  owner @{run}/user/@{uid}/xauth_@{rand6} r,
+
+  owner /dev/pts/@{u8} rw,
+
+  audit deny @{user_share_dirs}/gnome-shell/session.gvdb rw,
+
+  include if exists <local/firefox-gfxtest>
+}
+
+# vim:syntax=apparmor

--- a/share/apparmor/flags.d/00-main.conf
+++ b/share/apparmor/flags.d/00-main.conf
@@ -95,6 +95,7 @@ fail2ban-server complain
 fdisk complain
 filezilla complain
 finalrd complain
+firefox-gfxtest complain
 firewall-applet complain
 firewall-config complain
 flameshot complain


### PR DESCRIPTION
Firefox is merging all of the graphics related test on Linux into one binary with version 155 (stable release should be on Sep 1st):
https://bugzilla.mozilla.org/show_bug.cgi?id=1949093
I've used this profile for a while with Nightly and tested it later on VMs (KDE and Gnome, Arch and OpenSuse) and it seems fine, but for a few weeks I had problems with Ubuntu VMs, so those are left open. For this reason I gave it forced complain flag.
The rest of the test binaries were removed from packages, so there could be a chance to remove 3 separated profiles after ESR switches to being based on version 155+ and/or distros ditch the previous versions, but for now I haven't touched them.

Logs from tests:
[aa-firefox-gfxtest-merged.txt](https://github.com/user-attachments/files/31588086/aa-firefox-gfxtest-merged.txt)
