### PR TITLE
Add non-Debian support in kexec profile

### DIFF
--- a/apparmor.d/profiles-g-l/kexec
+++ b/apparmor.d/profiles-g-l/kexec
@@ -15,7 +15,11 @@ profile kexec @{exec_path} flags=(complain) {
 
   @{exec_path} mr,
 
+  #aa:exclude pacman
   owner @{efi}/{initrd.img,vmlinuz}-* r,
+
+  #aa:only pacman
+  owner @{efi}/{vmlinuz-*,initramfs-*.img} r,
 
   @{sys}/firmware/memmap/ r,
   @{sys}/firmware/memmap/@{int}/{start,end,type} r,

--- a/apparmor.d/profiles-g-l/kexec
+++ b/apparmor.d/profiles-g-l/kexec
@@ -15,11 +15,17 @@ profile kexec @{exec_path} flags=(complain) {
 
   @{exec_path} mr,
 
-  #aa:exclude pacman
+  #aa:only apt
   owner @{efi}/{initrd.img,vmlinuz}-* r,
 
   #aa:only pacman
   owner @{efi}/{vmlinuz-*,initramfs-*.img} r,
+
+  #aa:only fedora
+  owner @{efi}/{vmlinuz-*,initramfs-*.img} r,
+
+  #aa:only zypper
+  owner @{efi}/{vmlinuz-*,initrd-*} r,
 
   @{sys}/firmware/memmap/ r,
   @{sys}/firmware/memmap/@{int}/{start,end,type} r,


### PR DESCRIPTION
This PR adds support for the kernel image path format common on Arch Linux to the kexec profile, and prevents use of Debian-style kernel image paths on Arch. It may be worth looking into Fedora and opensuse's formats post-merge and potentially adding support for them separately.