### PR TITLE
Improve execution of nmap

### DIFF
--- a/apparmor.d/profiles-m-r/nmap
+++ b/apparmor.d/profiles-m-r/nmap
@@ -20,6 +20,7 @@ profile nmap @{exec_path} {
 
   network inet dgram,
   network inet6 dgram,
+  network packet dgram,
   network inet stream,
   network inet6 stream,
   network inet raw,
@@ -40,6 +41,7 @@ profile nmap @{exec_path} {
   owner @{PROC}/@{pid}/net/if_inet6 r,
   owner @{PROC}/@{pid}/net/ipv6_route r,
   owner @{PROC}/@{pid}/net/route r,
+  owner @{sys}/devices/virtual/net/*/statistics/rx_{missed,fifo}_errors r,
 
   # unprivileged
 #  @{PROC}/@{pid}/net/dev r,


### PR DESCRIPTION
This PR allows nmap to use additional types of network sockets and access data it wants, and should specifically help with spoofing source IPs during a privileged UDP scan over an IP-based VPN or physical network interface (e.g. tun or wireguard).