### PR TITLE
Allow console for whois

### DIFF
--- a/apparmor.d/profiles-s-z/whois
+++ b/apparmor.d/profiles-s-z/whois
@@ -10,7 +10,7 @@ include <tunables/global>
 profile whois @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
-  include <abstractions/attached/consoles>
+  include <abstractions/consoles>
 
   network inet dgram,
   network inet6 dgram,

--- a/apparmor.d/profiles-s-z/whois
+++ b/apparmor.d/profiles-s-z/whois
@@ -10,6 +10,7 @@ include <tunables/global>
 profile whois @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
+  include <abstractions/attached/consoles>
 
   network inet dgram,
   network inet6 dgram,


### PR DESCRIPTION
On Arch Linux, whois silently fails (doesn't write anything to the console) without the consoles abstraction.