### PR TITLE
Allow tailscale to access consoles

### DIFF
--- a/apparmor.d/groups/network/tailscale
+++ b/apparmor.d/groups/network/tailscale
@@ -10,6 +10,7 @@ include <tunables/global>
 profile tailscale @{exec_path} {
   include <abstractions/base>
   include <abstractions/nameservice-strict>
+  include <abstractions/consoles>
 
   capability sys_ptrace,
 


### PR DESCRIPTION
Tailscale's CLI fails to write anything to stdout or stderr when prevented from accessing consoles.