### PR TITLE
fix(profile): add mediate_deleted to kbuildsycoca.

### DIFF
--- a/apparmor.d/groups/kde/kbuildsycoca
+++ b/apparmor.d/groups/kde/kbuildsycoca
@@ -8,7 +8,7 @@ abi <abi/5.0>,
 include <tunables/global>
 
 @{exec_path} = @{bin}/kbuildsycoca{,5,6}
-profile kbuildsycoca @{exec_path} flags=(attach_disconnected) {
+profile kbuildsycoca @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/freedesktop.org>
   include <abstractions/nameservice-strict>


### PR DESCRIPTION
Same class of failure as #1180 and #1210, only hit by running kbuildsycoca6
from a shell instead of through another profile.

Qt 6.9+ QSaveFile saves through an anonymous O_TMPFILE that it publishes with
linkat on /proc/self/fd. Under attach_disconnected without mediate_deleted the
name lookup for the deleted entry fails, so linkat gets ENOENT even in complain
mode and the database is never written:

    kf.service.sycoca: ERROR writing database ... "Unknown error"

Adds the mediate_deleted flag, matching plasmashell, kded and the other KDE
profiles that already have it.

Fixes #1221
