### PR TITLE
Draft: File dialog and printing investigations

### DIFF
--- a/apparmor.d/abstractions/common/kde
+++ b/apparmor.d/abstractions/common/kde
@@ -30,9 +30,11 @@
   owner @{user_share_dirs}/@{profile_name}{,5,6}/ rw,
   owner @{user_share_dirs}/@{profile_name}{,5,6}/** rwlk,
   owner @{user_share_dirs}/color-schemes/{,**} r,
+  owner @{user_share_dirs}/kxmlgui{,5,6}/ w, # needed outside of KDE
   owner @{user_share_dirs}/kxmlgui{,5,6}/@{profile_name}/{,**} rw,
 
   owner @{user_state_dirs}/@{profile_name}{,5,6}staterc@{atomic} rwlk,
+  owner @{user_state_dirs}/UserFeedback.org.kde.@{profile_name}@{atomic} rwlk, #-> @{user_state_dirs}/#@{int},
 
   include if exists <abstractions/common/kde.d>
 

--- a/apparmor.d/abstractions/deny-home-dotfiles
+++ b/apparmor.d/abstractions/deny-home-dotfiles
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# Per the first rule of this project:
+#
+# !!! quote
+#
+#     As these are mandatory access control policies only what it explicitly required
+#     should be authorized. Meaning, you should not allow everything (or a large area)
+#     and blacklist some sub area.
+#
+# Should only be used when neccessery to silence requests
+
+  deny @{HOME}/.alias r,
+  deny @{HOME}/.bash* r,
+  deny @{HOME}/.emacs r,
+  deny @{HOME}/.histfile r,
+  deny @{HOME}/.inputrc r,
+  deny @{HOME}/.profile r,
+  deny @{HOME}/.viminfo r,
+  deny @{HOME}/.wget-hsts r,
+  deny @{HOME}/.zcompdump r,
+  deny @{HOME}/.zshrc r,
+
+  include if exists <abstractions/deny-home-dotfiles.d>
+
+# vim:syntax=apparmor

--- a/apparmor.d/abstractions/gnome-file-dialog
+++ b/apparmor.d/abstractions/gnome-file-dialog
@@ -1,0 +1,28 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# abstraction for file dialog in Gnome applications
+# if applicable, deny-home-dotfiles should be used as well
+# ToDo: clean and check
+#
+
+  abi <abi/5.0>,
+
+  include <abstractions/cgroup-limits>
+  include <abstractions/dconf-write>
+  include <abstractions/ibus-strict>
+  include <abstractions/thumbnails-cache-read>
+
+  owner @{user_config_dirs}/gtk-3.0/.goutputstream-@{rand6} rw,
+  owner @{user_config_dirs}/gtk-3.0/bookmarks w,
+  owner @{user_share_dirs}/gvfs-metadata/root r,
+  owner @{user_share_dirs}/gvfs-metadata/root-@{hex8}.log r,
+
+  owner @{PROC}/@{pid}/mountinfo r,
+
+  #/etc/fstab r,
+
+  include if exists <abstractions/gnome-file-dialog.d>
+
+# vim:syntax=apparmor

--- a/apparmor.d/abstractions/kde-export-settings
+++ b/apparmor.d/abstractions/kde-export-settings
@@ -24,9 +24,9 @@
   owner @{HOME}/#@{int} rwk,
   owner @{HOME}/*.@{export_ext}@{atomic} rwlk,
 
-  owner @{user_documents_dirs}/#@{int} rwk,
-  owner @{user_documents_dirs}/{,**/} r,
-  owner @{user_documents_dirs}/**.@{export_ext}@{atomic} rwlk,
+  owner @{user_documents_dirs}/**#@{int} rwk,
+  owner @{user_documents_dirs}/{,**/} rw,
+  owner @{user_documents_dirs}/**.@{export_ext}@{atomic} rwlk, # -> @{user_documents_dirs}/**#@{int},
 
   owner @{user_download_dirs}/**/ r,
   owner @{user_download_dirs}/**.@{export_ext} r,

--- a/apparmor.d/abstractions/kde-file-dialog
+++ b/apparmor.d/abstractions/kde-file-dialog
@@ -1,0 +1,68 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+# abstraction for file dialog in QT applications
+# if applicable, deny-home-dotfiles should be used as well
+#
+
+  abi <abi/5.0>,
+
+  # to be removed?
+  include <abstractions/disks-read>
+  include <abstractions/kde-globals-write>
+  include <abstractions/thumbnails-cache-read>
+
+  /usr/share/templates/{,**} r,
+  /usr/share/thumbnailers/{,*} r,
+
+  / r,
+  /home/ r,
+
+  owner @{HOME}/ r,
+  owner @{HOME}/*/{,*/} r,
+  owner @{HOME}/*/.directory r,
+
+  owner @{MOUNTS}/ r,
+  owner @{MOUNTS}/*/{,*/} r,
+  owner @{MOUNTS}/*/.directory r,
+
+  owner @{user_config_dirs}/baloofileinformationrc r,
+  owner @{user_config_dirs}/kioslaverc r,
+  owner @{user_config_dirs}/kiorc r,
+
+  owner @{user_share_dirs}/#@{int} rw,
+  owner @{user_share_dirs}/baloo/index r,
+  owner @{user_share_dirs}/baloo/index-lock rwk,
+  owner @{user_share_dirs}/kfile/ w,
+  owner @{user_share_dirs}/kfile/#@{int} rw,
+  owner @{user_share_dirs}/kfile/bookmarks.xml{,.bak,.tbcache}{,.@{rand6}} rwl, #-> @{user_share_dirs}/kfile/#@{int},
+  owner @{user_share_dirs}/user-places.xbel{,.bak,.tbcache}{,.@{rand6}} rwl, #-> @{user_share_dirs}/#@{int},
+
+  owner @{user_state_dirs}/kiostaterc@{atomic} rwlk, #-> @{user_state_dirs}/#@{int},
+
+  # to be removed?
+  @{sys}/bus/ r,
+  @{sys}/bus/usb/devices/ r,
+
+  #ToDo: remove all below
+  # Needed almost always, but tbd by profile creator
+  #network netlink raw,
+
+  #signal send set=term peer=kioworker,
+
+  #@{bin}/baloo_filemetadata_temp_extractor rix,
+  #@{bin}/net      Px,
+  #@{bin}/testparm Px,
+
+  #aa\:exec kioworker
+
+  #/etc/exports r,
+  #/etc/fstab r,
+
+  #owner @{run}/user/@{uid}/#@{int} rw,
+  #owner @{run}/user/@{uid}/@{profile_name}@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
+
+  include if exists <abstractions/kde-file-dialog.d>
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cups/cupsd
+++ b/apparmor.d/groups/cups/cupsd
@@ -107,12 +107,16 @@ profile cupsd @{exec_path} flags=(attach_disconnected) {
   owner @{PROC}/@{pid}/mounts r,
 
   owner @{tmp}/*_latest_print_info w,
+  owner @{tmp}/pdf-file-@{rand6} rw,
+  owner @{tmp}/tempfile@{rand6} rw,
 
   /dev/tty rw,
 
   profile gs {
     include <abstractions/base>
-    include <abstractions/fonts>
+    include <abstractions/fontconfig-cache-read>
+    include <abstractions/fonts-strict>
+    include <abstractions/nameservice-strict>
 
     @{bin}/gs{,.bin} mr,
 
@@ -126,6 +130,8 @@ profile cupsd @{exec_path} flags=(attach_disconnected) {
     owner /var/spool/cups/tmp/gs_@{rand6} rw,
 
     owner /tmp/gs_@{rand6} rw,
+
+    deny /var/spool/cups/tmp/@{hex} r,
 
     include if exists <local/cupsd_gs>
   }

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -12,6 +12,7 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   include <abstractions/base>
   include <abstractions/common/kde>
   include <abstractions/devices-usb-read>
+  include <abstractions/kde-file-dialog>
   include <abstractions/kde-globals-write>
   include <abstractions/nameservice-strict>
   include <abstractions/sys/input>
@@ -40,26 +41,20 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   @{exec_path} mr,
 
   @{bin}/lpr      rix,
-  @{bin}/net      ix,
-  @{bin}/testparm ix,
+  @{bin}/net      Px,
+  @{bin}/testparm Px,
   #aa:exec kioworker
 
   /usr/share/pipewire/client.conf.d/{,**} r,
   /usr/share/plasma/look-and-feel/** r,
-  /usr/share/thumbnailers/{,**} r,
 
-  @{etc_ro}/krb5.conf r,
   /etc/exports r,
   /etc/fstab r,
-  /etc/krb5.conf.d/{,**} r,
-  /etc/samba/* r,
   /etc/xdg/dolphinrc r,
 
   / r,
 
   @{lib}/ r,
-
-  owner /var/cache/samba/ w,
 
   owner @{HOME}/ r,
 
@@ -67,12 +62,9 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
 
   owner @{user_config_dirs}/autostart/org.kde.*.desktop r,
   owner @{user_config_dirs}/kbookmarkrc r,
-  owner @{user_config_dirs}/kioslaverc r,
   owner @{user_config_dirs}/knfsshare r,
   owner @{user_config_dirs}/kservicemenurc r,
   owner @{user_config_dirs}/Kvantum/{,**} r,
-
-  owner @{user_share_dirs}/user-places.xbel r,
 
   owner @{att}/.flatpak-info r,
 
@@ -90,7 +82,6 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
 
   owner @{PROC}/@{pid}/mountinfo r,
 
-  /dev/disk/by-label/ r,
   /dev/shm/ r,
   /dev/tty r,
 

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -38,6 +38,7 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
 
   @{exec_path} mr,
 
+  @{bin}/lpr      rix,
   @{bin}/net      ix,
   @{bin}/testparm ix,
   #aa:exec kioworker
@@ -73,6 +74,11 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   owner @{user_share_dirs}/user-places.xbel r,
 
   owner @{att}/.flatpak-info r,
+
+  owner @{tmp}/#@{int} rw,
+  owner @{tmp}/@{hex12}@{h} rw,
+  owner @{tmp}/gtkprint@{rand6} r,
+  owner @{tmp}/xdg-desktop-portal-kde.@{rand6} wl -> @{tmp}/#@{int},
 
         @{run}/user/@{uid}/gvfs/ r,
   owner @{run}/user/@{uid}/#@{int} rw,

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -17,6 +17,7 @@ profile xdg-desktop-portal-kde @{exec_path} flags=(attach_disconnected,mediate_d
   include <abstractions/sys/input>
   include <abstractions/thumbnails-cache-write>
   include <abstractions/user-dirs>
+  include <abstractions/user-read>
 
   capability sys_ptrace,
 

--- a/apparmor.d/groups/kde/dolphin
+++ b/apparmor.d/groups/kde/dolphin
@@ -142,6 +142,10 @@ profile dolphin @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
   /dev/ptmx rw,
 
+  # Silencing requests for printing
+  deny network inet stream,
+  deny network inet6 stream,
+
   include if exists <local/dolphin>
 }
 

--- a/apparmor.d/groups/kde/dolphin
+++ b/apparmor.d/groups/kde/dolphin
@@ -26,6 +26,16 @@ profile dolphin @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/ssl_certs>
   include <abstractions/thumbnails-cache-write>
 
+  if "kde" in @{DE} {
+    include <abstractions/kde-file-dialog>
+  }
+
+  if "gnome" in @{DE} {
+    include <abstractions/gnome-file-dialog>
+  }
+
+  network inet dgram,
+  network inet6 dgram,
   network netlink raw,
 
   signal send set=hup peer=@{p_systemd},
@@ -46,8 +56,10 @@ profile dolphin @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
   priority=1 @{ldd_path} rix,
 
-  @{bin}/lsb_release    rPx,
-  @{thunderbird_path}   rPx,
+  @{bin}/lsb_release  rPx,
+  @{bin}/net          Px,
+  @{bin}/testparm     Px,
+  @{thunderbird_path} rPx,
 
   #aa:exec kioworker
   #aa:exec utempter
@@ -62,8 +74,8 @@ profile dolphin @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   /usr/share/templates/{,*.desktop} r,
   /usr/share/thumbnailers/{,**} r,
 
-  /etc/fstab r,
   /etc/exports r,
+  /etc/fstab r,
   /etc/xdg/arkrc r,
   /etc/xdg/dolphinrc r,
   /etc/xdg/ui/ui_standards.rc r,
@@ -104,8 +116,6 @@ profile dolphin @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_share_dirs}/baloo/index-lock k,
   owner @{user_share_dirs}/kactivitymanagerd/resources/database{,-shm} k,
   owner link @{user_share_dirs}/user-places.xbel* -> @{user_share_dirs}/#@{int},
-
-  owner @{user_state_dirs}/UserFeedback.org.kde.dolphin@{atomic} lk -> @{user_state_dirs}/#@{int},
 
   owner @{tmp}/#@{int} rwk,
   owner @{tmp}/dolphin.@{rand6} rwl -> @{tmp}/#@{int},

--- a/apparmor.d/groups/kde/kioworker
+++ b/apparmor.d/groups/kde/kioworker
@@ -75,10 +75,10 @@ profile kioworker @{exec_path} {
   @{lib}/ r,
   @{MOUNTDIRS}/ r,
   @{MOUNTS}/ r,
-  @{MOUNTS}/** rw,
-  owner @{HOME}/{,**} rw,
-  owner @{run}/user/@{uid}/{,**} rw,
-  owner @{tmp}/{,**} rw,
+  @{MOUNTS}/** rwl,
+  owner @{HOME}/{,**} rwl,
+  owner @{run}/user/@{uid}/{,**} rwl,
+  owner @{tmp}/{,**} rwl,
 
   #aa:lint ignore=too-wide
   # Silence non user's data

--- a/apparmor.d/groups/kde/konsole
+++ b/apparmor.d/groups/kde/konsole
@@ -16,6 +16,7 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/bus-session>
   include <abstractions/common/kde>
   include <abstractions/consoles>
+  include <abstractions/deny-home-dotfiles>
   include <abstractions/kde-export-settings>
   include <abstractions/nameservice-strict>
 
@@ -47,6 +48,7 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   /usr/share/desktop-directories/kf5-*.directory r,
   /usr/share/kf6/{,**} r,
 
+  /etc/cups/client.conf r,
   /etc/xdg/konsolerc r,
   /etc/xdg/kshorturifilterrc r,
   /etc/xdg/menus/{,**} r,
@@ -66,6 +68,7 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_config_dirs}/session/** rwlk,
 
   owner @{tmp}/#@{int} rw,
+  owner @{tmp}/@{hex12}@{h} rw,
   owner @{tmp}/konsole.@{rand6} rw,
 
         @{run}/mount/utab r,
@@ -84,6 +87,10 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{PROC}/@{pid}/mountinfo r,
 
   /dev/ptmx rw,
+
+  # Silencing requests for printing
+  deny network inet stream,
+  deny network inet6 stream,
 
   include if exists <local/konsole>
 }

--- a/apparmor.d/groups/kde/konsole
+++ b/apparmor.d/groups/kde/konsole
@@ -7,7 +7,7 @@ abi <abi/5.0>,
 
 include <tunables/global>
 
-@{export_ext} = shortcuts pdf
+@{export_ext} = shortcuts pdf txt
 
 @{exec_path} = @{bin}/konsole
 profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
@@ -20,6 +20,18 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/kde-export-settings>
   include <abstractions/nameservice-strict>
 
+  if "kde" in @{DE} {
+    include <abstractions/kde-file-dialog>
+  }
+
+  if "gnome" in @{DE} {
+    include <abstractions/gnome-file-dialog>
+  }
+
+  network inet dgram,
+  network inet6 dgram,
+  network netlink raw,
+
   ptrace read,
 
   signal send,
@@ -27,6 +39,9 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   #aa:dbus own bus=session name=org.kde.konsole-@{int}
 
   @{exec_path} mr,
+
+  @{bin}/net      Px,
+  @{bin}/testparm Px,
 
   @{lib}/libheif/                            r,
   @{lib}/libheif/**                         mr,
@@ -49,6 +64,9 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   /usr/share/kf6/{,**} r,
 
   /etc/cups/client.conf r,
+  /etc/exports r,
+  /etc/fstab r,
+  /etc/xdg/dolphinrc r,
   /etc/xdg/konsolerc r,
   /etc/xdg/kshorturifilterrc r,
   /etc/xdg/menus/{,**} r,
@@ -58,7 +76,6 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
   owner @{user_config_dirs}/kbookmarkrc r,
   owner @{user_config_dirs}/kio_httprc r,
-  owner @{user_config_dirs}/kioslaverc r,
   owner @{user_config_dirs}/konsole.notifyrc@{atomic} rwlk,
   owner @{user_config_dirs}/konsolesshconfig@{atomic} rwlk,
   owner @{user_config_dirs}/kservicemenurc r,
@@ -66,6 +83,8 @@ profile konsole @{exec_path} flags=(attach_disconnected,mediate_deleted) {
   owner @{user_config_dirs}/Kvantum/{,**} r,
   owner @{user_config_dirs}/menus/{,**} r,
   owner @{user_config_dirs}/session/** rwlk,
+
+  owner @{user_share_dirs}/user-places.xbel r,
 
   owner @{tmp}/#@{int} rw,
   owner @{tmp}/@{hex12}@{h} rw,

--- a/apparmor.d/groups/kde/okular
+++ b/apparmor.d/groups/kde/okular
@@ -14,6 +14,7 @@ profile okular @{exec_path} {
   include <abstractions/base>
   include <abstractions/audio-client>
   include <abstractions/common/kde>
+  include <abstractions/deny-home-dotfiles>
   include <abstractions/devices-usb>
   include <abstractions/kde-export-settings>
   include <abstractions/nameservice-strict>
@@ -120,6 +121,10 @@ profile okular @{exec_path} {
 
   /dev/rfkill r,  # sending via Bluetooth
   /dev/tty r,
+
+  # Silencing requests for printing
+  deny network inet stream,
+  deny network inet6 stream,
 
   profile gpg {
     include <abstractions/base>

--- a/apparmor.d/groups/kde/okular
+++ b/apparmor.d/groups/kde/okular
@@ -24,6 +24,16 @@ profile okular @{exec_path} {
   include <abstractions/user-read-strict>
   include <abstractions/user-write-strict>
 
+  if "kde" in @{DE} {
+    include <abstractions/kde-file-dialog>
+  }
+
+  if "gnome" in @{DE} {
+    include <abstractions/gnome-file-dialog>
+  }
+
+  network inet dgram,
+  network inet6 dgram,
   network netlink raw,
 
   ptrace read peer=@{p_systemd},
@@ -35,10 +45,12 @@ profile okular @{exec_path} {
 
   @{exec_path} mr,
 
-  @{bin}/testparm          rix,
-  @{bin}/net               rix,
+  @{bin}/baloo_filemetadata_temp_extractor rix,
+
+  @{bin}/net               rPx,
   @{bin}/ps2pdf            rPUx,
   @{bin}/speech-dispatcher rPx,
+  @{bin}/testparm          rPx,
 
   @{bin}/gpg{,2}  rCx -> gpg,
   @{bin}/gpgconf  rCx -> gpg,
@@ -57,11 +69,7 @@ profile okular @{exec_path} {
   /etc/exports r,
   /etc/fstab r,
   /etc/xdg/dolphinrc r,
-  @{etc_ro}/krb5.conf r,
-  @{etc_ro}/krb5.conf.d/{,**} r,
   @{etc_ro}/vdpau_wrapper.cfg r,
-
-  owner /var/cache/samba/ w,
 
   / r,
   @{bin}/ r,
@@ -71,6 +79,7 @@ profile okular @{exec_path} {
 
   /var/tmp/ r,
 
+  owner @{user_config_dirs}/baloofileinformationrc r,
   owner @{user_config_dirs}/kbookmarkrc r,
   owner @{user_config_dirs}/KDE/*.conf r,
   owner @{user_config_dirs}/kioslaverc r,

--- a/apparmor.d/profiles-g-l/gimp
+++ b/apparmor.d/profiles-g-l/gimp
@@ -13,6 +13,7 @@ profile gimp @{exec_path} flags=(attach_disconnected) {
   include <abstractions/bus/session/org.freedesktop.FileManager1>
   include <abstractions/dconf-write>
   include <abstractions/desktop>
+  include <abstractions/gnome-file-dialog>
   include <abstractions/graphics>
   include <abstractions/gvfs>
   include <abstractions/nameservice-strict>

--- a/apparmor.d/profiles-m-r/net
+++ b/apparmor.d/profiles-m-r/net
@@ -1,0 +1,31 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/net
+profile net @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  @{etc_ro}/krb5.conf r,
+  @{etc_ro}/krb5.conf.d/{,**} r,
+  /etc/samba/smb.conf r,
+
+  owner /var/cache/samba/ w, # ToDo: what to do?
+
+  include if exists <local/net>
+}
+
+# vim:syntax=apparmor

--- a/apparmor.d/profiles-m-r/qbittorrent
+++ b/apparmor.d/profiles-m-r/qbittorrent
@@ -12,6 +12,7 @@ profile qbittorrent @{exec_path} {
   include <abstractions/base>
   include <abstractions/consoles>
   include <abstractions/dconf-write>
+  include <abstractions/deny-home-dotfiles>
   include <abstractions/desktop>
   include <abstractions/fontconfig-cache-read>
   include <abstractions/graphics>
@@ -24,6 +25,15 @@ profile qbittorrent @{exec_path} {
   include <abstractions/ssl_certs>
   include <abstractions/user-download-strict>
 
+  if "kde" in @{DE} {
+    include <abstractions/kde-file-dialog>
+  }
+
+  if "gnome" in @{DE} {
+    include <abstractions/gnome-file-dialog>
+  }
+
+  signal send set=term         peer=kioworker,
   signal send set=(term, kill) peer=qbittorrent//python,
 
   network inet dgram,
@@ -43,20 +53,30 @@ profile qbittorrent @{exec_path} {
   @{bin}/geany           rPx,
   @{bin}/mpv             rPx,
   @{bin}/nautilus        rPx,
+  @{bin}/net             rPx,
   @{bin}/qpdfview        rPx,
   @{bin}/smplayer        rPx,
   @{bin}/spacefm         rPx,
+  @{bin}/testparm        rPx,
   @{bin}/viewnior       rPUx,
   @{bin}/vlc             rPx,
   @{browsers_path}       rPx,
+
+  #aa:exec kioworker
+
+  /etc/fstab r,
 
   /usr/share/GeoIP/GeoIP.dat r,
   /usr/share/gvfs/remote-volume-monitors/{,*} r,
 
   owner @{user_cache_dirs}/qBittorrent/{,**} rw,
 
+  owner @{user_config_dirs}/kioslaverc r,
+  owner @{user_config_dirs}/klanguageoverridesrc r,
+  owner @{user_config_dirs}/kservicemenurc r,
   owner @{user_config_dirs}/qBittorrent/ rw,
   owner @{user_config_dirs}/qBittorrent/** rwlk -> @{user_config_dirs}/qBittorrent/#@{int},
+  owner @{user_config_dirs}/qBittorrentrc@{atomic} rwlk,
 
   owner @{user_share_dirs}/{,data/}qBittorrent/ rw,
   owner @{user_share_dirs}/{,data/}qBittorrent/** rwl -> @{user_share_dirs}/{,data/}qBittorrent/**/#@{int},
@@ -65,7 +85,6 @@ profile qbittorrent @{exec_path} {
   owner @{user_torrents_dirs}/ r,
   owner @{user_torrents_dirs}/** rw,
 
-  owner /dev/shm/#@{int} rw,
   owner @{tmp}/.*/{,s} rw,
   owner @{tmp}/.qBittorrent/ rw,
   owner @{tmp}/.qBittorrent/* rwl -> /tmp/.qBittorrent/*,
@@ -74,6 +93,19 @@ profile qbittorrent @{exec_path} {
   owner @{tmp}/qtsingleapp-qBitto-* rw,
   owner @{tmp}/qtsingleapp-qBitto-*-lockfile rwk,
   owner @{tmp}/tmp* rw,
+
+  @{att}/systemd/journal/stdout rw,
+
+  owner @{run}/user/@{uid}/#@{int} rw,
+  owner @{run}/user/@{uid}/qBittorrent@{rand6}.@{int}.kioworker.socket rwl -> @{run}/user/@{uid}/#@{int},
+
+  owner /dev/shm/#@{int} rw,
+
+  @{sys}/block/ r,
+  @{sys}/bus/ r,
+  @{sys}/bus/usb/devices/ r,
+  @{sys}/devices/**/dev r,
+  @{sys}/devices/**/uevent r,
 
   owner @{PROC}/@{pids}/cmdline r,
   owner @{PROC}/@{pids}/comm r,

--- a/apparmor.d/profiles-s-z/testparm
+++ b/apparmor.d/profiles-s-z/testparm
@@ -1,0 +1,34 @@
+# apparmor.d - Full set of apparmor profiles
+# Copyright (C) 2026 Łukasz Kozak <lakis.kozak@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+abi <abi/5.0>,
+
+include <tunables/global>
+
+@{exec_path} = @{bin}/testparm
+profile testparm @{exec_path} {
+  include <abstractions/base>
+  include <abstractions/nameservice-strict>
+
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  @{exec_path} mr,
+
+  /etc/samba/smb.conf r,
+
+  /var/lib/samba/ r,
+  /var/lib/samba/lock/ r,
+
+  @{run}/samba/ r,
+
+  @{PROC}/sys/crypto/fips_enabled r,
+
+  include if exists <local/testparm>
+}
+
+# vim:syntax=apparmor


### PR DESCRIPTION
I finally managed to prepare some _sensible_ investigation of printing and file dialog windows on KDE (mainly) and Gnome. Those are results, and for file dialog, preliminary proposals.

I used Gimp, Gnome Text Editor, Okular and qBittorrent for tests on both DEs to check what would be necessary. Sometimes I used some other applications to check Qt and Gtk alternatives.

As for printing, unfortunately I don't think there is a way to prepare any abstraction for that. It has to be case by case solution. At best, there is this proposed deny abstraction, it could be used to silence some unnecessary requests. As I don't have a physical printer at the moment, I could only simulate it by using _ippeveprinter_, so I'm not sure about denying access to network inet stream, I'm not versed in how CUPS works to judge it as of now.

File dialog gave more straightforward answers. For official KDE and Gnome application the same mechanisms are used, depending on DE. Gnome does everything via xdg-desktop-portal, so do some gtk applications. That would requires expanding access of xdg-desktop-portal-kde to ALL possible paths accessible by all applications. It's shown on screenshots below, (Okular vs gnome-text-editor on KDE), binaries to which change will be connected are in parenthesis. For KDE application, they use KDE mechanism on KDE and Gnome mechanism on Gnome. Qt and Gtk apps - it depends, there is no rule what devs use for file access dialog, so it's case by case solution there.

If deny-home-dotfiles is introduced, it should include some special dotfiles, like shell configs, not everything, as i.e. .recently_used is needed quite a lot and it's not the only such file.

As for kde-file-dialog: includes and /sys/** access are making it look chaotic, so probably they should be included in a given profile, but it would make this abstraction less useful. Things like kill signal to kioworker and _network netlink raw_ could be useful, but are not always necessary for qt applications and are to be removed (right now are there only for documentation what is regularly required).

Conditionals with *-file-dialog includes are a mouthful and I would like to avoid them - for me if someone is using kde apps on gnome, it's his problem to take care of that, if we go with separated abstractions for both DEs.

My current proposal is this: let's use deny-home-dotfiles to silence request when necessary and introduce *-file-dialog and use them case by case. Either that, or create file-dialog meta abstraction with conditional, to no repeat it in evert profile. Printing - let's leave it for now, till someone with real-life use case can test it.

[Investigation_logs.zip](https://github.com/user-attachments/files/32140183/Investigation_logs.zip)

<img width="1041" height="683" alt="obraz" src="https://github.com/user-attachments/assets/e0967030-2009-440d-9afd-56610cd11dde" />

<img width="1056" height="694" alt="obraz" src="https://github.com/user-attachments/assets/31cd92bd-de10-4e00-b834-d4a6b502f903" />